### PR TITLE
fix: v0.4.1 值班 dogfood 问题 (#9 #10 #11 #12 #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Maintenance rules:
 
 ## [Unreleased]
 
+### Fixed
+
+- Quick Start is now download/verify/extract/`./binlog-server`; `go run` / `make build` moved to Development (#9).
+- `flavor=mariadb` probes `server_id` + `gtid_domain_id` and fails with `log_bin is off` instead of `empty server_uuid` (#10).
+- `POST /api/tasks` validates the full spec before persist; HTTP 400 no longer leaves a LATEST task (#11).
+- Standalone (no `meta_dsn`) persists tasks and fsynced checkpoints under `BINLOG_SERVER_DATA_DIR` and resumes after crash (#12).
+- Bind failures no longer dump cobra Usage; access denied maps to `SOURCE_ACCESS_DENIED` without infinite retry; quiet-master lag is `IDLE`/`0`; `GET /api/health` works (#13).
+
+### Changed
+
+- Canonical GTID field is `gtid_set`; request alias `gtid` is accepted. `storage.dir` is rejected; files live at `{data_dir}/{task_id}/`.
+- `POST /api/tasks/{id}/start` returns JSON `{"id","state"}` instead of 204.
+
 ## [v0.1.2] - 2026-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,52 +59,55 @@ Probably not a fit for:
 
 ## Install / Download
 
-- For tagged public releases, download the archive that matches your platform from GitHub Releases:
-  - `binlog-server_<version>_darwin_amd64.tar.gz`
-  - `binlog-server_<version>_darwin_arm64.tar.gz`
-  - `binlog-server_<version>_linux_amd64.tar.gz`
-  - `binlog-server_<version>_linux_arm64.tar.gz`
-- The release page also provides `checksums.txt`; verify it before extracting.
-- UI assets are embedded into the binary, so you do not need to download a separate frontend package.
+For tagged public releases, download the archive that matches your platform from [GitHub Releases](https://github.com/Fanduzi/BinlogServer/releases):
 
-Source build remains the fallback path:
+- `binlog-server_<version>_darwin_amd64.tar.gz`
+- `binlog-server_<version>_darwin_arm64.tar.gz`
+- `binlog-server_<version>_linux_amd64.tar.gz`
+- `binlog-server_<version>_linux_arm64.tar.gz`
 
-```bash
-make build
+The real asset name is `binlog-server_<ver>_<os>_<arch>.tar.gz` (for example `binlog-server_0.4.1_linux_amd64.tar.gz`). The release page also provides `checksums.txt`; verify it before extracting. The tarball contains a versioned subdirectory:
 
-# Linux deployment binaries should keep CGO disabled to avoid host glibc coupling.
-make build-linux
+```text
+binlog-server_0.4.1_linux_amd64/
+  binlog-server
+  README.md
+  README_ZH.md
+  CHANGELOG.md
+  LICENSE
 ```
 
-To prepare a local set of release assets:
-
-```bash
-make release-assets VERSION=v0.4.1
-```
+UI assets are embedded into the binary, so you do not need a separate frontend package.
 
 ## Quick Start
 
-This section keeps the shortest path to a working service.
+This is the shortest path for release operators. You do not need Go installed.
 
 ### Prerequisites
 
-- Go `1.26.1+`
-- A reachable MySQL instance with binlog enabled
-- Docker available if you want to run E2E scenarios
+- A release tarball for your platform from GitHub Releases
+- A reachable MySQL or MariaDB instance with `log_bin` enabled
 
-### 1. Start the service
-
-```bash
-go run ./cmd/binlog-server
-```
-
-The default listen address is `:8080`.
-
-To set it explicitly:
+### 1. Download, verify, extract, run
 
 ```bash
-BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+VER=0.4.1
+OS=linux          # linux | darwin
+ARCH=amd64        # amd64 | arm64
+
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt"
+sha256sum -c checksums.txt --ignore-missing
+
+tar -xzf "binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+cd "binlog-server_${VER}_${OS}_${ARCH}"
+
+export BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:8080
+export BINLOG_SERVER_DATA_DIR=./data
+./binlog-server
 ```
+
+The default listen address is `:8080` if you omit `BINLOG_SERVER_LISTEN_ADDR`.
 
 ### 2. Verify `/healthz`
 
@@ -163,7 +166,7 @@ curl -fsS http://127.0.0.1:8080/api/tasks
 - UI: `http://127.0.0.1:8080/ui/`
 - Swagger: `http://127.0.0.1:8080/swagger/index.html`
 
-For more operational and usage guidance, continue from [docs/guide/README.md](docs/guide/README.md).
+For more operational and usage guidance, continue from [docs/guide/README.md](docs/guide/README.md) and [docs/guide/admin/deployment.md](docs/guide/admin/deployment.md).
 
 ### What You Should See
 
@@ -298,6 +301,32 @@ Once `Quick Start` works, continue from these entry points:
 | Replication pipeline | [internal/replication/README.md](internal/replication/README.md) |
 | Upload module | [internal/upload/README.md](internal/upload/README.md) |
 | E2E suite | [scripts/e2e/README.md](scripts/e2e/README.md) |
+
+## Development
+
+Source build is the fallback path when you are changing the code, not installing a release.
+
+Prerequisites: Go `1.26.1+`. Docker is needed only for E2E.
+
+```bash
+make build
+
+# Linux deployment binaries should keep CGO disabled to avoid host glibc coupling.
+make build-linux
+
+# Run from source
+go run ./cmd/binlog-server
+BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+
+# Prepare a local set of release assets
+make release-assets VERSION=v0.4.1
+```
+
+Standalone (no `meta_dsn`) persists tasks and fsynced checkpoints under `BINLOG_SERVER_DATA_DIR` (default `./data`):
+
+- task metadata: `{data_dir}/.meta/tasks/{id}.json`
+- checkpoint: `{data_dir}/{id}/checkpoint.json`
+- binlog files: `{data_dir}/{id}/` (`storage.dir` is rejected; this path is fixed)
 
 ## Development Validation
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -58,52 +58,55 @@ Binlog Server 是一个面向 MySQL binlog 备份与拉流场景的服务：负�
 
 ## 安装 / 下载
 
-- 对于带 tag 的公开版本，优先从 GitHub Releases 下载与你平台匹配的压缩包：
-  - `binlog-server_<version>_darwin_amd64.tar.gz`
-  - `binlog-server_<version>_darwin_arm64.tar.gz`
-  - `binlog-server_<version>_linux_amd64.tar.gz`
-  - `binlog-server_<version>_linux_arm64.tar.gz`
-- 同一页会提供 `checksums.txt`，下载后先校验再解压。
-- `/ui/` 所需前端静态资源已经内嵌在二进制里，不需要额外下载前端包。
+带 tag 的公开发布，从 [GitHub Releases](https://github.com/Fanduzi/BinlogServer/releases) 下载对应平台压缩包：
 
-源码构建作为 fallback：
+- `binlog-server_<version>_darwin_amd64.tar.gz`
+- `binlog-server_<version>_darwin_arm64.tar.gz`
+- `binlog-server_<version>_linux_amd64.tar.gz`
+- `binlog-server_<version>_linux_arm64.tar.gz`
 
-```bash
-make build
+真实资产名是 `binlog-server_<ver>_<os>_<arch>.tar.gz`（例如 `binlog-server_0.4.1_linux_amd64.tar.gz`）。同一页提供 `checksums.txt`，先校验再解压。解压后二进制在一层版本子目录里：
 
-# Linux 部署二进制请保持 CGO 关闭，避免绑定构建机 glibc 版本。
-make build-linux
+```text
+binlog-server_0.4.1_linux_amd64/
+  binlog-server
+  README.md
+  README_ZH.md
+  CHANGELOG.md
+  LICENSE
 ```
 
-如果你要在本地准备一组 release 产物：
-
-```bash
-make release-assets VERSION=v0.4.1
-```
+`/ui/` 所需前端静态资源已经内嵌在二进制里，不需要额外下载前端包。
 
 ## Quick Start
 
-这部分只保留“第一次跑起来”所需的最短路径。
+这是发布包操作员的最短路径。不需要安装 Go。
 
 ### 前置条件
 
-- Go `1.26.1+`
-- 一个可访问的 MySQL 实例，并且已经开启 binlog
-- 如需跑 E2E：Docker 可用
+- 从 GitHub Releases 下载对应平台 tarball
+- 一台已开启 `log_bin` 的 MySQL 或 MariaDB
 
-### 1. 启动服务
-
-```bash
-go run ./cmd/binlog-server
-```
-
-默认监听地址是 `:8080`。
-
-如果你想显式指定监听地址：
+### 1. 下载、校验、解压、运行
 
 ```bash
-BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+VER=0.4.1
+OS=linux          # linux | darwin
+ARCH=amd64        # amd64 | arm64
+
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt"
+sha256sum -c checksums.txt --ignore-missing
+
+tar -xzf "binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+cd "binlog-server_${VER}_${OS}_${ARCH}"
+
+export BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:8080
+export BINLOG_SERVER_DATA_DIR=./data
+./binlog-server
 ```
+
+如果不设置 `BINLOG_SERVER_LISTEN_ADDR`，默认监听 `:8080`。
 
 ### 2. 验证 `/healthz`
 
@@ -162,7 +165,7 @@ curl -fsS http://127.0.0.1:8080/api/tasks
 - UI: `http://127.0.0.1:8080/ui/`
 - Swagger: `http://127.0.0.1:8080/swagger/index.html`
 
-如果你要看更完整的运维与使用说明，从 [docs/guide/README.md](docs/guide/README.md) 进入。
+如果你要看更完整的运维与使用说明，从 [docs/guide/README.md](docs/guide/README.md) 和 [docs/guide/admin/deployment.md](docs/guide/admin/deployment.md) 进入。
 
 ### 运行后你会看到什么
 
@@ -297,6 +300,32 @@ BinlogServer 以控制面为核心组织服务，HTTP/API 处理、任务编排�
 | 复制执行链路 | [internal/replication/README.md](internal/replication/README.md) |
 | Upload 模块 | [internal/upload/README.md](internal/upload/README.md) |
 | E2E 测试套件 | [scripts/e2e/README.md](scripts/e2e/README.md) |
+
+## 开发
+
+源码构建是改代码时的 fallback，不是发布包安装路径。
+
+前置：Go `1.26.1+`。E2E 才需要 Docker。
+
+```bash
+make build
+
+# Linux 部署二进制请保持 CGO 关闭，避免绑定构建机 glibc 版本。
+make build-linux
+
+# 从源码运行
+go run ./cmd/binlog-server
+BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+
+# 本地准备一组 release 产物
+make release-assets VERSION=v0.4.1
+```
+
+standalone（未配置 `meta_dsn`）会把任务和已 fsync 的 checkpoint 写到 `BINLOG_SERVER_DATA_DIR`（默认 `./data`）：
+
+- 任务元数据：`{data_dir}/.meta/tasks/{id}.json`
+- checkpoint：`{data_dir}/{id}/checkpoint.json`
+- binlog 文件：`{data_dir}/{id}/`（`storage.dir` 会被拒绝；路径固定）
 
 ## 开发验证入口
 

--- a/cmd/binlog-server/cmd/README.md
+++ b/cmd/binlog-server/cmd/README.md
@@ -6,7 +6,7 @@ binlog-server CLI 子命令定义目录。
 
 | File | Responsibility |
 |------|---------------|
-| root.go | Cobra root command，负责参数绑定、根命令参数校验与应用启动调用 |
+| root.go | Cobra root command，负责参数绑定、根命令参数校验与应用启动调用；`SilenceUsage`/`SilenceErrors` 避免 bind 失败刷 Usage |
 | version.go | `version` 子命令、`--version` 输出与 ASCII banner 版本信息渲染 |
 | root_test.go | CLI 回归测试，覆盖 `version`、`--version` 与位置参数校验 |
 

--- a/cmd/binlog-server/cmd/root.go
+++ b/cmd/binlog-server/cmd/root.go
@@ -1,6 +1,6 @@
 // Package cmd provides module-level functionality for cmd.
 // input: config loader, signal context, logging setup, app runtime dependencies
-// output: root cobra command that starts binlog-server in configured mode
+// output: root cobra command that starts binlog-server without dumping Usage on bind errors
 // pos: CLI orchestration entry between process bootstrap and app lifecycle
 // note: if this file changes, update this header and module README.md.
 package cmd
@@ -20,9 +20,11 @@ func NewRootCommand() *cobra.Command {
 	var versionOnly bool
 
 	root := &cobra.Command{
-		Use:   "binlog-server",
-		Short: "Centralized MySQL binlog backup service",
-		Args:  cobra.NoArgs,
+		Use:           "binlog-server",
+		Short:         "Centralized MySQL binlog backup service",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if versionOnly {
 				_, err := fmt.Fprintln(cmd.OutOrStdout(), effectiveVersionInfo().Version)

--- a/cmd/binlog-server/cmd/root_test.go
+++ b/cmd/binlog-server/cmd/root_test.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -138,5 +139,27 @@ func TestRootCommandWithoutArgsStillStartsApp(t *testing.T) {
 	}
 	if startCalls != 1 {
 		t.Fatalf("expected app startup to run once, got %d calls", startCalls)
+	}
+}
+
+func TestRootCommandRunErrorOmitsUsage(t *testing.T) {
+	restoreRun := setTestRunRootApp(func(string, string) error {
+		return errors.New("listen tcp :8080: bind: address already in use")
+	})
+	defer restoreRun()
+
+	cmd := NewRootCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected bind error")
+	}
+	output := stdout.String()
+	if strings.Contains(output, "Usage:") {
+		t.Fatalf("expected no cobra Usage dump, got %q", output)
 	}
 }

--- a/docs/guide/admin/deployment.md
+++ b/docs/guide/admin/deployment.md
@@ -6,11 +6,14 @@
 
 ### 1.1 软件要求
 
+发布包部署不需要安装 Go。
+
 | 组件 | 版本要求 |
 |------|----------|
-| Go | 1.26.1+ |
-| MySQL | 5.7+ / 8.0+（作为元数据存储） |
-| 源 MySQL | 5.7+ / 8.0+（需要开启 binlog） |
+| 发布包 | 从 GitHub Releases 下载对应平台 `binlog-server_<ver>_<os>_<arch>.tar.gz` |
+| Go | 仅源码构建需要 1.26.1+ |
+| MySQL | 5.7+ / 8.0+（仅 cluster 模式作为元数据存储） |
+| 源库 | MySQL 5.7+/8.0+ 或 MariaDB 10+/11+（需要开启 `log_bin`） |
 
 ### 1.2 源 MySQL 配置
 
@@ -45,22 +48,39 @@ FLUSH PRIVILEGES;
 
 ## 2. 单机模式部署
 
-### 2.1 下载或编译
+### 2.1 下载发布包（推荐）
+
+真实资产名是 `binlog-server_<ver>_<os>_<arch>.tar.gz`，解压后二进制在一层版本子目录里。
 
 ```bash
-# 从源码编译
-git clone https://github.com/your-org/binlog-server.git
-cd binlog-server
-make build-linux
-cp bin/binlog-server-linux-amd64 ./binlog-server
+VER=0.4.1
+OS=linux          # linux | darwin
+ARCH=amd64        # amd64 | arm64
 
-# 或下载预编译版本
-# wget https://github.com/your-org/binlog-server/releases/download/v0.4.1/binlog-server-linux-amd64
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt"
+sha256sum -c checksums.txt --ignore-missing
+
+tar -xzf "binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+cd "binlog-server_${VER}_${OS}_${ARCH}"
+# 目录内是 ./binlog-server
+```
+
+### 2.1.1 从源码编译（开发路径）
+
+```bash
+git clone https://github.com/Fanduzi/BinlogServer.git
+cd BinlogServer
+make build-linux
 ```
 
 说明：Linux 部署二进制必须保持 `CGO_ENABLED=0`，避免 Ubuntu 等较新发行版构建出的产物绑定更高版本的 `glibc`；当前仓库的 `make build-linux` 和 release 流程默认按兼容 `glibc 2.17` 的方向构建。
 
 ### 2.2 创建配置文件
+
+未配置 `meta_dsn` 时，standalone 仍会把任务、事件和已 fsync 的 checkpoint 写到 `data_dir`（或 `BINLOG_SERVER_DATA_DIR`）。进程 `kill -9` 后重启会恢复任务并从 checkpoint 续拉，不会静默改回 `LATEST`。
+
+本地文件路径固定为 `{data_dir}/{task_id}/`。创建任务时如果传入 `storage.dir` 会被拒绝。
 
 **最小可运行配置（开发/测试环境）：**
 
@@ -133,8 +153,9 @@ export BINLOG_SERVER_API_AUTH_BEARER_TOKEN="your-secure-random-token"
 **使用 API（启用鉴权后）：**
 
 ```bash
-# 健康检查不需要鉴权
+# 健康检查不需要鉴权（/healthz 与 /api/health 均可）
 curl http://localhost:8080/healthz
+curl http://localhost:8080/api/health
 
 # API 请求需要 Bearer Token
 curl -H "Authorization: Bearer your-secure-random-token" \
@@ -416,8 +437,13 @@ MYSQL_ROOT_PASSWORD=your_secure_password
 ### 6.1 API 端点
 
 ```bash
-# 服务健康检查
+# 服务健康检查（JSON）
 curl http://localhost:8080/api/health
+# {"status":"ok"}
+
+# 进程级健康检查（纯文本）
+curl http://localhost:8080/healthz
+# ok
 
 # 查看集群状态
 curl http://localhost:8080/api/cluster/overview

--- a/docs/guide/admin/observability.md
+++ b/docs/guide/admin/observability.md
@@ -353,19 +353,13 @@ ORDER BY created_at DESC;
 ### 7.1 HTTP 健康检查
 
 ```bash
-# 简单检查
+# JSON 健康检查
 curl http://localhost:8080/api/health
 # {"status": "ok"}
 
-# 详细检查（包含依赖）
-curl http://localhost:8080/api/health?full=true
-# {
-#   "status": "ok",
-#   "checks": {
-#     "database": "ok",
-#     "storage": "ok"
-#   }
-# }
+# 进程级健康检查（纯文本，始终保留）
+curl http://localhost:8080/healthz
+# ok
 ```
 
 ### 7.2 Kubernetes 探针
@@ -373,14 +367,14 @@ curl http://localhost:8080/api/health?full=true
 ```yaml
 livenessProbe:
   httpGet:
-    path: /api/health
+    path: /healthz   # 或 /api/health
     port: 8080
   initialDelaySeconds: 10
   periodSeconds: 10
 
 readinessProbe:
   httpGet:
-    path: /api/health
+    path: /healthz   # 或 /api/health
     port: 8080
   initialDelaySeconds: 5
   periodSeconds: 5

--- a/docs/guide/admin/troubleshooting.md
+++ b/docs/guide/admin/troubleshooting.md
@@ -188,8 +188,8 @@ curl http://localhost:8080/api/tasks/{task_id}/replication
 ```
 
 关键字段：
-- `status`: `NORMAL / DELAYED / ABNORMAL`
-- `delay_seconds`: 基于 `last_event_at` 计算的延迟秒数
+- `status`: `NORMAL / DELAYED / ABNORMAL / IDLE`
+- `delay_seconds`: 落后源库 tip 的秒数。已经跟到最新位点、正在等待下一条事件时为 `0`，状态为 `IDLE`（不用最后一条 binlog event 的时间戳当延迟）
 - `has_progress=false`: 当前没有可用复制进度（需结合任务状态判断）
 
 ### 3.4 任务事件

--- a/docs/guide/reference/api.md
+++ b/docs/guide/reference/api.md
@@ -108,7 +108,7 @@ curl -X POST http://localhost:8080/api/tasks \
     },
     "start": {
       "mode": "GTID",
-      "gtid": "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100"
+      "gtid_set": "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100"
     }
   }'
 ```
@@ -126,8 +126,9 @@ curl -X POST http://localhost:8080/api/tasks \
 | start.mode | string | 是 | LATEST / FILE_POS / GTID |
 | start.file | string | 条件 | 文件名（FILE_POS 模式必填） |
 | start.pos | int | 条件 | 位置（FILE_POS 模式必填） |
-| start.gtid | string | 条件 | GTID（GTID 模式必填） |
+| start.gtid_set | string | 条件 | GTID 集合（GTID 模式必填；也接受别名 `gtid`） |
 | storage.retention_days | int | 否 | 保留天数（默认 7，范围 1-3650） |
+| storage.dir | string | 否 | **不支持**。文件固定写在 `{data_dir}/{task_id}/`，传入非空值会 400 |
 
 **响应示例：**
 
@@ -575,11 +576,19 @@ curl http://localhost:8080/metrics
 
 | HTTP 状态码 | 错误码 | 说明 |
 |------------|--------|------|
-| 400 | INVALID_REQUEST | 请求参数错误 |
+| 400 | INVALID_REQUEST | 请求参数错误（校验失败不落库） |
 | 404 | TASK_NOT_FOUND | 任务不存在 |
 | 409 | TASK_ALREADY_EXISTS | 任务已存在 |
 | 409 | INVALID_STATE_TRANSITION | 状态转换非法 |
 | 500 | INTERNAL_ERROR | 内部错误 |
+
+任务 `last_error` 里的稳定源库错误码：
+
+| 错误码 | 说明 | 重试 |
+|--------|------|------|
+| SOURCE_ACCESS_DENIED | 源库 ERROR 1045 | 否，进入 FAILED |
+| SOURCE_LOG_BIN_OFF | 源库未开 binlog | 否，进入 FAILED |
+| SOURCE_IDENTITY_UNAVAILABLE | 无法读取源库身份 | 否，进入 FAILED |
 
 ## 10. 常用调试场景
 

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -520,7 +520,7 @@
 for real operations</h1>
       <p class="hero-sub animate-fade-up" style="animation-delay:0.2s;" data-i18n="heroSub">BinlogServer centralizes MySQL binlog backup behind one service. Run local-first durable capture, inspect state through API and embedded UI, scale into cluster roles, export metrics, and archive sealed files with optional S3-compatible upload.</p>
       <div class="hero-actions animate-fade-up" style="animation-delay:0.28s;">
-        <a href="../guide/admin/deployment.md" class="btn-primary" data-i18n="heroPrimary">Open Deployment Guide</a>
+        <a href="#deployment" class="btn-primary" data-i18n="heroPrimary">Open Deployment Guide</a>
         <a href="#features" class="btn-secondary" data-i18n="heroSecondary">Learn More</a>
       </div>
       <div class="hero-code animate-fade-up" style="animation-delay:0.36s;">
@@ -536,6 +536,25 @@ Signals        Checkpoint / Lag / Events / Workers / Metrics</code>
         <span class="tag tag-cluster">Cluster</span>
         <span class="tag tag-api">Prometheus</span>
         <span class="tag tag-go">Apache 2.0</span>
+      </div>
+    </div>
+  </section>
+
+  <section id="deployment" class="alt">
+    <div class="container">
+      <p class="section-label" data-i18n="deployLabel">Quick Start</p>
+      <h2 class="section-title" data-i18n="deployTitle">Download the release tarball,
+verify, extract, run</h2>
+      <p class="section-sub" data-i18n="deploySub">Operators do not need Go. Real assets are named <code>binlog-server_&lt;ver&gt;_&lt;os&gt;_&lt;arch&gt;.tar.gz</code> and extract into a versioned subdirectory. Full write-up: <a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/admin/deployment.md">docs/guide/admin/deployment.md</a>.</p>
+      <div class="hero-code">
+        <code data-i18n="deployCode">VER=0.4.1 OS=linux ARCH=amd64
+curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz
+curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt
+sha256sum -c checksums.txt --ignore-missing
+tar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz
+cd binlog-server_${VER}_${OS}_${ARCH}
+export BINLOG_SERVER_DATA_DIR=./data
+./binlog-server</code>
       </div>
     </div>
   </section>
@@ -814,8 +833,8 @@ better UI, better ops, better reliability</h2>
 and into a real product surface</h2>
       <p data-i18n="ctaSub">Review the deployment guide, inspect the release line, and evaluate BinlogServer as what it already is: a centralized MySQL binlog backup control plane.</p>
       <div class="hero-actions" style="margin-bottom:0;">
-        <a href="../guide/admin/deployment.md" class="btn-primary" data-i18n="ctaPrimary">Open Deployment Guide</a>
-        <a href="../../research_product_website_20260330.md" class="btn-secondary" data-i18n="ctaSecondary">Read Product Research</a>
+        <a href="#deployment" class="btn-primary" data-i18n="ctaPrimary">Open Deployment Guide</a>
+        <a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/README.md" class="btn-secondary" data-i18n="ctaSecondary">Read the Guide</a>
       </div>
     </div>
   </section>
@@ -837,9 +856,9 @@ and into a real product surface</h2>
         <div class="footer-col">
           <div class="footer-col-title" data-i18n="footerCol1">Start</div>
           <ul>
-            <li><a href="../guide/admin/deployment.md" data-i18n="footerLink1">Deployment Guide</a></li>
-            <li><a href="../../research_product_website_20260330.md" data-i18n="footerLink2">Product Research</a></li>
-            <li><a href="../../CHANGELOG.md" data-i18n="footerLink3">Changelog</a></li>
+            <li><a href="#deployment" data-i18n="footerLink1">Deployment Guide</a></li>
+            <li><a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/README.md" data-i18n="footerLink2">Operator Guide</a></li>
+            <li><a href="https://github.com/Fanduzi/BinlogServer/blob/main/CHANGELOG.md" data-i18n="footerLink3">Changelog</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -886,6 +905,10 @@ and into a real product surface</h2>
         navSurfaces: 'Surfaces',
         navChangelog: 'Changelog',
         navCta: 'Releases',
+        deployLabel: 'Quick Start',
+        deployTitle: 'Download the release tarball,\nverify, extract, run',
+        deploySub: 'Operators do not need Go. Real assets are named binlog-server_&lt;ver&gt;_&lt;os&gt;_&lt;arch&gt;.tar.gz and extract into a versioned subdirectory.',
+        deployCode: 'VER=0.4.1 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
         heroBadge: 'v0.4.1 — latest release',
         heroTitle: 'MySQL binlog backup control plane\nfor real operations',
         heroSub: 'BinlogServer centralizes MySQL binlog backup behind one service. Run local-first durable capture, inspect state through API and embedded UI, scale into cluster roles, export metrics, and archive sealed files with optional S3-compatible upload.',
@@ -996,11 +1019,11 @@ and into a real product surface</h2>
         ctaTitle: 'Move binlog backup out of shell history\nand into a real product surface',
         ctaSub: 'Review the deployment guide, inspect the release line, and evaluate BinlogServer as what it already is: a centralized MySQL binlog backup control plane.',
         ctaPrimary: 'Open Deployment Guide',
-        ctaSecondary: 'Read Product Research',
+        ctaSecondary: 'Read the Guide',
         footerBrand: 'Centralized MySQL binlog backup service for teams that want durable local capture, visible state, and operator control. Apache 2.0 licensed.',
         footerCol1: 'Start',
         footerLink1: 'Deployment Guide',
-        footerLink2: 'Product Research',
+        footerLink2: 'Operator Guide',
         footerLink3: 'Changelog',
         footerCol2: 'Product',
         footerLink4: 'Capabilities',
@@ -1023,6 +1046,10 @@ and into a real product surface</h2>
         navSurfaces: '界面',
         navChangelog: '版本',
         navCta: '版本发布',
+        deployLabel: '快速开始',
+        deployTitle: '下载 release tarball，\n校验、解压、运行',
+        deploySub: '值班不需要安装 Go。真实资产名是 binlog-server_&lt;ver&gt;_&lt;os&gt;_&lt;arch&gt;.tar.gz，解压后在一层版本子目录里。',
+        deployCode: 'VER=0.4.1 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
         heroBadge: 'v0.4.1 — 最新发布',
         heroTitle: '面向真实运维的\nMySQL binlog 备份控制平面',
         heroSub: 'BinlogServer 把 MySQL binlog 备份集中到一个服务里：本地优先的可靠采集、通过 API 与内置 UI 可见的运行状态、可扩展到集群角色的执行模型、Prometheus 指标，以及可选的兼容 S3 的归档上传。',
@@ -1133,11 +1160,11 @@ and into a real product surface</h2>
         ctaTitle: '把 binlog 备份从命令行历史里拉出来，\n放回真正的产品界面',
         ctaSub: '先看部署指南，再检查版本线，把 BinlogServer 当作它本来就已经是的东西去评估：集中式 MySQL binlog 备份控制平面。',
         ctaPrimary: '打开部署指南',
-        ctaSecondary: '阅读产品研究',
+        ctaSecondary: '阅读使用指南',
         footerBrand: '面向需要可靠本地采集、状态可见和运维控制的团队的集中式 MySQL binlog 备份服务。Apache 2.0 许可。',
         footerCol1: '开始',
         footerLink1: '部署指南',
-        footerLink2: '产品研究',
+        footerLink2: '运维指南',
         footerLink3: '版本记录',
         footerCol2: '产品',
         footerLink4: '核心能力',
@@ -1185,6 +1212,11 @@ and into a real product surface</h2>
         root.classList.remove('switching');
       }, 90);
     };
+
+    const docPaths = new Set(['/docs', '/docs/', '/docs/deployment', '/docs/deployment/', '/deployment', '/deployment/', '/guide', '/guide/']);
+    if (docPaths.has(location.pathname) && location.hash !== '#deployment') {
+      location.hash = 'deployment';
+    }
 
     const savedLanguage = localStorage.getItem('binlogserver-lang');
     const preferredLanguage = savedLanguage || (navigator.language && navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en');

--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -3,7 +3,7 @@
 ## Files
 | File | Responsibility |
 |------|---------------|
-| `server.go` | HTTP server/router 组装、路由注册 |
+| `server.go` | HTTP server/router 组装、路由注册（`/healthz` 与 `/api/health`） |
 | `auth.go` | 路由级鉴权配置与认证中间件、ServerOption 定义 |
 | `rate_limiter.go` | 基于 IP 的令牌桶限流器 |
 | `metrics_prometheus.go` | `/metrics` 采集与输出（基于 `prometheus/client_golang`） |
@@ -25,7 +25,10 @@
 - Tracing: `go.opentelemetry.io/otel`
 
 ## Features
-- 认证：支持 Bearer Token 或 API Key；`/healthz` 默认匿名，`/metrics` 与 `/api/*` 可配置保护
+- 认证：支持 Bearer Token 或 API Key；`/healthz` 与 `/api/health` 默认匿名，`/metrics` 与 `/api/*` 可配置保护
+- 创建任务：整包校验失败返回 JSON `{"error","code"}` 且不落库；`start.gtid` 作为 `gtid_set` 别名
+- `POST /api/tasks/{id}/start` 成功返回 JSON `{"id","state"}`
+- 已跟到源库 tip 时 replication `status=IDLE` 且 `delay_seconds=0`
 - 限流：基于 IP 的令牌桶限流，默认 100 req/s，burst 200
 - Tracing：OTel HTTP span（可选）
 

--- a/internal/api/handlers_tasks.go
+++ b/internal/api/handlers_tasks.go
@@ -338,36 +338,13 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		var req createTaskRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
+			writeAPIError(w, http.StatusBadRequest, tasks.CodeInvalidRequest, "invalid json")
 			return
 		}
 
-		task, err := s.tasks.CreateTask(req.Name, req.ClusterKey)
+		task, err := s.tasks.CreateTaskFromSpec(req.Name, req.ClusterKey, req.Source, req.Start, req.Storage)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if req.Source != nil {
-			if err := s.tasks.ConfigureSource(task.ID, *req.Source); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-		if req.Start != nil {
-			if err := s.tasks.ConfigureStart(task.ID, *req.Start); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-		if req.Storage != nil {
-			if err := s.tasks.ConfigureStorage(task.ID, *req.Storage); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-		task, err = s.tasks.GetTask(task.ID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeTaskError(w, err)
 			return
 		}
 		writeJSON(w, http.StatusCreated, sanitizeTask(task))
@@ -508,11 +485,19 @@ func (s *Server) handleTaskAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		if errors.Is(err, tasks.ErrTaskNotFound) {
-			http.Error(w, err.Error(), http.StatusNotFound)
+		writeTaskError(w, err)
+		return
+	}
+	if action == "start" {
+		task, getErr := s.tasks.GetTask(taskID)
+		if getErr != nil {
+			writeTaskError(w, getErr)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		writeJSON(w, http.StatusOK, map[string]string{
+			"id":    task.ID,
+			"state": string(task.State),
+		})
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -702,7 +687,13 @@ func buildReplicationResponse(task tasks.Task, progress tasks.ReplicationProgres
 			resp.Reason = "TASK_STATE_ERROR"
 		}
 	case tasks.StateRunning:
-		if !exists || progress.LastEventAt.IsZero() {
+		if progress.CaughtUp {
+			resp.DelaySeconds = 0
+			resp.Status = "IDLE"
+			resp.Reason = ""
+			return resp
+		}
+		if !exists || (progress.LastEventAt.IsZero() && progress.LastEventFile == "") {
 			resp.Status = "ABNORMAL"
 			resp.Reason = "NO_PROGRESS"
 			return resp
@@ -750,14 +741,14 @@ func (s *Server) handleTaskEntity(w http.ResponseWriter, r *http.Request, taskID
 		})
 		if err != nil {
 			if errors.Is(err, tasks.ErrTaskNotFound) {
-				http.Error(w, err.Error(), http.StatusNotFound)
+				writeAPIError(w, http.StatusNotFound, "TASK_NOT_FOUND", err.Error())
 				return
 			}
 			if isTaskUpdateBadRequest(err) {
-				http.Error(w, err.Error(), http.StatusBadRequest)
+				writeAPIError(w, http.StatusBadRequest, tasks.CodeInvalidRequest, err.Error())
 				return
 			}
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			writeAPIError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error")
 			return
 		}
 		writeJSON(w, http.StatusOK, sanitizeTask(updated))
@@ -783,10 +774,34 @@ func isTaskUpdateBadRequest(err error) bool {
 		errors.Is(err, tasks.ErrClusterKeyExists) ||
 		errors.Is(err, tasks.ErrInvalidTaskName) ||
 		errors.Is(err, tasks.ErrInvalidSourceConfig) ||
+		errors.Is(err, tasks.ErrSourceRequired) ||
+		errors.Is(err, tasks.ErrSourcePasswordRequired) ||
+		errors.Is(err, tasks.ErrStorageDirNotSupported) ||
 		errors.Is(err, tasks.ErrFilePosRequired) ||
 		errors.Is(err, tasks.ErrGTIDSetRequired) ||
 		errors.Is(err, tasks.ErrInvalidStartMode) ||
 		errors.Is(err, tasks.ErrInvalidRetentionDays)
+}
+
+type apiErrorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+func writeAPIError(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, apiErrorBody{Error: msg, Code: code})
+}
+
+func writeTaskError(w http.ResponseWriter, err error) {
+	if errors.Is(err, tasks.ErrTaskNotFound) {
+		writeAPIError(w, http.StatusNotFound, "TASK_NOT_FOUND", err.Error())
+		return
+	}
+	if isTaskUpdateBadRequest(err) {
+		writeAPIError(w, http.StatusBadRequest, tasks.CodeInvalidRequest, err.Error())
+		return
+	}
+	writeAPIError(w, http.StatusBadRequest, tasks.CodeInvalidRequest, err.Error())
 }
 
 // writeJSON 统一输出 JSON 响应。

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces
-// output: REST API responses and status codes for task/cluster operations
+// output: REST API responses including /healthz and /api/health
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -22,6 +22,7 @@ import (
 type taskService interface {
 	// 任务 CRUD/控制。
 	CreateTask(name string, clusterKey string) (tasks.Task, error)
+	CreateTaskFromSpec(name string, clusterKey string, source *tasks.SourceConfig, start *tasks.StartConfig, storage *tasks.Storage) (tasks.Task, error)
 	UpdateTask(id string, patch tasks.TaskPatch) (tasks.Task, error)
 	ConfigureClusterKey(id string, clusterKey string) error
 	ConfigureName(id string, name string) error
@@ -105,6 +106,7 @@ func (s *Server) routes() {
 		apiHandlers = append(apiHandlers, s.authMiddleware())
 	}
 	apiGroup := s.gin.Group("/api", apiHandlers...)
+	apiGroup.GET("/health", gin.WrapF(s.handleAPIHealth))
 	apiGroup.GET("/summary", gin.WrapF(s.handleSummary))
 	apiGroup.GET("/dashboard", gin.WrapF(s.handleDashboard))
 	apiGroup.GET("/sources/lookup", gin.WrapF(s.handleSourceLookup))
@@ -135,6 +137,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
+}
+
+// handleAPIHealth godoc
+// @Summary Service health check (JSON)
+// @Tags System
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Router /api/health [get]
+func (s *Server) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // handleMetrics 返回 Prometheus 文本格式指标。

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -133,7 +133,7 @@ func TestTaskAPI_CreateListStartStop(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -159,8 +159,15 @@ func TestTaskAPI_CreateListStartStop(t *testing.T) {
 	startResp := httptest.NewRecorder()
 	startReq := httptest.NewRequest(http.MethodPost, "/api/tasks/"+created.ID+"/start", nil)
 	handler.ServeHTTP(startResp, startReq)
-	if startResp.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d body=%s", startResp.Code, startResp.Body.String())
+	if startResp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", startResp.Code, startResp.Body.String())
+	}
+	var started map[string]string
+	if err := json.Unmarshal(startResp.Body.Bytes(), &started); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	if started["id"] == "" || started["state"] == "" {
+		t.Fatalf("expected start JSON with id/state, got %s", startResp.Body.String())
 	}
 
 	stopResp := httptest.NewRecorder()
@@ -207,7 +214,7 @@ func TestTaskAPI_CreateWithSourceAndStart(t *testing.T) {
 		"cluster_key":"cluster-a-key",
 		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001},
 		"start":{"mode":"FILE_POS","file":"mysql-bin.000001","pos":4},
-		"storage":{"dir":"./data","retention_days":15}
+		"storage":{"retention_days":15}
 	}`
 	createResp := httptest.NewRecorder()
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(reqBody))
@@ -251,7 +258,7 @@ func TestTaskAPI_CreateTaskRequiresClusterKey(t *testing.T) {
 	createResp := httptest.NewRecorder()
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -270,7 +277,7 @@ func TestTaskAPI_UpdateTaskRequiresClusterKey(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -296,7 +303,7 @@ func TestTaskAPI_ClusterKeyMustBeUnique(t *testing.T) {
 	firstReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"dup-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	firstReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(first, firstReq)
@@ -308,7 +315,7 @@ func TestTaskAPI_ClusterKeyMustBeUnique(t *testing.T) {
 	secondReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-b",
 		"cluster_key":"dup-key",
-		"source":{"host":"127.0.0.1","port":3307,"user":"repl","flavor":"mysql","server_id":200002}
+		"source":{"host":"127.0.0.1","port":3307,"user":"repl","password":"secret","flavor":"mysql","server_id":200002}
 	}`))
 	secondReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(second, secondReq)
@@ -349,7 +356,7 @@ func TestTaskAPI_UpdateRejectsInvalidInput(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -384,7 +391,7 @@ func TestTaskAPI_UpdateInvalidStartHasNoSideEffects(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -447,7 +454,7 @@ func TestTaskAPI_UpdateTaskStoreFailureReturnsInternalServerError(t *testing.T) 
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -460,7 +467,7 @@ func TestTaskAPI_UpdateTaskStoreFailureReturnsInternalServerError(t *testing.T) 
 	updateReq := httptest.NewRequest(http.MethodPut, "/api/tasks/1", bytes.NewBufferString(`{
 		"name":"cluster-b",
 		"cluster_key":"cluster-b-key",
-		"source":{"host":"127.0.0.1","port":3307,"user":"repl2","flavor":"mysql","server_id":200002}
+		"source":{"host":"127.0.0.1","port":3307,"user":"repl2","password":"secret","flavor":"mysql","server_id":200002}
 	}`))
 	updateReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(updateResp, updateReq)
@@ -580,7 +587,7 @@ func TestTaskAPI_GetCheckpoint(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -620,7 +627,7 @@ func TestTaskAPI_UpdateAndDeleteTask(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1158,7 +1165,7 @@ func TestTaskAPI_MetricsIncludeRetryUploadCounters(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1313,7 +1320,7 @@ func TestTaskAPI_ListUploadFailureReasons(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1345,7 +1352,7 @@ func TestTaskAPI_ListEvents(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1382,7 +1389,7 @@ func TestTaskAPI_ListFiles(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1413,7 +1420,7 @@ func TestTaskAPI_RetryUploadLimitValidation(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1444,7 +1451,7 @@ func TestTaskAPI_UploadFailureReasonsLimitValidation(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1522,7 +1529,7 @@ func TestTaskAPI_RetryUploadReturnsStats(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1554,7 +1561,7 @@ func TestTaskAPI_ListEventsWithLimit(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -2202,5 +2209,97 @@ func TestAPI_SwaggerDocContainsKeyPaths(t *testing.T) {
 		if _, exists := paths[key]; !exists {
 			t.Fatalf("expected swagger path %s", key)
 		}
+	}
+}
+
+func TestTaskAPI_CreateValidationDoesNotPersist(t *testing.T) {
+	scheduler := tasks.NewScheduler()
+	handler := NewServer(scheduler)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"missing gtid_set", `{"name":"repro-400-create","cluster_key":"repro-400-create","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"replpass"},"start":{"mode":"GTID"}}`},
+		{"missing file/pos", `{"name":"repro-file","cluster_key":"repro-file","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"replpass"},"start":{"mode":"FILE_POS"}}`},
+		{"missing source", `{"name":"repro-source","cluster_key":"repro-source"}`},
+		{"missing password", `{"name":"repro-pass","cluster_key":"repro-pass","source":{"host":"127.0.0.1","port":3306,"user":"repl"}}`},
+	}
+	for _, tc := range cases {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(tc.body))
+		req.Header.Set("Content-Type", "application/json")
+		handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("%s: expected 400, got %d body=%s", tc.name, resp.Code, resp.Body.String())
+		}
+		var body apiErrorBody
+		if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+			t.Fatalf("%s: expected JSON error body, got %s", tc.name, resp.Body.String())
+		}
+		if body.Code != tasks.CodeInvalidRequest || body.Error == "" {
+			t.Fatalf("%s: unexpected error body %+v", tc.name, body)
+		}
+		if got := scheduler.ListTasks(); len(got) != 0 {
+			t.Fatalf("%s: expected no persisted task, got %+v", tc.name, got)
+		}
+	}
+}
+
+func TestTaskAPI_CreateAcceptsGTIDAlias(t *testing.T) {
+	scheduler := tasks.NewScheduler()
+	handler := NewServer(scheduler)
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
+		"name":"gtid-alias","cluster_key":"gtid-alias",
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"},
+		"start":{"mode":"GTID","gtid":"3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100"}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var created tasks.Task
+	if err := json.Unmarshal(resp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.Start.GTIDSet != "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100" {
+		t.Fatalf("expected gtid alias mapped to gtid_set, got %+v", created.Start)
+	}
+}
+
+func TestAPIHealthJSON(t *testing.T) {
+	handler := NewServer(tasks.NewScheduler())
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("unexpected health body %+v", body)
+	}
+}
+
+func TestTaskAPI_ReplicationCaughtUpIsIdle(t *testing.T) {
+	scheduler := tasks.NewScheduler()
+	task, err := scheduler.CreateTask("lag-task", "lag-task")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	scheduler.ReportReplicationProgress(task.ID, time.Now().Add(-12*time.Hour), "mysql-bin.000001", 4)
+	scheduler.ReportReplicationCaughtUp(task.ID, "mysql-bin.000001", 4)
+	progress, ok, err := scheduler.GetReplicationProgress(task.ID)
+	if err != nil || !ok {
+		t.Fatalf("progress ok=%v err=%v", ok, err)
+	}
+	resp := buildReplicationResponse(tasks.Task{ID: task.ID, State: tasks.StateRunning}, progress, true, time.Now(), defaultDelayThresholdSeconds)
+	if resp.Status != "IDLE" || resp.DelaySeconds != 0 {
+		t.Fatalf("expected IDLE delay=0, got %+v", resp)
 	}
 }

--- a/internal/api/swagger_docs_only.go
+++ b/internal/api/swagger_docs_only.go
@@ -53,10 +53,11 @@ func (s *Server) swaggerTaskDeleteDoc() {}
 // swaggerTaskStartDoc godoc
 // @Summary Start task
 // @Tags Tasks
+// @Produce json
 // @Param id path string true "Task ID"
-// @Success 204 {string} string
-// @Failure 400 {string} string
-// @Failure 404 {string} string
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} apiErrorBody
+// @Failure 404 {object} apiErrorBody
 // @Router /api/tasks/{id}/start [post]
 func (s *Server) swaggerTaskStartDoc() {}
 

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -8,6 +8,7 @@
 ## Exports
 - `New(cfg)` / `Run(ctx)`: 应用生命周期入口。
 - role/mode 装配逻辑：control-plane/worker/all-in-one。
+- 未配置 `meta_dsn` 时注入 `meta.FileTaskStore`，standalone 任务/checkpoint 落在 `data_dir`，重启后按 checkpoint resume。
 - control-plane 与 worker-health HTTP server 均应用可配置超时（ReadHeader/Read/Write/Idle）。
 - 通过 `config.meta.timeout.*` 注入 tasks/meta 的内部依赖调用超时（读/写/lease/上传）。
 - API server 支持从 `config.API.Auth` 注入鉴权策略。

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
-// input: runtime config, scheduler/runner/meta store dependencies, process context
-// output: application lifecycle control including startup, role wiring, and shutdown
+// input: runtime config, scheduler/runner/meta or file store dependencies, process context
+// output: application lifecycle control including standalone file persistence and resume
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -158,6 +158,18 @@ func (a *App) Run(ctx context.Context) error {
 		runnerOpts = append(runnerOpts, replication.WithCheckpointStore(mysqlStore))
 		runnerOpts = append(runnerOpts, replication.WithFileMetaStore(mysqlStore))
 		leaseManager, leaseVerifier = newClusterLeaseRuntimeForRun(mysqlStore)
+	} else {
+		// standalone 无 meta_dsn 时，把任务/checkpoint/files 持久化到 data_dir，保证 kill -9 后可恢复。
+		fileStore, err := meta.NewFileTaskStore(a.cfg.DataDir)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, tasks.WithStore(fileStore))
+		opts = append(opts, tasks.WithCheckpointReader(fileStore))
+		opts = append(opts, tasks.WithEventStore(fileStore))
+		opts = append(opts, tasks.WithFileStore(fileStore))
+		runnerOpts = append(runnerOpts, replication.WithCheckpointStore(fileStore))
+		runnerOpts = append(runnerOpts, replication.WithFileMetaStore(fileStore))
 	}
 
 	opts = append(opts, tasks.WithInternalCallTimeouts(tasks.InternalCallTimeouts{
@@ -263,12 +275,13 @@ func (a *App) Run(ctx context.Context) error {
 	if err := scheduler.Restore(restoreCtx); err != nil {
 		return err
 	}
-	if workerEnabled && isClusterMode(a.cfg) {
-		// worker 重启后把可恢复任务重新拉起，清理遗留的中间态。
+	if workerEnabled {
+		// cluster worker 与 standalone 都从持久化状态恢复 RUNNING/STARTING/RETRY 任务，
+		// 由 runner 按 checkpoint 续拉，而不是静默改回 LATEST。
 		stats := resumeClusterWorkerTasks(scheduler)
 		if stats.StopErrors > 0 || stats.StartErrors > 0 {
 			log.Printf(
-				"cluster resume completed with errors considered=%d resumed=%d stop_errors=%d start_errors=%d",
+				"task resume completed with errors considered=%d resumed=%d stop_errors=%d start_errors=%d",
 				stats.Considered,
 				stats.Resumed,
 				stats.StopErrors,

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -157,7 +157,7 @@ func (s *fakeAppMetaStore) snapshot() (acquireCalls, renewCalls, releaseCalls in
 
 // TestApp_StartAndServeHealth 验证相关行为。
 func TestApp_StartAndServeHealth(t *testing.T) {
-	cfg := config.Config{ListenAddr: "127.0.0.1:0"}
+	cfg := config.Config{ListenAddr: "127.0.0.1:0", DataDir: t.TempDir()}
 	a := New(cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -199,6 +199,7 @@ func TestApp_StartAndServeHealth(t *testing.T) {
 func TestApp_ClusterControlPlaneRole(t *testing.T) {
 	cfg := config.Config{
 		ListenAddr: "127.0.0.1:0",
+		DataDir:    t.TempDir(),
 		Mode:       "cluster",
 		Cluster: config.ClusterConfig{
 			Role: "control-plane",
@@ -224,7 +225,7 @@ func TestApp_ClusterControlPlaneRole(t *testing.T) {
 	createBody := `{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl"}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}
 	}`
 	createResp := postJSON(t, "http://"+a.Addr()+"/api/tasks", createBody)
 	if createResp.StatusCode != http.StatusCreated {
@@ -250,6 +251,7 @@ func TestApp_ClusterControlPlaneRole(t *testing.T) {
 func TestApp_ClusterWorkerRole(t *testing.T) {
 	cfg := config.Config{
 		ListenAddr: "127.0.0.1:0",
+		DataDir:    t.TempDir(),
 		Mode:       "cluster",
 		Cluster: config.ClusterConfig{
 			Role: "worker",
@@ -279,6 +281,7 @@ func TestApp_ClusterWorkerRole(t *testing.T) {
 func TestApp_ClusterWorkerRoleWithHealthProbe(t *testing.T) {
 	cfg := config.Config{
 		ListenAddr: "127.0.0.1:0",
+		DataDir:    t.TempDir(),
 		Mode:       "cluster",
 		Cluster: config.ClusterConfig{
 			Role:                   "worker",
@@ -316,6 +319,7 @@ func TestApp_ClusterWorkerRoleWithHealthProbe(t *testing.T) {
 func TestApp_ClusterAllInOneRole(t *testing.T) {
 	cfg := config.Config{
 		ListenAddr: "127.0.0.1:0",
+		DataDir:    t.TempDir(),
 		Mode:       "cluster",
 		Cluster: config.ClusterConfig{
 			Role: "all-in-one",
@@ -341,7 +345,7 @@ func TestApp_ClusterAllInOneRole(t *testing.T) {
 	createBody := `{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl"}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}
 	}`
 	createResp := postJSON(t, "http://"+a.Addr()+"/api/tasks", createBody)
 	if createResp.StatusCode != http.StatusCreated {
@@ -355,9 +359,10 @@ func TestApp_ClusterAllInOneRole(t *testing.T) {
 		t.Fatalf("decode create response: %v", err)
 	}
 	startResp := postJSON(t, "http://"+a.Addr()+"/api/tasks/"+created.ID+"/start", "")
-	if startResp.StatusCode != http.StatusNoContent {
-		t.Fatalf("expected start status 204 in all-in-one role, got %d body=%s", startResp.StatusCode, string(startResp.Body))
+	if startResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected start status 200 in all-in-one role, got %d body=%s", startResp.StatusCode, string(startResp.Body))
 	}
+	_ = postJSON(t, "http://"+a.Addr()+"/api/tasks/"+created.ID+"/stop", "")
 
 	cancel()
 	waitRunExit(t, errCh)
@@ -927,7 +932,7 @@ func TestApp_RunWorkerIdentityStaysCoherentForActiveSession(t *testing.T) {
 	go func() { errCh <- a.Run(ctx) }()
 	waitReady(t, a)
 
-	taskBody := `{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl"}}`
+	taskBody := `{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`
 	createResp := postJSON(t, "http://"+a.Addr()+"/api/tasks", taskBody)
 	if createResp.StatusCode != http.StatusCreated {
 		t.Fatalf("expected create status 201, got %d body=%s", createResp.StatusCode, string(createResp.Body))
@@ -939,8 +944,8 @@ func TestApp_RunWorkerIdentityStaysCoherentForActiveSession(t *testing.T) {
 		t.Fatalf("decode create response: %v", err)
 	}
 	startResp := postJSON(t, "http://"+a.Addr()+"/api/tasks/"+created.ID+"/start", "")
-	if startResp.StatusCode != http.StatusNoContent {
-		t.Fatalf("expected start status 204, got %d body=%s", startResp.StatusCode, string(startResp.Body))
+	if startResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected start status 200, got %d body=%s", startResp.StatusCode, string(startResp.Body))
 	}
 
 	var startedTask tasks.Task

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -14,6 +14,7 @@
 - `Decryptor.DecryptIfEncrypted(value)` - 解密带 `enc:aes256:` 前缀的值
 
 ## Configuration Sections
+- `meta_dsn` 为空时，standalone 控制面持久化到 `data_dir`（不再是纯内存）
 - `api.auth.*` - API 鉴权开关、模式（`bearer`/`api_key`）与凭证配置
 - `api.rate_limit.*` - API 限流配置（enabled/requests_per_second/burst），默认 100 req/s、burst 200
 - `http.control_plane.*` / `http.worker_health.*` - HTTP 超时配置

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 // Package config provides module-level functionality for config.
 // input: YAML files, environment variables, default config constants
-// output: validated runtime configuration structs for downstream modules
+// output: validated runtime configuration structs including data_dir persistence semantics
 // pos: configuration boundary translating external settings into internal options
 // note: if this file changes, update this header and module README.md.
 package config
@@ -24,7 +24,7 @@ type Config struct {
 	ListenAddr string
 	// DataDir 是本地 binlog 文件落盘目录。
 	DataDir string
-	// MetaDSN 是元数据 MySQL 连接串；为空则走内存模式。
+	// MetaDSN 是元数据 MySQL 连接串；为空则把控制面持久化到 data_dir。
 	MetaDSN string
 	// Mode 支持 standalone/cluster。
 	Mode string
@@ -86,9 +86,9 @@ type APIConfig struct {
 
 // RateLimitConfig 定义 API 速率限制配置。
 type RateLimitConfig struct {
-	Enabled            bool
-	RequestsPerSecond  float64
-	Burst              int
+	Enabled           bool
+	RequestsPerSecond float64
+	Burst             int
 }
 
 // APIAuthConfig 定义 /metrics 与 /api/* 鉴权策略。

--- a/internal/meta/README.md
+++ b/internal/meta/README.md
@@ -2,6 +2,7 @@
 
 ## Files
 - `mysql_store.go`: 元数据持久化实现与 schema 校验。
+- `file_store.go`: standalone 文件元数据存储（无 `meta_dsn` 时使用）。
 - `lease_store.go`: lease 读写逻辑。
 - `retry.go`: 重试策略适配层与执行器封装（基于 backoff v4，屏蔽第三方类型）。
 - `tracing.go`: metadata store tracing 开关与 span helper（默认关闭）。
@@ -10,6 +11,7 @@
 
 ## Exports
 - Task/Checkpoint/Event/File/Lease/Run/Worker metadata 存储接口。
+- `NewFileTaskStore(dataDir)`：任务写 `{data_dir}/.meta/tasks/{id}.json`，checkpoint 写 `{data_dir}/{id}/checkpoint.json`（fsync）。
 - 启动期 schema 版本与结构校验（支持 schema 校验超时配置）。
 
 ## Dependencies

--- a/internal/meta/file_store.go
+++ b/internal/meta/file_store.go
@@ -1,0 +1,385 @@
+// Package meta provides module-level functionality for meta.
+// input: standalone data_dir, task/checkpoint/event/file snapshots
+// output: fsynced control-plane files that survive process kill -9
+// pos: file-backed metadata store used when meta_dsn is empty
+// note: if this file changes, update this header and module README.md.
+package meta
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"binlog_server/internal/binlog"
+	"binlog_server/internal/tasks"
+)
+
+const (
+	fileMetaRoot        = ".meta"
+	fileTasksDir        = "tasks"
+	fileEventsDir       = "events"
+	fileFilesDir        = "files"
+	checkpointFileName  = "checkpoint.json"
+	openEpochNameMarker = ".open.e"
+)
+
+// FileTaskStore persists tasks, checkpoints, events, and file metadata under data_dir.
+type FileTaskStore struct {
+	dataDir string
+	mu      sync.Mutex
+}
+
+// NewFileTaskStore creates a standalone file-backed metadata store.
+func NewFileTaskStore(dataDir string) (*FileTaskStore, error) {
+	if strings.TrimSpace(dataDir) == "" {
+		dataDir = "./data"
+	}
+	store := &FileTaskStore{dataDir: dataDir}
+	if err := os.MkdirAll(store.tasksDir(), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(store.eventsDir(), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(store.filesMetaDir(), 0o755); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *FileTaskStore) tasksDir() string {
+	return filepath.Join(s.dataDir, fileMetaRoot, fileTasksDir)
+}
+
+func (s *FileTaskStore) eventsDir() string {
+	return filepath.Join(s.dataDir, fileMetaRoot, fileEventsDir)
+}
+
+func (s *FileTaskStore) filesMetaDir() string {
+	return filepath.Join(s.dataDir, fileMetaRoot, fileFilesDir)
+}
+
+func (s *FileTaskStore) taskPath(taskID string) string {
+	return filepath.Join(s.tasksDir(), taskID+".json")
+}
+
+func (s *FileTaskStore) eventsPath(taskID string) string {
+	return filepath.Join(s.eventsDir(), taskID+".jsonl")
+}
+
+func (s *FileTaskStore) filesPath(taskID string) string {
+	return filepath.Join(s.filesMetaDir(), taskID+".json")
+}
+
+func (s *FileTaskStore) checkpointPath(taskID string) string {
+	return filepath.Join(s.dataDir, taskID, checkpointFileName)
+}
+
+func (s *FileTaskStore) taskDataDir(taskID string) string {
+	return filepath.Join(s.dataDir, taskID)
+}
+
+// Close implements the optional closer used by MySQL store; file store has no handles.
+func (s *FileTaskStore) Close() error {
+	return nil
+}
+
+// UpsertTask fsyncs the task snapshot.
+func (s *FileTaskStore) UpsertTask(_ context.Context, task tasks.Task) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return writeJSONAtomic(s.taskPath(task.ID), task)
+}
+
+// ListTasks reads all persisted task snapshots.
+func (s *FileTaskStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := os.ReadDir(s.tasksDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []tasks.Task{}, nil
+		}
+		return nil, err
+	}
+	out := make([]tasks.Task, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		var task tasks.Task
+		if err := readJSONFile(filepath.Join(s.tasksDir(), entry.Name()), &task); err != nil {
+			return nil, err
+		}
+		if task.ID == "" {
+			task.ID = strings.TrimSuffix(entry.Name(), ".json")
+		}
+		out = append(out, task)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left, leftErr := strconv.Atoi(out[i].ID)
+		right, rightErr := strconv.Atoi(out[j].ID)
+		if leftErr == nil && rightErr == nil {
+			return left < right
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+// DeleteTask removes control-plane records; binlog files are left for operator inspection.
+func (s *FileTaskStore) DeleteTask(_ context.Context, taskID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = os.Remove(s.taskPath(taskID))
+	_ = os.Remove(s.eventsPath(taskID))
+	_ = os.Remove(s.filesPath(taskID))
+	_ = os.Remove(s.checkpointPath(taskID))
+	return nil
+}
+
+// UpsertCheckpoint fsyncs the durable position under {data_dir}/{task_id}/checkpoint.json.
+func (s *FileTaskStore) UpsertCheckpoint(_ context.Context, taskID string, checkpoint binlog.Checkpoint) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if checkpoint.UpdatedAt.IsZero() {
+		checkpoint.UpdatedAt = time.Now()
+	}
+	if err := os.MkdirAll(s.taskDataDir(taskID), 0o755); err != nil {
+		return err
+	}
+	return writeJSONAtomic(s.checkpointPath(taskID), checkpoint)
+}
+
+// LoadCheckpoint reads the last fsynced position.
+func (s *FileTaskStore) LoadCheckpoint(_ context.Context, taskID string) (binlog.Checkpoint, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var checkpoint binlog.Checkpoint
+	if err := readJSONFile(s.checkpointPath(taskID), &checkpoint); err != nil {
+		if os.IsNotExist(err) {
+			return binlog.Checkpoint{}, false, nil
+		}
+		return binlog.Checkpoint{}, false, err
+	}
+	if checkpoint.File == "" || checkpoint.Pos == 0 {
+		return binlog.Checkpoint{}, false, nil
+	}
+	return checkpoint, true, nil
+}
+
+// AppendEvent appends a JSONL event record.
+func (s *FileTaskStore) AppendEvent(_ context.Context, event tasks.TaskEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(s.eventsDir(), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.eventsPath(event.TaskID), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+// ListEvents returns the latest events (newest last, then truncated from the head).
+func (s *FileTaskStore) ListEvents(_ context.Context, taskID string, limit int) ([]tasks.TaskEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := os.ReadFile(s.eventsPath(taskID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []tasks.TaskEvent{}, nil
+		}
+		return nil, err
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	events := make([]tasks.TaskEvent, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var event tasks.TaskEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		events = append(events, event)
+	}
+	if limit > 0 && len(events) > limit {
+		events = events[len(events)-limit:]
+	}
+	return events, nil
+}
+
+// UpsertBinlogFile persists file metadata and is merged with a disk scan on list.
+func (s *FileTaskStore) UpsertBinlogFile(_ context.Context, meta tasks.BinlogFile) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	files, err := s.readFileMetaLocked(meta.TaskID)
+	if err != nil {
+		return err
+	}
+	replaced := false
+	for i, item := range files {
+		if item.FileName == meta.FileName || item.FilePath == meta.FilePath {
+			files[i] = meta
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		files = append(files, meta)
+	}
+	return writeJSONAtomic(s.filesPath(meta.TaskID), files)
+}
+
+// ListBinlogFiles returns persisted metadata plus currently open/sealed files on disk.
+func (s *FileTaskStore) ListBinlogFiles(_ context.Context, taskID string, limit int) ([]tasks.BinlogFile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	files, err := s.readFileMetaLocked(taskID)
+	if err != nil {
+		return nil, err
+	}
+	files = mergeDiskBinlogFiles(files, s.taskDataDir(taskID), taskID)
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].CreatedAt.Equal(files[j].CreatedAt) {
+			return files[i].FileName < files[j].FileName
+		}
+		return files[i].CreatedAt.After(files[j].CreatedAt)
+	})
+	if limit > 0 && len(files) > limit {
+		files = files[:limit]
+	}
+	return files, nil
+}
+
+func (s *FileTaskStore) readFileMetaLocked(taskID string) ([]tasks.BinlogFile, error) {
+	var files []tasks.BinlogFile
+	if err := readJSONFile(s.filesPath(taskID), &files); err != nil {
+		if os.IsNotExist(err) {
+			return []tasks.BinlogFile{}, nil
+		}
+		return nil, err
+	}
+	return files, nil
+}
+
+func mergeDiskBinlogFiles(existing []tasks.BinlogFile, dir, taskID string) []tasks.BinlogFile {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return existing
+	}
+	byName := make(map[string]int, len(existing))
+	for i, item := range existing {
+		byName[item.FileName] = i
+		if item.FilePath != "" {
+			byName[filepath.Base(item.FilePath)] = i
+		}
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == checkpointFileName || strings.HasSuffix(name, ".tmp") || strings.HasSuffix(name, ".json") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		sourceName := displayBinlogFileName(name)
+		if idx, ok := byName[sourceName]; ok {
+			if existing[idx].SizeBytes == 0 {
+				existing[idx].SizeBytes = info.Size()
+			}
+			if existing[idx].FilePath == "" {
+				existing[idx].FilePath = filepath.Join(dir, name)
+			}
+			continue
+		}
+		if idx, ok := byName[name]; ok {
+			if existing[idx].SizeBytes == 0 {
+				existing[idx].SizeBytes = info.Size()
+			}
+			continue
+		}
+		existing = append(existing, tasks.BinlogFile{
+			TaskID:      taskID,
+			FileName:    sourceName,
+			FilePath:    filepath.Join(dir, name),
+			SizeBytes:   info.Size(),
+			CreatedAt:   info.ModTime(),
+			UploadState: "LOCAL_ONLY",
+		})
+		byName[sourceName] = len(existing) - 1
+	}
+	return existing
+}
+
+func displayBinlogFileName(name string) string {
+	if idx := strings.LastIndex(name, openEpochNameMarker); idx > 0 {
+		return name[:idx]
+	}
+	return name
+}
+
+func writeJSONAtomic(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}
+
+func readJSONFile(path string, v any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}

--- a/internal/meta/file_store_test.go
+++ b/internal/meta/file_store_test.go
@@ -1,0 +1,91 @@
+// Package meta provides module-level functionality for meta.
+// input: temp data_dir fixtures and task/checkpoint/file snapshots
+// output: assertions that standalone file store survives reload and lists open files
+// pos: unit tests for file-backed metadata used without meta_dsn
+// note: if this file changes, update this header and module README.md.
+package meta
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"binlog_server/internal/binlog"
+	"binlog_server/internal/tasks"
+)
+
+func TestFileTaskStore_PersistsTaskAndCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileTaskStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileTaskStore: %v", err)
+	}
+
+	task := tasks.Task{
+		ID:         "4",
+		Name:       "dogfood",
+		ClusterKey: "dogfood",
+		State:      tasks.StateRunning,
+		Start:      tasks.StartConfig{Mode: tasks.StartModeLatest},
+		Source: tasks.SourceConfig{
+			Host:     "127.0.0.1",
+			Port:     3306,
+			User:     "repl",
+			Password: "secret",
+		},
+		UpdatedAt: time.Now(),
+	}
+	if err := store.UpsertTask(context.Background(), task); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	if err := store.UpsertCheckpoint(context.Background(), task.ID, binlog.Checkpoint{
+		File: "binlog.000002",
+		Pos:  1205,
+	}); err != nil {
+		t.Fatalf("UpsertCheckpoint: %v", err)
+	}
+
+	reloaded, err := NewFileTaskStore(dir)
+	if err != nil {
+		t.Fatalf("reload store: %v", err)
+	}
+	list, err := reloaded.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "4" || list[0].Start.Mode != tasks.StartModeLatest {
+		t.Fatalf("unexpected restored tasks: %+v", list)
+	}
+	checkpoint, ok, err := reloaded.LoadCheckpoint(context.Background(), "4")
+	if err != nil || !ok {
+		t.Fatalf("LoadCheckpoint ok=%v err=%v", ok, err)
+	}
+	if checkpoint.File != "binlog.000002" || checkpoint.Pos != 1205 {
+		t.Fatalf("unexpected checkpoint: %+v", checkpoint)
+	}
+}
+
+func TestFileTaskStore_ListFilesIncludesOpenSegment(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileTaskStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileTaskStore: %v", err)
+	}
+	taskDir := filepath.Join(dir, "4")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "binlog.000002"), []byte("binlog"), 0o644); err != nil {
+		t.Fatalf("write open segment: %v", err)
+	}
+
+	files, err := store.ListBinlogFiles(context.Background(), "4", 200)
+	if err != nil {
+		t.Fatalf("ListBinlogFiles: %v", err)
+	}
+	if len(files) != 1 || files[0].FileName != "binlog.000002" {
+		t.Fatalf("expected open segment listed, got %+v", files)
+	}
+}

--- a/internal/replication/README.md
+++ b/internal/replication/README.md
@@ -1,7 +1,8 @@
 # internal/replication Module
 
 ## Files
-- `mysql_runner.go`: 复制主执行流程。
+- `mysql_runner.go`: 复制主执行流程、空闲 caught-up 上报、打开中文件元数据。
+- `source_identity.go`: flavor 感知源身份（MariaDB 用 `server_id`+`gtid_domain_id`）与 `log_bin` 探测。
 - `resolver.go`: 起点解析。
 - 其余 `*_test.go`: 复制、恢复、上传等行为测试。
   其中 `mysql_runner_run_test.go` 重点覆盖 runner 级起点选择、checkpoint 推进/失败、错误传播与停止清理语义。

--- a/internal/replication/mysql_runner.go
+++ b/internal/replication/mysql_runner.go
@@ -1,7 +1,7 @@
 // Package replication provides module-level functionality for replication.
-// input: source replication config, task state, checkpoint/file store dependencies
-// output: replication run control, local binlog artifacts, and upload/recovery signals
-// pos: data-plane runtime that consumes MySQL binlog stream and emits durable outputs
+// input: source replication config, flavor-aware identity, checkpoint/file store dependencies
+// output: replication run control, durable local artifacts, caught-up progress, and permanent source errors
+// pos: data-plane runtime that consumes MySQL/MariaDB binlog stream and emits durable outputs
 // note: if this file changes, update this header and module README.md.
 package replication
 
@@ -200,17 +200,17 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 	// source_server_uuid 作为 object key 的稳定维度，避免 cluster_key 相同但源实例切换时冲突。
 	sourceServerUUID, err := r.fetcher.FetchServerUUID(ctx, task.Source)
 	if err != nil {
-		return err
+		return classifySourceError(err)
 	}
 	sourceServerUUID = strings.TrimSpace(sourceServerUUID)
 	if sourceServerUUID == "" {
-		return errors.New("empty source server_uuid")
+		return tasks.NewPermanentError(tasks.CodeSourceIdentityUnavailable, "empty source server_uuid")
 	}
 
 	// 先解析请求的 start strategy（LATEST/FILE_POS/GTID）。
 	start, err := ResolveStart(ctx, task, r.fetcher)
 	if err != nil {
-		return err
+		return classifySourceError(err)
 	}
 	if r.checkpointStore != nil {
 		// 持久化 checkpoint 优先级更高，保证重启后的 resumability。
@@ -240,6 +240,9 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 
 	file, writer, currentPath, err := writerOpener(task, currentFile, currentPos)
 	if err != nil {
+		return err
+	}
+	if err := r.persistOpenFileMeta(ctx, task, currentFile, currentPath, currentPos, currentCreatedAt); err != nil {
 		return err
 	}
 	defer func() {
@@ -393,41 +396,103 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 		return fmt.Errorf("unsupported resolved start mode: %s", start.Mode)
 	}
 	if err != nil {
-		return err
+		return classifySourceError(err)
 	}
 
 	if onReady != nil {
 		// 到这里说明“连接 + 起点 + writer”都已 ready，Scheduler 可安全切 RUNNING。
 		onReady()
 	}
+	r.reportCaughtUp(task.ID, currentFile, currentPos)
 
 	if semiSyncRequested {
 		// SynchronousEventHandler 模式下，事件由 syncer 内部 goroutine 推送到 handler。
 		// 这里阻塞等待错误或取消，保持任务生命周期。
 		for {
-			_, err := streamer.GetEvent(ctx)
+			event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos)
 			if err != nil {
 				if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 					return nil
 				}
 				return err
 			}
+			if event == nil {
+				continue
+			}
 		}
 	}
 
 	// Step 5: 异步模式主循环（逐条拉取并处理事件）。
 	for {
-		event, err := streamer.GetEvent(ctx)
+		event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos)
 		if err != nil {
 			if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 				return nil
 			}
 			return err
 		}
+		if event == nil {
+			continue
+		}
 		if err := handleEvent(event); err != nil {
 			return err
 		}
 	}
+}
+
+const idlePollInterval = 2 * time.Second
+
+func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, taskID, file string, pos uint32) (*replication.BinlogEvent, error) {
+	eventCtx, cancel := context.WithTimeout(ctx, idlePollInterval)
+	event, err := streamer.GetEvent(eventCtx)
+	cancel()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			r.reportCaughtUp(taskID, file, pos)
+			return nil, nil
+		}
+		return nil, classifySourceError(err)
+	}
+	return event, nil
+}
+
+func (r *MySQLRunner) reportCaughtUp(taskID, file string, pos uint32) {
+	if r.progressReporter == nil {
+		return
+	}
+	if reporter, ok := r.progressReporter.(interface {
+		ReportReplicationCaughtUp(taskID string, file string, pos uint32)
+	}); ok {
+		reporter.ReportReplicationCaughtUp(taskID, file, pos)
+	}
+}
+
+func (r *MySQLRunner) persistOpenFileMeta(ctx context.Context, task tasks.Task, fileName, path string, startPos uint32, createdAt time.Time) error {
+	if r.fileMetaStore == nil {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return r.fileMetaStore.UpsertBinlogFile(ctx, tasks.BinlogFile{
+		TaskID:      task.ID,
+		FileName:    fileName,
+		FilePath:    path,
+		SizeBytes:   info.Size(),
+		StartPos:    startPos,
+		CreatedAt:   createdAt,
+		UploadState: "LOCAL_ONLY",
+	})
 }
 
 // finalizeSealedFile 负责 open 文件 seal、元数据落库以及 best-effort 上传。
@@ -631,13 +696,16 @@ func (f *mysqlStatusFetcher) FetchMasterStatus(_ context.Context, source tasks.S
 	addr := fmt.Sprintf("%s:%d", source.Host, source.Port)
 	conn, err := sqlclient.Connect(addr, source.User, source.Password, "")
 	if err != nil {
-		return MasterStatus{}, err
+		return MasterStatus{}, classifySourceError(err)
 	}
 	defer conn.Close()
 
 	result, err := conn.Execute("SHOW MASTER STATUS")
-	if err != nil {
-		return MasterStatus{}, err
+	if err != nil || result == nil || result.Resultset == nil || result.Resultset.RowNumber() == 0 {
+		result, err = conn.Execute("SHOW BINLOG STATUS")
+		if err != nil {
+			return MasterStatus{}, classifySourceError(err)
+		}
 	}
 	if result == nil || result.Resultset == nil || result.Resultset.RowNumber() == 0 {
 		return MasterStatus{}, errors.New("empty master status")
@@ -658,32 +726,38 @@ func (f *mysqlStatusFetcher) FetchMasterStatus(_ context.Context, source tasks.S
 	}, nil
 }
 
-// FetchServerUUID 读取源库 server_uuid（用于 object key 维度）。
+// FetchServerUUID 读取源库身份（MySQL server_uuid；MariaDB 使用 server_id+gtid_domain_id）。
 func (f *mysqlStatusFetcher) FetchServerUUID(_ context.Context, source tasks.SourceConfig) (string, error) {
 	addr := fmt.Sprintf("%s:%d", source.Host, source.Port)
 	conn, err := sqlclient.Connect(addr, source.User, source.Password, "")
 	if err != nil {
-		return "", err
+		return "", classifySourceError(err)
 	}
 	defer conn.Close()
 
-	result, err := conn.Execute("SHOW VARIABLES LIKE 'server_uuid'")
+	logBin, err := queryVariable(conn, "log_bin")
+	if err != nil {
+		return "", classifySourceError(err)
+	}
+	serverUUID, _ := queryVariable(conn, "server_uuid")
+	serverID, _ := queryVariable(conn, "server_id")
+	domainID, _ := queryVariable(conn, "gtid_domain_id")
+	return resolveSourceIdentity(source.Flavor, logBin, serverUUID, serverID, domainID)
+}
+
+func queryVariable(conn *sqlclient.Conn, name string) (string, error) {
+	result, err := conn.Execute("SHOW VARIABLES LIKE '" + name + "'")
 	if err != nil {
 		return "", err
 	}
 	if result == nil || result.Resultset == nil || result.Resultset.RowNumber() == 0 {
-		return "", errors.New("empty server_uuid")
+		return "", nil
 	}
-
 	value, err := result.GetString(0, 1)
 	if err != nil {
 		return "", err
 	}
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", errors.New("empty server_uuid")
-	}
-	return value, nil
+	return strings.TrimSpace(value), nil
 }
 
 // effectiveStartFromCheckpoint 在 checkpoint 可用时覆盖请求起点。

--- a/internal/replication/source_identity.go
+++ b/internal/replication/source_identity.go
@@ -1,0 +1,70 @@
+// Package replication provides module-level functionality for replication.
+// input: source connection results, flavor, log_bin and identity variables
+// output: stable source identity strings and permanent source configuration errors
+// pos: flavor-aware source probe used before binlog dump starts
+// note: if this file changes, update this header and module README.md.
+package replication
+
+import (
+	"fmt"
+	"strings"
+
+	"binlog_server/internal/tasks"
+)
+
+func isAccessDeniedMessage(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(msg, "ERROR 1045") ||
+		strings.Contains(msg, "Error 1045") ||
+		strings.Contains(lower, "access denied")
+}
+
+func classifySourceError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if tasks.IsPermanent(err) {
+		return err
+	}
+	if isAccessDeniedMessage(err.Error()) {
+		return tasks.NewPermanentError(tasks.CodeSourceAccessDenied, err.Error())
+	}
+	return err
+}
+
+func isLogBinEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "on", "1", "true":
+		return true
+	default:
+		return false
+	}
+}
+
+func isMariaDBFlavor(flavor string) bool {
+	return strings.EqualFold(strings.TrimSpace(flavor), "mariadb")
+}
+
+// resolveSourceIdentity maps probed variables to a stable identity.
+// MariaDB 11 has no @@server_uuid; identity is mariadb:<server_id>:<gtid_domain_id>.
+func resolveSourceIdentity(flavor, logBin, serverUUID, serverID, domainID string) (string, error) {
+	if !isLogBinEnabled(logBin) {
+		return "", tasks.NewPermanentError(tasks.CodeSourceLogBinOff, "log_bin is off")
+	}
+	if isMariaDBFlavor(flavor) {
+		serverID = strings.TrimSpace(serverID)
+		if serverID == "" {
+			return "", tasks.NewPermanentError(tasks.CodeSourceIdentityUnavailable, "empty mariadb server_id")
+		}
+		domainID = strings.TrimSpace(domainID)
+		if domainID == "" {
+			domainID = "0"
+		}
+		return fmt.Sprintf("mariadb:%s:%s", serverID, domainID), nil
+	}
+	serverUUID = strings.TrimSpace(serverUUID)
+	if serverUUID == "" {
+		return "", tasks.NewPermanentError(tasks.CodeSourceIdentityUnavailable, "empty server_uuid")
+	}
+	return serverUUID, nil
+}

--- a/internal/replication/source_identity_test.go
+++ b/internal/replication/source_identity_test.go
@@ -1,0 +1,63 @@
+// Package replication provides module-level functionality for replication.
+// input: flavor/log_bin/identity fixtures and go-mysql style error strings
+// output: source identity resolution and permanent-error classification assertions
+// pos: unit tests for MariaDB/MySQL source probe semantics
+// note: if this file changes, update this header and module README.md.
+package replication
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"binlog_server/internal/tasks"
+)
+
+func TestResolveSourceIdentity_MariaDBUsesServerID(t *testing.T) {
+	id, err := resolveSourceIdentity("mariadb", "ON", "", "1", "0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "mariadb:1:0" {
+		t.Fatalf("unexpected identity %q", id)
+	}
+}
+
+func TestResolveSourceIdentity_LogBinOffIsPermanent(t *testing.T) {
+	_, err := resolveSourceIdentity("mariadb", "OFF", "", "1", "0")
+	if !tasks.IsPermanent(err) {
+		t.Fatalf("expected permanent error, got %v", err)
+	}
+	var pe *tasks.PermanentError
+	if !errors.As(err, &pe) || pe.Code != tasks.CodeSourceLogBinOff {
+		t.Fatalf("expected SOURCE_LOG_BIN_OFF, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "log_bin is off") {
+		t.Fatalf("expected log_bin off message, got %v", err)
+	}
+}
+
+func TestResolveSourceIdentity_MySQLRequiresServerUUID(t *testing.T) {
+	_, err := resolveSourceIdentity("mysql", "ON", "", "1", "0")
+	if !tasks.IsPermanent(err) {
+		t.Fatalf("expected permanent empty server_uuid, got %v", err)
+	}
+	id, err := resolveSourceIdentity("mysql", "1", "abc-uuid", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "abc-uuid" {
+		t.Fatalf("unexpected identity %q", id)
+	}
+}
+
+func TestClassifySourceError_AccessDenied(t *testing.T) {
+	err := classifySourceError(errors.New("handleAuthResult: ERROR 1045 (28000): Access denied for user 'repl'@'127.0.0.1'"))
+	if !tasks.IsPermanent(err) {
+		t.Fatalf("expected permanent error, got %v", err)
+	}
+	var pe *tasks.PermanentError
+	if !errors.As(err, &pe) || pe.Code != tasks.CodeSourceAccessDenied {
+		t.Fatalf("expected SOURCE_ACCESS_DENIED, got %v", err)
+	}
+}

--- a/internal/swaggerdocs/README.md
+++ b/internal/swaggerdocs/README.md
@@ -2,9 +2,11 @@
 
 ## Files
 - `docs.go`: 生成的 swagger/openapi 文档代码。
+- `swagger.json` / `swagger.yaml`: 与 `docs.go` 同步的 OpenAPI 产物。
 
 ## Exports
 - swagger 文档元数据供 API 文档页面消费。
+- 当前契约：`POST /api/tasks/{id}/start` 成功为 200 JSON；`GET /api/health` 与 `/healthz` 均在 spec 中。
 
 ## Dependencies
 - Upstream: `internal/api` 注释与接口定义。

--- a/internal/swaggerdocs/docs.go
+++ b/internal/swaggerdocs/docs.go
@@ -89,6 +89,28 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/health": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Service health check (JSON)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/sources/lookup": {
             "get": {
                 "produces": [
@@ -101,14 +123,14 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "MySQL source host",
+                        "description": "MySQL source host (required)",
                         "name": "host",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "integer",
-                        "description": "MySQL source port",
+                        "description": "MySQL source port (required, 1-65535)",
                         "name": "port",
                         "in": "query",
                         "required": true
@@ -599,6 +621,7 @@ const docTemplate = `{
                     },
                     {
                         "maximum": 1000,
+                        "minimum": 1,
                         "type": "integer",
                         "default": 100,
                         "description": "Retry upload limit",
@@ -771,6 +794,9 @@ const docTemplate = `{
         },
         "/api/tasks/{id}/start": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Tasks"
                 ],
@@ -785,22 +811,25 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content",
+                    "200": {
+                        "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/api.apiErrorBody"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/api.apiErrorBody"
                         }
                     }
                 }
@@ -862,6 +891,7 @@ const docTemplate = `{
                     },
                     {
                         "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
                         "default": 20,
                         "description": "Failure reason list limit",
@@ -954,6 +984,17 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "api.apiErrorBody": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
         "api.clusterOverview": {
             "type": "object",
             "properties": {
@@ -1359,6 +1400,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "password": {
+                    "description": "仅用于输入，API 响应前会清空",
                     "type": "string"
                 },
                 "port": {
@@ -1554,7 +1596,6 @@ var SwaggerInfo = &swag.Spec{
 	RightDelim:       "}}",
 }
 
-// init 实现对应功能逻辑。
 func init() {
 	swag.Register(SwaggerInfo.InstanceName(), SwaggerInfo)
 }

--- a/internal/swaggerdocs/swagger.json
+++ b/internal/swaggerdocs/swagger.json
@@ -78,6 +78,28 @@
                 }
             }
         },
+        "/api/health": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Service health check (JSON)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/sources/lookup": {
             "get": {
                 "produces": [
@@ -90,14 +112,14 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "MySQL source host",
+                        "description": "MySQL source host (required)",
                         "name": "host",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "integer",
-                        "description": "MySQL source port",
+                        "description": "MySQL source port (required, 1-65535)",
                         "name": "port",
                         "in": "query",
                         "required": true
@@ -588,6 +610,7 @@
                     },
                     {
                         "maximum": 1000,
+                        "minimum": 1,
                         "type": "integer",
                         "default": 100,
                         "description": "Retry upload limit",
@@ -760,6 +783,9 @@
         },
         "/api/tasks/{id}/start": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Tasks"
                 ],
@@ -774,22 +800,25 @@
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "No Content",
+                    "200": {
+                        "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/api.apiErrorBody"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/api.apiErrorBody"
                         }
                     }
                 }
@@ -851,6 +880,7 @@
                     },
                     {
                         "maximum": 200,
+                        "minimum": 1,
                         "type": "integer",
                         "default": 20,
                         "description": "Failure reason list limit",
@@ -943,6 +973,17 @@
         }
     },
     "definitions": {
+        "api.apiErrorBody": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
         "api.clusterOverview": {
             "type": "object",
             "properties": {
@@ -1348,6 +1389,7 @@
                     "type": "string"
                 },
                 "password": {
+                    "description": "仅用于输入，API 响应前会清空",
                     "type": "string"
                 },
                 "port": {

--- a/internal/swaggerdocs/swagger.yaml
+++ b/internal/swaggerdocs/swagger.yaml
@@ -1,5 +1,12 @@
 basePath: /
 definitions:
+  api.apiErrorBody:
+    properties:
+      code:
+        type: string
+      error:
+        type: string
+    type: object
   api.clusterOverview:
     properties:
       leased_task_count:
@@ -259,6 +266,7 @@ definitions:
       host:
         type: string
       password:
+        description: 仅用于输入，API 响应前会清空
         type: string
       port:
         type: integer
@@ -433,15 +441,29 @@ paths:
       summary: Get task dashboard with replication delay overview
       tags:
       - Dashboard
+  /api/health:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Service health check (JSON)
+      tags:
+      - System
   /api/sources/lookup:
     get:
       parameters:
-      - description: MySQL source host
+      - description: MySQL source host (required)
         in: query
         name: host
         required: true
         type: string
-      - description: MySQL source port
+      - description: MySQL source port (required, 1-65535)
         in: query
         name: port
         required: true
@@ -769,6 +791,7 @@ paths:
         description: Retry upload limit
         in: query
         maximum: 1000
+        minimum: 1
         name: limit
         type: integer
       produces:
@@ -889,19 +912,23 @@ paths:
         name: id
         required: true
         type: string
+      produces:
+      - application/json
       responses:
-        "204":
-          description: No Content
+        "200":
+          description: OK
           schema:
-            type: string
+            additionalProperties:
+              type: string
+            type: object
         "400":
           description: Bad Request
           schema:
-            type: string
+            $ref: '#/definitions/api.apiErrorBody'
         "404":
           description: Not Found
           schema:
-            type: string
+            $ref: '#/definitions/api.apiErrorBody'
       summary: Start task
       tags:
       - Tasks
@@ -941,6 +968,7 @@ paths:
         description: Failure reason list limit
         in: query
         maximum: 200
+        minimum: 1
         name: limit
         type: integer
       produces:

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -2,8 +2,9 @@
 
 ## Files
 - `scheduler.go`: 调度器核心类型、选项注入与通用辅助函数。
-- `scheduler_task_ops.go`: 任务 CRUD 与配置更新（非运行时生命周期）。
-- `scheduler_lifecycle.go`: 启停、运行协程与重试退避生命周期流程。
+- `scheduler_task_ops.go`: 任务 CRUD 与配置更新；`CreateTaskFromSpec` 先整包校验再一次落库。
+- `scheduler_lifecycle.go`: 启停、运行协程、可重试退避与不可恢复 FAILED。
+- `errors.go`: `PermanentError`（`SOURCE_ACCESS_DENIED` / `SOURCE_LOG_BIN_OFF` 等）。
 - `scheduler_cluster_lease.go`: cluster lease 续租与降级/失租处理。
 - `scheduler_observability.go`: 复制进度、checkpoint、事件/文件/运行历史查询。
 - `scheduler_retry_upload.go`: 上传失败补偿重试与失败原因聚合。

--- a/internal/tasks/errors.go
+++ b/internal/tasks/errors.go
@@ -1,0 +1,49 @@
+// Package tasks provides module-level functionality for tasks.
+// input: runner/source failure strings and typed operator error codes
+// output: permanent (non-retryable) errors that stop the task state machine
+// pos: shared error types used by scheduler retry policy and source probing
+// note: if this file changes, update this header and module README.md.
+package tasks
+
+import "errors"
+
+const (
+	// CodeSourceAccessDenied is MySQL/MariaDB ERROR 1045.
+	CodeSourceAccessDenied = "SOURCE_ACCESS_DENIED"
+	// CodeSourceLogBinOff is an unrecoverable source configuration error.
+	CodeSourceLogBinOff = "SOURCE_LOG_BIN_OFF"
+	// CodeSourceIdentityUnavailable is a missing source identity after probing.
+	CodeSourceIdentityUnavailable = "SOURCE_IDENTITY_UNAVAILABLE"
+	// CodeInvalidRequest is a create/update validation failure.
+	CodeInvalidRequest = "INVALID_REQUEST"
+)
+
+// PermanentError is an unrecoverable task error that must not enter RETRY_BACKOFF.
+type PermanentError struct {
+	Code    string
+	Message string
+}
+
+func (e *PermanentError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Code == "" {
+		return e.Message
+	}
+	if e.Message == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.Message
+}
+
+// NewPermanentError constructs an unrecoverable operator-facing error.
+func NewPermanentError(code, message string) error {
+	return &PermanentError{Code: code, Message: message}
+}
+
+// IsPermanent reports whether err (or any wrapped error) is unrecoverable.
+func IsPermanent(err error) bool {
+	var pe *PermanentError
+	return errors.As(err, &pe)
+}

--- a/internal/tasks/model.go
+++ b/internal/tasks/model.go
@@ -1,11 +1,14 @@
 // Package tasks provides module-level functionality for tasks.
-// input: task commands/events, runner callbacks, store/lease/uploader dependencies
-// output: task state transitions, scheduling decisions, and execution coordination
-// pos: core domain orchestration layer governing backup task lifecycle and policies
+// input: task JSON payloads, runner callbacks, store/lease/uploader dependencies
+// output: task/start/source models including gtid alias decoding and caught-up progress
+// pos: core domain models for backup task lifecycle and operator-facing contracts
 // note: if this file changes, update this header and module README.md.
 package tasks
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // State 表示任务生命周期状态。
 type State string
@@ -104,11 +107,36 @@ type SourceConfig struct {
 }
 
 // StartConfig 描述复制起点策略。
+// Canonical GTID field is gtid_set; gtid is accepted as an input alias.
 type StartConfig struct {
 	Mode    StartMode `json:"mode"`
 	File    string    `json:"file,omitempty"`
 	Pos     uint32    `json:"pos,omitempty"`
 	GTIDSet string    `json:"gtid_set,omitempty"`
+}
+
+type startConfigJSON struct {
+	Mode    StartMode `json:"mode"`
+	File    string    `json:"file,omitempty"`
+	Pos     uint32    `json:"pos,omitempty"`
+	GTIDSet string    `json:"gtid_set,omitempty"`
+	GTID    string    `json:"gtid,omitempty"`
+}
+
+// UnmarshalJSON accepts both gtid_set and the api.md alias gtid.
+func (s *StartConfig) UnmarshalJSON(data []byte) error {
+	var raw startConfigJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	s.Mode = raw.Mode
+	s.File = raw.File
+	s.Pos = raw.Pos
+	s.GTIDSet = raw.GTIDSet
+	if s.GTIDSet == "" {
+		s.GTIDSet = raw.GTID
+	}
+	return nil
 }
 
 // Storage 描述本地存储策略。
@@ -170,4 +198,6 @@ type ReplicationProgress struct {
 	LastEventFile string    `json:"last_event_file"`
 	LastEventPos  uint32    `json:"last_event_pos"`
 	UpdatedAt     time.Time `json:"updated_at"`
+	// CaughtUp 表示拉流已跟到源库 tip，正在等待下一条事件（静默主库不应计为延迟）。
+	CaughtUp bool `json:"caught_up,omitempty"`
 }

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -34,6 +34,9 @@ var ErrFilePosRequired = errors.New("file/pos is required")
 var ErrGTIDSetRequired = errors.New("gtid_set is required")
 var ErrInvalidStartMode = errors.New("invalid start mode")
 var ErrInvalidRetentionDays = errors.New("invalid retention_days")
+var ErrSourcePasswordRequired = errors.New("source.password is required")
+var ErrSourceRequired = errors.New("source.host/port/user/password is required")
+var ErrStorageDirNotSupported = errors.New("storage.dir is not supported; files are stored at {data_dir}/{task_id}/")
 
 var clusterKeyAllowedPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
@@ -520,6 +523,10 @@ func normalizeAndValidateStartConfig(start StartConfig) (StartConfig, error) {
 // normalizeAndValidateStorage 归一化并校验存储策略。
 func normalizeAndValidateStorage(storage Storage) (Storage, error) {
 	normalized := storage
+	if strings.TrimSpace(normalized.Dir) != "" {
+		return Storage{}, ErrStorageDirNotSupported
+	}
+	normalized.Dir = ""
 	if normalized.RetentionDays < minRetentionDays || normalized.RetentionDays > maxRetentionDays {
 		return Storage{}, ErrInvalidRetentionDays
 	}

--- a/internal/tasks/scheduler_lifecycle.go
+++ b/internal/tasks/scheduler_lifecycle.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: start/stop commands, runner callbacks, and runtime cancellation signals
-// output: task state transitions across STARTING/RUNNING/RETRY/STOPPING lifecycle
+// input: start/stop commands, runner callbacks, permanent/retryable errors, cancellation signals
+// output: task state transitions across STARTING/RUNNING/RETRY/FAILED/STOPPING lifecycle
 // pos: scheduler execution lifecycle orchestration excluding lease-renew loop details
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"log"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 func (s *Scheduler) StartTask(id string) error {
@@ -303,11 +305,20 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 			return
 		}
 
+		errMsg := err.Error()
+		zap.L().Error("runner error", zap.String("task_id", id), zap.Error(err))
+		s.appendEventLocked(id, "TASK_RUNNER_ERROR", "runner error", errMsg)
+		if IsPermanent(err) {
+			_ = s.markFailedLocked(id, errMsg)
+			s.mu.Unlock()
+			return
+		}
+
 		current.State = StateRetryBackoff
-		current.LastError = err.Error()
+		current.LastError = errMsg
 		current.UpdatedAt = time.Now()
 		s.tasks[id] = current
-		s.appendEventLocked(id, "TASK_RUNNER_ERROR", "runner error", err.Error())
+		s.appendEventLocked(id, "TASK_RETRY_BACKOFF", "task entered retry backoff", errMsg)
 		_ = s.persistTaskLocked(current)
 		s.mu.Unlock()
 
@@ -403,6 +414,32 @@ func (s *Scheduler) failSafeStopLocked(id, eventType, message string) {
 		cancel()
 		delete(s.cancels, id)
 	}
+}
+
+// markFailedLocked 将任务收敛到 FAILED，用于不可恢复的源库/配置错误。
+func (s *Scheduler) markFailedLocked(id, message string) error {
+	task, ok := s.tasks[id]
+	if !ok {
+		return nil
+	}
+	if task.State == StateFailed {
+		task.LastError = message
+		s.tasks[id] = task
+		return nil
+	}
+	task.State = StateFailed
+	task.LastError = message
+	task.OwnerWorkerID = ""
+	task.Epoch = 0
+	task.RunID = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[id] = task
+	s.appendEventLocked(id, "TASK_FAILED", "task failed", message)
+	if cancel, ok := s.cancels[id]; ok {
+		cancel()
+		delete(s.cancels, id)
+	}
+	return s.persistTaskLocked(task)
 }
 
 // markStoppedLocked 将任务收敛到最终 STOPPED 并清理运行时 ownership 字段。

--- a/internal/tasks/scheduler_observability.go
+++ b/internal/tasks/scheduler_observability.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: replication/checkpoint/event/file/history read requests and store snapshots
-// output: observability-facing task progress, events, files, runs, and worker heartbeat views
+// output: observability-facing task progress (including caught-up), events, files, runs, and heartbeats
 // pos: scheduler read/query layer for API and metrics consumption
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -36,6 +36,32 @@ func (s *Scheduler) ReportReplicationProgress(taskID string, sourceEventAt time.
 	if pos > 0 {
 		progress.LastEventPos = pos
 	}
+	progress.CaughtUp = false
+	progress.UpdatedAt = time.Now()
+	s.replica[taskID] = progress
+}
+
+// ReportReplicationCaughtUp 标记任务已跟到源库 tip，延迟应视为 0 / IDLE。
+func (s *Scheduler) ReportReplicationCaughtUp(taskID string, file string, pos uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	task, ok := s.tasks[taskID]
+	if !ok {
+		return
+	}
+	if task.State == StateStopping || task.State == StateStopped {
+		return
+	}
+	progress := s.replica[taskID]
+	progress.TaskID = taskID
+	if file != "" {
+		progress.LastEventFile = file
+	}
+	if pos > 0 {
+		progress.LastEventPos = pos
+	}
+	progress.CaughtUp = true
 	progress.UpdatedAt = time.Now()
 	s.replica[taskID] = progress
 }

--- a/internal/tasks/scheduler_task_ops.go
+++ b/internal/tasks/scheduler_task_ops.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: task mutation requests and persisted task snapshots from TaskStore
-// output: validated task CRUD/config updates persisted into scheduler state
+// input: task mutation requests, full create specs, and persisted task snapshots from TaskStore
+// output: validated task CRUD/config updates persisted only after whole-spec validation
 // pos: scheduler task-management operations layer (non-runner lifecycle actions)
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -13,6 +13,15 @@ import (
 )
 
 func (s *Scheduler) CreateTask(name, clusterKey string) (Task, error) {
+	return s.createTask(name, clusterKey, nil, nil, nil, false)
+}
+
+// CreateTaskFromSpec 在一次校验通过后才落库；HTTP 400 路径不得留下半成品任务。
+func (s *Scheduler) CreateTaskFromSpec(name, clusterKey string, source *SourceConfig, start *StartConfig, storage *Storage) (Task, error) {
+	return s.createTask(name, clusterKey, source, start, storage, true)
+}
+
+func (s *Scheduler) createTask(name, clusterKey string, source *SourceConfig, start *StartConfig, storage *Storage, requireSource bool) (Task, error) {
 	validatedName, err := normalizeAndValidateTaskName(name)
 	if err != nil {
 		return Task{}, err
@@ -21,6 +30,48 @@ func (s *Scheduler) CreateTask(name, clusterKey string) (Task, error) {
 	if err != nil {
 		return Task{}, err
 	}
+
+	var validatedSource SourceConfig
+	if requireSource {
+		if source == nil {
+			return Task{}, ErrSourceRequired
+		}
+		if source.Password == "" {
+			return Task{}, ErrSourcePasswordRequired
+		}
+		validatedSource, err = normalizeAndValidateSourceConfig(*source)
+		if err != nil {
+			return Task{}, err
+		}
+		validatedSource.Password = source.Password
+	} else if source != nil {
+		validatedSource, err = normalizeAndValidateSourceConfig(*source)
+		if err != nil {
+			return Task{}, err
+		}
+		validatedSource.Password = source.Password
+	}
+
+	validatedStart := StartConfig{Mode: StartModeLatest}
+	if start != nil {
+		validatedStart, err = normalizeAndValidateStartConfig(*start)
+		if err != nil {
+			return Task{}, err
+		}
+	}
+
+	validatedStorage := Storage{RetentionDays: defaultRetentionDays}
+	if storage != nil {
+		candidate := *storage
+		if candidate.RetentionDays == 0 && candidate.Dir == "" {
+			candidate.RetentionDays = defaultRetentionDays
+		}
+		validatedStorage, err = normalizeAndValidateStorage(candidate)
+		if err != nil {
+			return Task{}, err
+		}
+	}
+
 	if err := s.syncTasksFromStore(); err != nil {
 		return Task{}, err
 	}
@@ -39,13 +90,10 @@ func (s *Scheduler) CreateTask(name, clusterKey string) (Task, error) {
 		Name:       validatedName,
 		ClusterKey: validatedClusterKey,
 		State:      StateCreated,
-		Start: StartConfig{
-			Mode: StartModeLatest,
-		},
-		Storage: Storage{
-			RetentionDays: defaultRetentionDays,
-		},
-		UpdatedAt: now,
+		Source:     validatedSource,
+		Start:      validatedStart,
+		Storage:    validatedStorage,
+		UpdatedAt:  now,
 	}
 	s.tasks[id] = task
 	s.appendEventLocked(id, "TASK_CREATED", "task created", "")

--- a/internal/tasks/scheduler_test.go
+++ b/internal/tasks/scheduler_test.go
@@ -604,6 +604,89 @@ func TestScheduler_UpdateTaskStoreFailureHasNoMutation(t *testing.T) {
 	}
 }
 
+func TestScheduler_CreateTaskFromSpecRejectsMissingGTIDWithoutPersist(t *testing.T) {
+	store := newFakeStore()
+	s := NewScheduler(WithStore(store))
+	source := SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl", Password: "secret", Flavor: "mysql"}
+	start := StartConfig{Mode: StartModeGTID}
+	_, err := s.CreateTaskFromSpec("repro-400-create", "repro-400-create", &source, &start, nil)
+	if !errors.Is(err, ErrGTIDSetRequired) {
+		t.Fatalf("expected ErrGTIDSetRequired, got %v", err)
+	}
+	if len(store.tasks) != 0 {
+		t.Fatalf("expected no persisted task, got %+v", store.tasks)
+	}
+	if len(s.ListTasks()) != 0 {
+		t.Fatalf("expected no in-memory task after validation failure")
+	}
+}
+
+func TestScheduler_CreateTaskFromSpecAcceptsGTIDAliasAndRequiresPassword(t *testing.T) {
+	s := NewScheduler()
+	source := SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl", Flavor: "mysql"}
+	_, err := s.CreateTaskFromSpec("no-pass", "no-pass", &source, nil, nil)
+	if !errors.Is(err, ErrSourcePasswordRequired) {
+		t.Fatalf("expected ErrSourcePasswordRequired, got %v", err)
+	}
+
+	source.Password = "secret"
+	start := StartConfig{Mode: StartModeGTID, GTIDSet: "0-1-1"}
+	task, err := s.CreateTaskFromSpec("gtid-ok", "gtid-ok", &source, &start, nil)
+	if err != nil {
+		t.Fatalf("CreateTaskFromSpec: %v", err)
+	}
+	if task.Start.GTIDSet != "0-1-1" {
+		t.Fatalf("expected gtid_set persisted, got %+v", task.Start)
+	}
+}
+
+func TestScheduler_CreateTaskFromSpecRejectsStorageDir(t *testing.T) {
+	s := NewScheduler()
+	source := SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl", Password: "secret"}
+	storage := Storage{Dir: "./custom", RetentionDays: 7}
+	_, err := s.CreateTaskFromSpec("dir-task", "dir-task", &source, nil, &storage)
+	if !errors.Is(err, ErrStorageDirNotSupported) {
+		t.Fatalf("expected ErrStorageDirNotSupported, got %v", err)
+	}
+}
+
+func TestScheduler_PermanentRunnerErrorMarksFailed(t *testing.T) {
+	s := NewScheduler(WithRunner(&permanentErrorRunner{}))
+	task, err := s.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource: %v", err)
+	}
+	if err := s.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, err := s.GetTask(task.ID)
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		if got.State == StateFailed {
+			if !strings.Contains(got.LastError, CodeSourceAccessDenied) {
+				t.Fatalf("expected SOURCE_ACCESS_DENIED in last_error, got %q", got.LastError)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected FAILED, got %s err=%q", got.State, got.LastError)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type permanentErrorRunner struct{}
+
+func (r *permanentErrorRunner) Run(_ context.Context, _ Task) error {
+	return NewPermanentError(CodeSourceAccessDenied, "Access denied for user 'repl'")
+}
+
 type schedulerTestStore struct {
 	mu            sync.Mutex
 	tasks         map[string]Task

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -8,6 +8,7 @@
 - semi-sync ACK/阻塞语义
 - metadata MySQL failover（Percona57 主从 + ProxySQL + orchestrator）
 - cluster 角色分离（control-plane + worker）与 worker heartbeat 在线/离线恢复
+- `POST /api/tasks/{id}/start` 成功现在是 HTTP 200 JSON（不再是 204）
 
 ## 依赖
 

--- a/scripts/e2e/smoke-cluster-roles.sh
+++ b/scripts/e2e/smoke-cluster-roles.sh
@@ -168,7 +168,7 @@ start_task() {
   local task_id="$1"
   local http_code
   http_code="$(curl -sS -o /tmp/e2e-cluster-start-${RUN_TAG}.resp -w '%{http_code}' -X POST "$API/api/tasks/$task_id/start")"
-  if [[ "$http_code" != "204" ]]; then
+  if [[ "$http_code" != "200" ]]; then
     echo "start task failed: http=$http_code body=$(cat /tmp/e2e-cluster-start-${RUN_TAG}.resp)" >&2
     return 1
   fi

--- a/scripts/e2e/smoke-control-plane-failover.sh
+++ b/scripts/e2e/smoke-control-plane-failover.sh
@@ -143,7 +143,7 @@ start_task() {
   local task_id="$1"
   local http_code
   http_code="$(curl -sS -o /tmp/e2e-control-failover-start-${RUN_TAG}.resp -w '%{http_code}' -X POST "$API/api/tasks/$task_id/start")"
-  if [[ "$http_code" != "204" ]]; then
+  if [[ "$http_code" != "200" ]]; then
     echo "start task failed: http=$http_code body=$(cat /tmp/e2e-control-failover-start-${RUN_TAG}.resp)" >&2
     return 1
   fi

--- a/scripts/e2e/smoke-observability.sh
+++ b/scripts/e2e/smoke-observability.sh
@@ -107,7 +107,7 @@ start_task() {
   local task_id="$1"
   local http_code
   http_code="$(curl -sS -o /tmp/e2e-observability-start-${RUN_TAG}.resp -w '%{http_code}' -X POST "$API/api/tasks/$task_id/start")"
-  if [[ "$http_code" != "204" ]]; then
+  if [[ "$http_code" != "200" ]]; then
     echo "start task failed: http=$http_code body=$(cat /tmp/e2e-observability-start-${RUN_TAG}.resp)" >&2
     exit 1
   fi

--- a/scripts/e2e/smoke-retry-upload.sh
+++ b/scripts/e2e/smoke-retry-upload.sh
@@ -184,7 +184,7 @@ JSON
   fi
   local code
   code="$(curl -sS -o /tmp/e2e-retry-upload-start-${RUN_TAG}.resp -w '%{http_code}' -X POST "$API/api/tasks/$task_id/start")"
-  if [[ "$code" != "204" ]]; then
+  if [[ "$code" != "200" ]]; then
     echo "start task failed: http=$code body=$(cat /tmp/e2e-retry-upload-start-${RUN_TAG}.resp)" >&2
     exit 1
   fi

--- a/scripts/e2e/smoke-worker-crash-recovery.sh
+++ b/scripts/e2e/smoke-worker-crash-recovery.sh
@@ -133,7 +133,7 @@ start_task() {
   local task_id="$1"
   local http_code
   http_code="$(curl -sS -o /tmp/e2e-worker-crash-start-${RUN_TAG}.resp -w '%{http_code}' -X POST "$API/api/tasks/$task_id/start")"
-  if [[ "$http_code" != "204" ]]; then
+  if [[ "$http_code" != "200" ]]; then
     echo "start task failed: http=$http_code body=$(cat /tmp/e2e-worker-crash-start-${RUN_TAG}.resp)" >&2
     return 1
   fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 描述 / Summary

修复 v0.4.1 第一轮值班 dogfood 的 5 个操作员问题。未改 Dependabot PR #7/#8。

This PR makes the released binary installable from docs, lets `flavor=mariadb` start, rejects invalid creates without persisting, keeps standalone tasks/checkpoints across `kill -9`, and stops the unfriendly failure paths.

## 关联 Issue

- Fixes #9
- Fixes #10
- Fixes #11
- Fixes #12
- Fixes #13

## 改动类型

- [x] Bug fix
- [x] Documentation
- [x] Test

## 改动内容

### #9 第一公里文档
- Quick Start 改为：下载 `binlog-server_<ver>_<os>_<arch>.tar.gz` → `checksums.txt` → 解压到版本子目录 → `./binlog-server`
- `go run` / `make build` 移到 Development
- `deployment.md` 去掉 `your-org` 和错误资产名 `binlog-server-linux-amd64`
- 落地页 `#deployment` 写真实安装命令；`/docs` `/deployment` `/guide` 会落到该段，不再是空壳

### #10 MariaDB
- 先探 `log_bin`；关闭则 `SOURCE_LOG_BIN_OFF` / `log_bin is off`
- MariaDB 身份用 `server_id` + `gtid_domain_id`，不再依赖 `@@server_uuid`
- 不可恢复错误进入 `FAILED`，不再无限 `RETRY_BACKOFF`

### #11 创建校验
- 整包校验通过后才落库；HTTP 400 **不落库**
- 缺 `source.host/port/user/password`、FILE_POS 缺 file/pos、GTID 缺 `gtid_set` → 400
- 不再静默改成 `LATEST`
- 错误体为 JSON `{"error","code"}`
- 规范字段为 `gtid_set`，同时接受 `gtid` 别名

### #12 standalone 持久化
- 无 `meta_dsn` 时任务 + checkpoint + files 写到 `BINLOG_SERVER_DATA_DIR`
- 运行中 `GET /checkpoint` 返回已 fsync 位点；`GET /files` 列出正在写的 segment
- `storage.dir` 非空则拒绝；真实路径 `{data_dir}/{task_id}/`
- `POST /start` 成功返回 JSON `{"id","state"}`，不再是 204
- 重启后按 checkpoint resume，不静默从 LATEST 重拉

### #13 失败路径
- bind 失败只报一行，不刷 cobra Usage
- ERROR 1045 → `SOURCE_ACCESS_DENIED`，进入 FAILED
- 已跟到 tip 的静默主库：`delay_seconds=0` / `IDLE`
- `GET /api/health` → `{"status":"ok"}`，保留 `/healthz`
- runner 错误用 zap error 级别写应用日志

### Swagger
- 已 `swag init` 重生成：`POST /start` 为 200 JSON，`GET /api/health` 出现在 spec 里

## 测试 / Test plan（值班可复现）

```bash
# 单元 / 静态
go test ./...
go vet ./...
go test -race ./internal/tasks ./internal/api ./internal/replication ./internal/meta ./internal/app
```

**#9** 按 README Quick Start 下载 v0.4.1 tarball、校验、解压、`./binlog-server`。打开落地页 `/deployment` 应看到安装命令。

**#10** MariaDB 11（`log_bin=ON`，无 `server_uuid`）创建 `flavor=mariadb` 任务并 START，应变 RUNNING 并拉流。对 `log_bin=OFF` 的实例 START，应 FAILED，`last_error` 含 `log_bin is off`，不要无限 RETRY。

**#11**
```bash
# 应 400 JSON，且 GET /api/tasks 没有这条
curl -sS -D - -X POST http://127.0.0.1:8080/api/tasks \
  -H 'Content-Type: application/json' \
  -d '{"name":"repro-400-create","cluster_key":"repro-400-create","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"replpass"},"start":{"mode":"GTID"}}'
```

**#12** 不设 `meta_dsn`，设 `BINLOG_SERVER_DATA_DIR`，START 后写文件，期间 `GET /checkpoint` 与 `GET /files` 应有数据。`kill -9` 后重启，任务还在并从 checkpoint 续拉。

**#13** 端口占用只打一行 bind 错误。错误密码 START 后 `last_error` 含 `SOURCE_ACCESS_DENIED`。静默主库 LATEST 追上后 `/replication` 应为 `IDLE` / `delay_seconds=0`。`curl /api/health` 与 `/healthz` 都成功。

本环境无 Docker，未跑 `make e2e-quick`。

## 配置兼容

- 无 `meta_dsn`：standalone 从内存改为 `data_dir` 文件持久化（行为变化，这是 #12 的修复）
- `storage.dir`：非空现在 400（原先被忽略）
- `POST /start`：204 → 200 JSON

## 回滚

```bash
git revert 0e1c918 003c72b
```

## 未决

- `govulncheck` 失败来自既有依赖 / Go 1.26.1 stdlib（`golang.org/x/net`、`net/http`、`crypto/tls` 等），与本 PR 无关。按要求未改 Dependabot #7/#8。
- `GET /checkpoint` 在第一条事件 fsync 之前仍可能 404（尚无已 fsync 位点）；一旦开始写文件就会返回位点。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006158d9-3f7d-4846-a6bd-2b7c7667b029?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006158d9-3f7d-4846-a6bd-2b7c7667b029&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

