### PR TITLE
fix: v0.4.1 值班问题（#9 #10 #11 #13；#12 按设计文档化）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Maintenance rules:
 
 ## [Unreleased]
 
+### Fixed
+
+- Create task now validates the full spec before persist. HTTP 400 no longer leaves a `LATEST` task behind.
+- `flavor=mariadb` probes `server_id` + `gtid_domain_id` instead of MySQL-only `@@server_uuid`. `log_bin=off` fails as `SOURCE_LOG_BIN_OFF`.
+- Access denied (ERROR 1045) is `SOURCE_ACCESS_DENIED` and enters `FAILED` instead of infinite retry. `POST /start` can restart a `FAILED` task after the operator fixes credentials.
+- Silent masters no longer report multi-hour `DELAYED` lag: an idle dump wait treats lag as 0 / `NORMAL`. Heartbeat events are not written into backup files.
+- Bind failures no longer dump cobra `Usage`.
+- `GET /api/health` returns `{"status":"ok"}` (keep `/healthz`).
+
+### Changed
+
+- Quick Start is download/verify/extract/`./binlog-server`. `go run` moved to Development.
+- Standalone without `meta_dsn` is documented as in-memory control plane. Restartable tasks need `meta_dsn`.
+
 ## [v0.1.2] - 2026-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,52 +59,55 @@ Probably not a fit for:
 
 ## Install / Download
 
-- For tagged public releases, download the archive that matches your platform from GitHub Releases:
-  - `binlog-server_<version>_darwin_amd64.tar.gz`
-  - `binlog-server_<version>_darwin_arm64.tar.gz`
-  - `binlog-server_<version>_linux_amd64.tar.gz`
-  - `binlog-server_<version>_linux_arm64.tar.gz`
-- The release page also provides `checksums.txt`; verify it before extracting.
-- UI assets are embedded into the binary, so you do not need to download a separate frontend package.
+For tagged public releases, download the archive that matches your platform from [GitHub Releases](https://github.com/Fanduzi/BinlogServer/releases):
 
-Source build remains the fallback path:
+- `binlog-server_<version>_darwin_amd64.tar.gz`
+- `binlog-server_<version>_darwin_arm64.tar.gz`
+- `binlog-server_<version>_linux_amd64.tar.gz`
+- `binlog-server_<version>_linux_arm64.tar.gz`
 
-```bash
-make build
+The real asset name is `binlog-server_<ver>_<os>_<arch>.tar.gz` (for example `binlog-server_0.4.1_linux_amd64.tar.gz`). The release page also provides `checksums.txt`; verify it before extracting. The tarball contains a versioned subdirectory:
 
-# Linux deployment binaries should keep CGO disabled to avoid host glibc coupling.
-make build-linux
+```text
+binlog-server_0.4.1_linux_amd64/
+  binlog-server
+  README.md
+  README_ZH.md
+  CHANGELOG.md
+  LICENSE
 ```
 
-To prepare a local set of release assets:
-
-```bash
-make release-assets VERSION=v0.4.1
-```
+UI assets are embedded into the binary, so you do not need a separate frontend package.
 
 ## Quick Start
 
-This section keeps the shortest path to a working service.
+This is the shortest path for release operators. You do not need Go installed.
 
 ### Prerequisites
 
-- Go `1.26.1+`
-- A reachable MySQL instance with binlog enabled
-- Docker available if you want to run E2E scenarios
+- A release tarball for your platform from GitHub Releases
+- A reachable MySQL or MariaDB instance with `log_bin` enabled
 
-### 1. Start the service
-
-```bash
-go run ./cmd/binlog-server
-```
-
-The default listen address is `:8080`.
-
-To set it explicitly:
+### 1. Download, verify, extract, run
 
 ```bash
-BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+VER=0.4.1
+OS=linux          # linux | darwin
+ARCH=amd64        # amd64 | arm64
+
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt"
+sha256sum -c checksums.txt --ignore-missing
+
+tar -xzf "binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+cd "binlog-server_${VER}_${OS}_${ARCH}"
+
+export BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:8080
+export BINLOG_SERVER_DATA_DIR=./data
+./binlog-server
 ```
+
+The default listen address is `:8080` if you omit `BINLOG_SERVER_LISTEN_ADDR`.
 
 ### 2. Verify `/healthz`
 
@@ -190,6 +193,7 @@ Development defaults are intentionally permissive. Do not carry them unchanged i
 
 - Auth: disabled by default; production should protect at least `/api/*` and `/metrics`
 - Meta DB: if `meta_dsn` is configured, run migrations first; the service does not auto-create or auto-upgrade schema
+- Standalone without `meta_dsn` keeps task metadata, checkpoints, and file records in memory only. `kill -9` / process restart drops the control plane. Binlog bytes already written under `{data_dir}/{task_id}/` remain as orphan files. For restartable tasks and `GET /checkpoint` / `GET /files`, configure `meta_dsn`. `storage.dir` is ignored; files always go to `{data_dir}/{task_id}/`.
 - Upload: S3-compatible upload is optional, but required fields must be complete when enabled
 - Tracing: disabled by default; validate exporter configuration and sampling before rollout
 
@@ -298,6 +302,26 @@ Once `Quick Start` works, continue from these entry points:
 | Replication pipeline | [internal/replication/README.md](internal/replication/README.md) |
 | Upload module | [internal/upload/README.md](internal/upload/README.md) |
 | E2E suite | [scripts/e2e/README.md](scripts/e2e/README.md) |
+
+## Development
+
+Source build is the path when you are changing the code, not installing a release.
+
+Prerequisites: Go `1.26.1+`. Docker is needed only for E2E.
+
+```bash
+make build
+
+# Linux deployment binaries should keep CGO disabled to avoid host glibc coupling.
+make build-linux
+
+# Run from source
+go run ./cmd/binlog-server
+BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+
+# Prepare a local set of release assets
+make release-assets VERSION=v0.4.1
+```
 
 ## Development Validation
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -58,52 +58,55 @@ Binlog Server 是一个面向 MySQL binlog 备份与拉流场景的服务：负�
 
 ## 安装 / 下载
 
-- 对于带 tag 的公开版本，优先从 GitHub Releases 下载与你平台匹配的压缩包：
-  - `binlog-server_<version>_darwin_amd64.tar.gz`
-  - `binlog-server_<version>_darwin_arm64.tar.gz`
-  - `binlog-server_<version>_linux_amd64.tar.gz`
-  - `binlog-server_<version>_linux_arm64.tar.gz`
-- 同一页会提供 `checksums.txt`，下载后先校验再解压。
-- `/ui/` 所需前端静态资源已经内嵌在二进制里，不需要额外下载前端包。
+带 tag 的公开版本，从 [GitHub Releases](https://github.com/Fanduzi/BinlogServer/releases) 下载对应平台压缩包：
 
-源码构建作为 fallback：
+- `binlog-server_<version>_darwin_amd64.tar.gz`
+- `binlog-server_<version>_darwin_arm64.tar.gz`
+- `binlog-server_<version>_linux_amd64.tar.gz`
+- `binlog-server_<version>_linux_arm64.tar.gz`
 
-```bash
-make build
+真实资产名是 `binlog-server_<ver>_<os>_<arch>.tar.gz`（例如 `binlog-server_0.4.1_linux_amd64.tar.gz`）。同一页提供 `checksums.txt`，先校验再解压。压缩包里有一层版本子目录：
 
-# Linux 部署二进制请保持 CGO 关闭，避免绑定构建机 glibc 版本。
-make build-linux
+```text
+binlog-server_0.4.1_linux_amd64/
+  binlog-server
+  README.md
+  README_ZH.md
+  CHANGELOG.md
+  LICENSE
 ```
 
-如果你要在本地准备一组 release 产物：
-
-```bash
-make release-assets VERSION=v0.4.1
-```
+`/ui/` 所需前端静态资源已经内嵌在二进制里，不需要额外下载前端包。
 
 ## Quick Start
 
-这部分只保留“第一次跑起来”所需的最短路径。
+这是给 release 操作员的最短路径，不需要安装 Go。
 
 ### 前置条件
 
-- Go `1.26.1+`
-- 一个可访问的 MySQL 实例，并且已经开启 binlog
-- 如需跑 E2E：Docker 可用
+- GitHub Releases 上对应平台的 tarball
+- 一台已开启 `log_bin` 的 MySQL 或 MariaDB
 
-### 1. 启动服务
-
-```bash
-go run ./cmd/binlog-server
-```
-
-默认监听地址是 `:8080`。
-
-如果你想显式指定监听地址：
+### 1. 下载、校验、解压、运行
 
 ```bash
-BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+VER=0.4.1
+OS=linux          # linux | darwin
+ARCH=amd64        # amd64 | arm64
+
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt"
+sha256sum -c checksums.txt --ignore-missing
+
+tar -xzf "binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+cd "binlog-server_${VER}_${OS}_${ARCH}"
+
+export BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:8080
+export BINLOG_SERVER_DATA_DIR=./data
+./binlog-server
 ```
+
+未设置 `BINLOG_SERVER_LISTEN_ADDR` 时，默认监听 `:8080`。
 
 ### 2. 验证 `/healthz`
 
@@ -189,6 +192,7 @@ curl -fsS http://127.0.0.1:8080/api/tasks
 
 - Auth：默认关闭，生产环境至少应保护 `/api/*` 与 `/metrics`
 - Meta DB：如果配置了 `meta_dsn`，必须先执行 migration，服务不会自动建表或自动升级 schema
+- 未配置 `meta_dsn` 的 standalone：任务元数据、checkpoint、文件记录只在内存。进程 `kill -9` / 重启后控制面清空。已经写到 `{data_dir}/{task_id}/` 的 binlog 会变成孤儿文件。需要重启可恢复、以及运行中 `GET /checkpoint` / `GET /files` 时，请配置 `meta_dsn`。`storage.dir` 会被忽略，真实路径固定为 `{data_dir}/{task_id}/`。
 - Upload：S3-compatible upload 是可选能力，但一旦启用，必填项必须完整
 - Tracing：默认关闭，启用前先确认 exporter 配置和采样策略
 
@@ -297,6 +301,26 @@ BinlogServer 以控制面为核心组织服务，HTTP/API 处理、任务编排�
 | 复制执行链路 | [internal/replication/README.md](internal/replication/README.md) |
 | Upload 模块 | [internal/upload/README.md](internal/upload/README.md) |
 | E2E 测试套件 | [scripts/e2e/README.md](scripts/e2e/README.md) |
+
+## 开发
+
+改代码时用源码构建，不要把它当成 release 安装路径。
+
+前置：Go `1.26.1+`。E2E 才需要 Docker。
+
+```bash
+make build
+
+# Linux 部署二进制请保持 CGO 关闭，避免绑定构建机 glibc 版本。
+make build-linux
+
+# 从源码运行
+go run ./cmd/binlog-server
+BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
+
+# 本地准备一组 release 产物
+make release-assets VERSION=v0.4.1
+```
 
 ## 开发验证入口
 

--- a/cmd/binlog-server/cmd/README.md
+++ b/cmd/binlog-server/cmd/README.md
@@ -6,7 +6,7 @@ binlog-server CLI 子命令定义目录。
 
 | File | Responsibility |
 |------|---------------|
-| root.go | Cobra root command，负责参数绑定、根命令参数校验与应用启动调用 |
+| root.go | Cobra root command，负责参数绑定、根命令参数校验与应用启动调用；bind 失败不刷 Usage |
 | version.go | `version` 子命令、`--version` 输出与 ASCII banner 版本信息渲染 |
 | root_test.go | CLI 回归测试，覆盖 `version`、`--version` 与位置参数校验 |
 

--- a/cmd/binlog-server/cmd/root.go
+++ b/cmd/binlog-server/cmd/root.go
@@ -1,6 +1,6 @@
 // Package cmd provides module-level functionality for cmd.
 // input: config loader, signal context, logging setup, app runtime dependencies
-// output: root cobra command that starts binlog-server in configured mode
+// output: root cobra command that starts binlog-server without dumping Usage on bind errors
 // pos: CLI orchestration entry between process bootstrap and app lifecycle
 // note: if this file changes, update this header and module README.md.
 package cmd
@@ -20,9 +20,11 @@ func NewRootCommand() *cobra.Command {
 	var versionOnly bool
 
 	root := &cobra.Command{
-		Use:   "binlog-server",
-		Short: "Centralized MySQL binlog backup service",
-		Args:  cobra.NoArgs,
+		Use:           "binlog-server",
+		Short:         "Centralized MySQL binlog backup service",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if versionOnly {
 				_, err := fmt.Fprintln(cmd.OutOrStdout(), effectiveVersionInfo().Version)

--- a/cmd/binlog-server/cmd/root_test.go
+++ b/cmd/binlog-server/cmd/root_test.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -138,5 +139,27 @@ func TestRootCommandWithoutArgsStillStartsApp(t *testing.T) {
 	}
 	if startCalls != 1 {
 		t.Fatalf("expected app startup to run once, got %d calls", startCalls)
+	}
+}
+
+func TestRootCommandRunErrorOmitsUsage(t *testing.T) {
+	restoreRun := setTestRunRootApp(func(string, string) error {
+		return errors.New("listen tcp :8080: bind: address already in use")
+	})
+	defer restoreRun()
+
+	cmd := NewRootCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected bind error")
+	}
+	output := stdout.String()
+	if strings.Contains(output, "Usage:") {
+		t.Fatalf("expected no cobra Usage dump, got %q", output)
 	}
 }

--- a/docs/guide/admin/configuration.md
+++ b/docs/guide/admin/configuration.md
@@ -131,7 +131,7 @@ log:
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `meta_dsn` | string | - | MySQL 连接字符串（cluster 模式必需） |
+| `meta_dsn` | string | - | MySQL 连接字符串。cluster 模式必需。standalone 为空时控制面只在内存，进程退出后任务元数据丢失；binlog 文件仍落在 `data_dir`。 |
 
 **DSN 格式：**
 

--- a/docs/guide/admin/deployment.md
+++ b/docs/guide/admin/deployment.md
@@ -48,14 +48,21 @@ FLUSH PRIVILEGES;
 ### 2.1 下载或编译
 
 ```bash
-# 从源码编译
-git clone https://github.com/your-org/binlog-server.git
-cd binlog-server
-make build-linux
-cp bin/binlog-server-linux-amd64 ./binlog-server
+# 推荐：下载 GitHub Release tarball（不需要 Go）
+VER=0.4.1
+OS=linux          # linux | darwin
+ARCH=amd64        # amd64 | arm64
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt"
+sha256sum -c checksums.txt --ignore-missing
+tar -xzf "binlog-server_${VER}_${OS}_${ARCH}.tar.gz"
+cd "binlog-server_${VER}_${OS}_${ARCH}"
 
-# 或下载预编译版本
-# wget https://github.com/your-org/binlog-server/releases/download/v0.4.1/binlog-server-linux-amd64
+# 或从源码编译（开发机）
+# git clone https://github.com/Fanduzi/BinlogServer.git
+# cd BinlogServer
+# make build-linux
+# cp bin/binlog-server ./binlog-server
 ```
 
 说明：Linux 部署二进制必须保持 `CGO_ENABLED=0`，避免 Ubuntu 等较新发行版构建出的产物绑定更高版本的 `glibc`；当前仓库的 `make build-linux` 和 release 流程默认按兼容 `glibc 2.17` 的方向构建。
@@ -69,6 +76,9 @@ cp bin/binlog-server-linux-amd64 ./binlog-server
 listen_addr: ":8080"
 data_dir: "./data"
 mode: "standalone"
+
+# 未配置 meta_dsn 时，任务/checkpoint/files 只在内存，进程退出后控制面丢失。
+# 需要重启可恢复时请配置 meta_dsn 并先跑 migration。
 
 # 日志配置
 log:

--- a/docs/guide/reference/api.md
+++ b/docs/guide/reference/api.md
@@ -108,7 +108,7 @@ curl -X POST http://localhost:8080/api/tasks \
     },
     "start": {
       "mode": "GTID",
-      "gtid": "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100"
+      "gtid_set": "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100"
     }
   }'
 ```
@@ -126,8 +126,10 @@ curl -X POST http://localhost:8080/api/tasks \
 | start.mode | string | 是 | LATEST / FILE_POS / GTID |
 | start.file | string | 条件 | 文件名（FILE_POS 模式必填） |
 | start.pos | int | 条件 | 位置（FILE_POS 模式必填） |
-| start.gtid | string | 条件 | GTID（GTID 模式必填） |
+| start.gtid_set | string | 条件 | GTID 集合（GTID 模式必填）。也接受别名 `gtid`。 |
 | storage.retention_days | int | 否 | 保留天数（默认 7，范围 1-3650） |
+
+校验失败返回 HTTP 400 JSON `{"error","code"}`，**不会落库**。`source.host/port/user/password` 必填；`FILE_POS` 必须带 file/pos；`GTID` 必须带 `gtid_set`（或别名 `gtid`）。不要假设 400 之后任务不存在——实现上 400 就是没写入。
 
 **响应示例：**
 
@@ -254,7 +256,7 @@ curl http://localhost:8080/api/tasks/{task_id}/checkpoint
   "task_id": "task-xxx",
   "file": "mysql-bin.000010",
   "pos": 12345,
-  "gtid": "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-100",
+  "gtid_set": "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-100",
   "updated_at": "2024-01-01T10:05:00Z"
 }
 ```

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -520,7 +520,7 @@
 for real operations</h1>
       <p class="hero-sub animate-fade-up" style="animation-delay:0.2s;" data-i18n="heroSub">BinlogServer centralizes MySQL binlog backup behind one service. Run local-first durable capture, inspect state through API and embedded UI, scale into cluster roles, export metrics, and archive sealed files with optional S3-compatible upload.</p>
       <div class="hero-actions animate-fade-up" style="animation-delay:0.28s;">
-        <a href="../guide/admin/deployment.md" class="btn-primary" data-i18n="heroPrimary">Open Deployment Guide</a>
+        <a href="#deployment" class="btn-primary" data-i18n="heroPrimary">Open Deployment Guide</a>
         <a href="#features" class="btn-secondary" data-i18n="heroSecondary">Learn More</a>
       </div>
       <div class="hero-code animate-fade-up" style="animation-delay:0.36s;">
@@ -536,6 +536,25 @@ Signals        Checkpoint / Lag / Events / Workers / Metrics</code>
         <span class="tag tag-cluster">Cluster</span>
         <span class="tag tag-api">Prometheus</span>
         <span class="tag tag-go">Apache 2.0</span>
+      </div>
+    </div>
+  </section>
+
+  <section id="deployment" class="alt">
+    <div class="container">
+      <p class="section-label" data-i18n="deployLabel">Quick Start</p>
+      <h2 class="section-title" data-i18n="deployTitle">Download the release tarball,
+verify, extract, run</h2>
+      <p class="section-sub" data-i18n="deploySub">Operators do not need Go. Real assets are named <code>binlog-server_&lt;ver&gt;_&lt;os&gt;_&lt;arch&gt;.tar.gz</code> and extract into a versioned subdirectory. Full write-up: <a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/admin/deployment.md">docs/guide/admin/deployment.md</a>.</p>
+      <div class="hero-code">
+        <code data-i18n="deployCode">VER=0.4.1 OS=linux ARCH=amd64
+curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz
+curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt
+sha256sum -c checksums.txt --ignore-missing
+tar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz
+cd binlog-server_${VER}_${OS}_${ARCH}
+export BINLOG_SERVER_DATA_DIR=./data
+./binlog-server</code>
       </div>
     </div>
   </section>
@@ -814,8 +833,8 @@ better UI, better ops, better reliability</h2>
 and into a real product surface</h2>
       <p data-i18n="ctaSub">Review the deployment guide, inspect the release line, and evaluate BinlogServer as what it already is: a centralized MySQL binlog backup control plane.</p>
       <div class="hero-actions" style="margin-bottom:0;">
-        <a href="../guide/admin/deployment.md" class="btn-primary" data-i18n="ctaPrimary">Open Deployment Guide</a>
-        <a href="../../research_product_website_20260330.md" class="btn-secondary" data-i18n="ctaSecondary">Read Product Research</a>
+        <a href="#deployment" class="btn-primary" data-i18n="ctaPrimary">Open Deployment Guide</a>
+        <a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/README.md" class="btn-secondary" data-i18n="ctaSecondary">Read the Guide</a>
       </div>
     </div>
   </section>
@@ -837,9 +856,9 @@ and into a real product surface</h2>
         <div class="footer-col">
           <div class="footer-col-title" data-i18n="footerCol1">Start</div>
           <ul>
-            <li><a href="../guide/admin/deployment.md" data-i18n="footerLink1">Deployment Guide</a></li>
-            <li><a href="../../research_product_website_20260330.md" data-i18n="footerLink2">Product Research</a></li>
-            <li><a href="../../CHANGELOG.md" data-i18n="footerLink3">Changelog</a></li>
+            <li><a href="#deployment" data-i18n="footerLink1">Deployment Guide</a></li>
+            <li><a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/README.md" data-i18n="footerLink2">Operator Guide</a></li>
+            <li><a href="https://github.com/Fanduzi/BinlogServer/blob/main/CHANGELOG.md" data-i18n="footerLink3">Changelog</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -886,6 +905,10 @@ and into a real product surface</h2>
         navSurfaces: 'Surfaces',
         navChangelog: 'Changelog',
         navCta: 'Releases',
+        deployLabel: 'Quick Start',
+        deployTitle: 'Download the release tarball,\nverify, extract, run',
+        deploySub: 'Operators do not need Go. Real assets are named binlog-server_<ver>_<os>_<arch>.tar.gz and extract into a versioned subdirectory.',
+        deployCode: 'VER=0.4.1 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
         heroBadge: 'v0.4.1 — latest release',
         heroTitle: 'MySQL binlog backup control plane\nfor real operations',
         heroSub: 'BinlogServer centralizes MySQL binlog backup behind one service. Run local-first durable capture, inspect state through API and embedded UI, scale into cluster roles, export metrics, and archive sealed files with optional S3-compatible upload.',
@@ -1023,6 +1046,10 @@ and into a real product surface</h2>
         navSurfaces: '界面',
         navChangelog: '版本',
         navCta: '版本发布',
+        deployLabel: '快速开始',
+        deployTitle: '下载 release tarball，\n校验、解压、运行',
+        deploySub: '值班不需要安装 Go。真实资产名是 binlog-server_<ver>_<os>_<arch>.tar.gz，解压后在一层版本子目录里。',
+        deployCode: 'VER=0.4.1 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
         heroBadge: 'v0.4.1 — 最新发布',
         heroTitle: '面向真实运维的\nMySQL binlog 备份控制平面',
         heroSub: 'BinlogServer 把 MySQL binlog 备份集中到一个服务里：本地优先的可靠采集、通过 API 与内置 UI 可见的运行状态、可扩展到集群角色的执行模型、Prometheus 指标，以及可选的兼容 S3 的归档上传。',
@@ -1177,6 +1204,11 @@ and into a real product surface</h2>
 
       localStorage.setItem('binlogserver-lang', lang);
     };
+
+    const docPaths = new Set(['/docs', '/docs/', '/docs/deployment', '/docs/deployment/', '/deployment', '/deployment/', '/guide', '/guide/']);
+    if (docPaths.has(location.pathname) && location.hash !== '#deployment') {
+      location.hash = 'deployment';
+    }
 
     const switchLanguage = (lang) => {
       root.classList.add('switching');

--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -3,7 +3,7 @@
 ## Files
 | File | Responsibility |
 |------|---------------|
-| `server.go` | HTTP server/router 组装、路由注册 |
+| `server.go` | HTTP server/router 组装、路由注册（含 `/healthz` 与 `/api/health`） |
 | `auth.go` | 路由级鉴权配置与认证中间件、ServerOption 定义 |
 | `rate_limiter.go` | 基于 IP 的令牌桶限流器 |
 | `metrics_prometheus.go` | `/metrics` 采集与输出（基于 `prometheus/client_golang`） |
@@ -26,6 +26,8 @@
 
 ## Features
 - 认证：支持 Bearer Token 或 API Key；`/healthz` 默认匿名，`/metrics` 与 `/api/*` 可配置保护
+- 创建任务：`CreateTaskFromSpec` 整包校验通过后才落库；400 返回 JSON `{"error","code"}`
+- 健康检查：`GET /healthz` 文本 `ok`；`GET /api/health` JSON `{"status":"ok"}`
 - 限流：基于 IP 的令牌桶限流，默认 100 req/s，burst 200
 - Tracing：OTel HTTP span（可选）
 

--- a/internal/api/handlers_tasks.go
+++ b/internal/api/handlers_tasks.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces
-// output: REST API responses and status codes for task/cluster operations
+// output: REST API JSON responses including structured 400 bodies for create validation
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -329,7 +329,7 @@ type updateTaskRequest struct {
 // @Param body body createTaskRequest true "Task create payload (name:1-255, cluster_key:[a-zA-Z0-9._-], source/start/storage 按字段规则校验)"
 // @Success 200 {array} tasks.Task
 // @Success 201 {object} tasks.Task
-// @Failure 400 {string} string
+// @Failure 400 {object} apiErrorBody
 // @Failure 405 {string} string
 // @Router /api/tasks [get]
 // @Router /api/tasks [post]
@@ -338,36 +338,13 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		var req createTaskRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
+			writeAPIError(w, http.StatusBadRequest, tasks.CodeInvalidRequest, "invalid json")
 			return
 		}
 
-		task, err := s.tasks.CreateTask(req.Name, req.ClusterKey)
+		task, err := s.tasks.CreateTaskFromSpec(req.Name, req.ClusterKey, req.Source, req.Start, req.Storage)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if req.Source != nil {
-			if err := s.tasks.ConfigureSource(task.ID, *req.Source); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-		if req.Start != nil {
-			if err := s.tasks.ConfigureStart(task.ID, *req.Start); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-		if req.Storage != nil {
-			if err := s.tasks.ConfigureStorage(task.ID, *req.Storage); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-		task, err = s.tasks.GetTask(task.ID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeTaskError(w, err)
 			return
 		}
 		writeJSON(w, http.StatusCreated, sanitizeTask(task))
@@ -736,7 +713,7 @@ func (s *Server) handleTaskEntity(w http.ResponseWriter, r *http.Request, taskID
 	case http.MethodPut:
 		var req updateTaskRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
+			writeAPIError(w, http.StatusBadRequest, tasks.CodeInvalidRequest, "invalid json")
 			return
 		}
 		// PUT 走 Scheduler.UpdateTask 原子更新：
@@ -783,10 +760,33 @@ func isTaskUpdateBadRequest(err error) bool {
 		errors.Is(err, tasks.ErrClusterKeyExists) ||
 		errors.Is(err, tasks.ErrInvalidTaskName) ||
 		errors.Is(err, tasks.ErrInvalidSourceConfig) ||
+		errors.Is(err, tasks.ErrSourceRequired) ||
+		errors.Is(err, tasks.ErrSourcePasswordRequired) ||
 		errors.Is(err, tasks.ErrFilePosRequired) ||
 		errors.Is(err, tasks.ErrGTIDSetRequired) ||
 		errors.Is(err, tasks.ErrInvalidStartMode) ||
 		errors.Is(err, tasks.ErrInvalidRetentionDays)
+}
+
+type apiErrorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+func writeAPIError(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, apiErrorBody{Error: msg, Code: code})
+}
+
+func writeTaskError(w http.ResponseWriter, err error) {
+	if errors.Is(err, tasks.ErrTaskNotFound) {
+		writeAPIError(w, http.StatusNotFound, "TASK_NOT_FOUND", err.Error())
+		return
+	}
+	if isTaskUpdateBadRequest(err) {
+		writeAPIError(w, http.StatusBadRequest, tasks.CodeInvalidRequest, err.Error())
+		return
+	}
+	writeAPIError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error")
 }
 
 // writeJSON 统一输出 JSON 响应。

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces
-// output: REST API responses and status codes for task/cluster operations
+// output: REST API responses including /healthz and /api/health
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -22,6 +22,7 @@ import (
 type taskService interface {
 	// 任务 CRUD/控制。
 	CreateTask(name string, clusterKey string) (tasks.Task, error)
+	CreateTaskFromSpec(name string, clusterKey string, source *tasks.SourceConfig, start *tasks.StartConfig, storage *tasks.Storage) (tasks.Task, error)
 	UpdateTask(id string, patch tasks.TaskPatch) (tasks.Task, error)
 	ConfigureClusterKey(id string, clusterKey string) error
 	ConfigureName(id string, name string) error
@@ -105,6 +106,7 @@ func (s *Server) routes() {
 		apiHandlers = append(apiHandlers, s.authMiddleware())
 	}
 	apiGroup := s.gin.Group("/api", apiHandlers...)
+	apiGroup.GET("/health", gin.WrapF(s.handleAPIHealth))
 	apiGroup.GET("/summary", gin.WrapF(s.handleSummary))
 	apiGroup.GET("/dashboard", gin.WrapF(s.handleDashboard))
 	apiGroup.GET("/sources/lookup", gin.WrapF(s.handleSourceLookup))
@@ -135,6 +137,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
+}
+
+// handleAPIHealth godoc
+// @Summary Service health check (JSON)
+// @Tags System
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Router /api/health [get]
+func (s *Server) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // handleMetrics 返回 Prometheus 文本格式指标。

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -133,7 +133,7 @@ func TestTaskAPI_CreateListStartStop(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -251,7 +251,7 @@ func TestTaskAPI_CreateTaskRequiresClusterKey(t *testing.T) {
 	createResp := httptest.NewRecorder()
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -270,7 +270,7 @@ func TestTaskAPI_UpdateTaskRequiresClusterKey(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -296,7 +296,7 @@ func TestTaskAPI_ClusterKeyMustBeUnique(t *testing.T) {
 	firstReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"dup-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	firstReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(first, firstReq)
@@ -308,7 +308,7 @@ func TestTaskAPI_ClusterKeyMustBeUnique(t *testing.T) {
 	secondReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-b",
 		"cluster_key":"dup-key",
-		"source":{"host":"127.0.0.1","port":3307,"user":"repl","flavor":"mysql","server_id":200002}
+		"source":{"host":"127.0.0.1","port":3307,"user":"repl","password":"secret","flavor":"mysql","server_id":200002}
 	}`))
 	secondReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(second, secondReq)
@@ -325,7 +325,7 @@ func TestTaskAPI_CreateRejectsInvalidInput(t *testing.T) {
 	cases := []string{
 		`{"name":"` + strings.Repeat("a", 256) + `","cluster_key":"cluster-a-key"}`,
 		`{"name":"cluster-a","cluster_key":"../bad"}`,
-		`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"bad host","port":3306,"user":"repl","flavor":"mysql","server_id":200001}}`,
+		`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"bad host","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}}`,
 		`{"name":"cluster-a","cluster_key":"cluster-a-key","start":{"mode":"BAD_MODE"}}`,
 		`{"name":"cluster-a","cluster_key":"cluster-a-key","storage":{"retention_days":0}}`,
 	}
@@ -340,6 +340,84 @@ func TestTaskAPI_CreateRejectsInvalidInput(t *testing.T) {
 	}
 }
 
+// TestTaskAPI_CreateInvalidStartDoesNotPersist 验证 400 不得留下默认 LATEST 任务。
+func TestTaskAPI_CreateInvalidStartDoesNotPersist(t *testing.T) {
+	scheduler := tasks.NewScheduler()
+	handler := NewServer(scheduler)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"missing gtid_set", `{"name":"repro-400-create","cluster_key":"repro-400-create","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"replpass"},"start":{"mode":"GTID"}}`},
+		{"missing file/pos", `{"name":"repro-file","cluster_key":"repro-file","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"replpass"},"start":{"mode":"FILE_POS"}}`},
+		{"missing source", `{"name":"repro-nosource","cluster_key":"repro-nosource"}`},
+		{"missing password", `{"name":"repro-nopass","cluster_key":"repro-nopass","source":{"host":"127.0.0.1","port":3306,"user":"repl"}}`},
+	}
+	for _, tc := range cases {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(tc.body))
+		req.Header.Set("Content-Type", "application/json")
+		handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("%s: expected 400, got %d body=%s", tc.name, resp.Code, resp.Body.String())
+		}
+		var body apiErrorBody
+		if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+			t.Fatalf("%s: expected JSON error body, got %s", tc.name, resp.Body.String())
+		}
+		if body.Code != tasks.CodeInvalidRequest || body.Error == "" {
+			t.Fatalf("%s: unexpected error body %+v", tc.name, body)
+		}
+	}
+	if got := len(scheduler.ListTasks()); got != 0 {
+		t.Fatalf("expected no persisted tasks after 400 creates, got %d", got)
+	}
+}
+
+// TestTaskAPI_CreateAcceptsGTIDAlias 验证 api.md 的 start.gtid 别名写入 gtid_set。
+func TestTaskAPI_CreateAcceptsGTIDAlias(t *testing.T) {
+	scheduler := tasks.NewScheduler()
+	handler := NewServer(scheduler)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
+		"name":"gtid-alias","cluster_key":"gtid-alias",
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"},
+		"start":{"mode":"GTID","gtid":"3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100"}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var created tasks.Task
+	if err := json.Unmarshal(resp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.Start.Mode != tasks.StartModeGTID || created.Start.GTIDSet != "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-100" {
+		t.Fatalf("expected gtid alias mapped to gtid_set, got %+v", created.Start)
+	}
+}
+
+// TestTaskAPI_HealthJSON 验证文档中的 /api/health。
+func TestTaskAPI_HealthJSON(t *testing.T) {
+	handler := NewServer(tasks.NewScheduler())
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("unexpected health body %+v", body)
+	}
+}
+
 // TestTaskAPI_UpdateRejectsInvalidInput 验证相关行为。
 func TestTaskAPI_UpdateRejectsInvalidInput(t *testing.T) {
 	scheduler := tasks.NewScheduler()
@@ -349,7 +427,7 @@ func TestTaskAPI_UpdateRejectsInvalidInput(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -360,7 +438,7 @@ func TestTaskAPI_UpdateRejectsInvalidInput(t *testing.T) {
 	cases := []string{
 		`{"name":"` + strings.Repeat("b", 256) + `","cluster_key":"cluster-a-key"}`,
 		`{"name":"cluster-b","cluster_key":"../bad"}`,
-		`{"name":"cluster-b","cluster_key":"cluster-a-key","source":{"host":"bad host","port":3306,"user":"repl","flavor":"mysql"}}`,
+		`{"name":"cluster-b","cluster_key":"cluster-a-key","source":{"host":"bad host","port":3306,"user":"repl","password":"secret","flavor":"mysql"}}`,
 		`{"name":"cluster-b","cluster_key":"cluster-a-key","start":{"mode":"BAD_MODE"}}`,
 		`{"name":"cluster-b","cluster_key":"cluster-a-key","storage":{"retention_days":3651}}`,
 	}
@@ -384,7 +462,7 @@ func TestTaskAPI_UpdateInvalidStartHasNoSideEffects(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -447,7 +525,7 @@ func TestTaskAPI_UpdateTaskStoreFailureReturnsInternalServerError(t *testing.T) 
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
@@ -580,7 +658,7 @@ func TestTaskAPI_GetCheckpoint(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -620,7 +698,7 @@ func TestTaskAPI_UpdateAndDeleteTask(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -661,7 +739,7 @@ func TestTaskAPI_UpdateAndDeleteTask(t *testing.T) {
 
 	updateNoPassword := `{
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"10.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":300001}
+		"source":{"host":"10.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":300001}
 	}`
 	updateNoPwdResp := httptest.NewRecorder()
 	updateNoPwdReq := httptest.NewRequest(http.MethodPut, "/api/tasks/1", bytes.NewBufferString(updateNoPassword))
@@ -1158,7 +1236,7 @@ func TestTaskAPI_MetricsIncludeRetryUploadCounters(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1313,7 +1391,7 @@ func TestTaskAPI_ListUploadFailureReasons(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1345,7 +1423,7 @@ func TestTaskAPI_ListEvents(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1382,7 +1460,7 @@ func TestTaskAPI_ListFiles(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1413,7 +1491,7 @@ func TestTaskAPI_RetryUploadLimitValidation(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1444,7 +1522,7 @@ func TestTaskAPI_UploadFailureReasonsLimitValidation(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1522,7 +1600,7 @@ func TestTaskAPI_RetryUploadReturnsStats(t *testing.T) {
 	handler := NewServer(scheduler)
 
 	createResp := httptest.NewRecorder()
-	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)
 	if createResp.Code != http.StatusCreated {
@@ -1554,7 +1632,7 @@ func TestTaskAPI_ListEventsWithLimit(t *testing.T) {
 	createReq := httptest.NewRequest(http.MethodPost, "/api/tasks", bytes.NewBufferString(`{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret","flavor":"mysql","server_id":200001}
 	}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(createResp, createReq)

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -3,7 +3,7 @@
 ## Files
 - `app.go`: 应用主流程与运行时装配。
 - `tracing.go`: tracing provider 初始化与生命周期管理。
-- `smoke_test.go`: 应用层烟测。
+- `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`）。
 
 ## Exports
 - `New(cfg)` / `Run(ctx)`: 应用生命周期入口。

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -224,7 +224,7 @@ func TestApp_ClusterControlPlaneRole(t *testing.T) {
 	createBody := `{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl"}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}
 	}`
 	createResp := postJSON(t, "http://"+a.Addr()+"/api/tasks", createBody)
 	if createResp.StatusCode != http.StatusCreated {
@@ -341,7 +341,7 @@ func TestApp_ClusterAllInOneRole(t *testing.T) {
 	createBody := `{
 		"name":"cluster-a",
 		"cluster_key":"cluster-a-key",
-		"source":{"host":"127.0.0.1","port":3306,"user":"repl"}
+		"source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}
 	}`
 	createResp := postJSON(t, "http://"+a.Addr()+"/api/tasks", createBody)
 	if createResp.StatusCode != http.StatusCreated {
@@ -927,7 +927,7 @@ func TestApp_RunWorkerIdentityStaysCoherentForActiveSession(t *testing.T) {
 	go func() { errCh <- a.Run(ctx) }()
 	waitReady(t, a)
 
-	taskBody := `{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl"}}`
+	taskBody := `{"name":"cluster-a","cluster_key":"cluster-a-key","source":{"host":"127.0.0.1","port":3306,"user":"repl","password":"secret"}}`
 	createResp := postJSON(t, "http://"+a.Addr()+"/api/tasks", taskBody)
 	if createResp.StatusCode != http.StatusCreated {
 		t.Fatalf("expected create status 201, got %d body=%s", createResp.StatusCode, string(createResp.Body))

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -3,7 +3,7 @@
 ## Files
 | File | Responsibility |
 |------|---------------|
-| `config.go` | 配置模型、加载与默认值、校验 |
+| `config.go` | 配置模型、加载与默认值、校验（`meta_dsn` 为空时 standalone 控制面仅内存） |
 | `config_test.go` | 配置加载与覆盖规则测试 |
 | `encryption.go` | AES-256-GCM 配置值解密工具 |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	ListenAddr string
 	// DataDir 是本地 binlog 文件落盘目录。
 	DataDir string
-	// MetaDSN 是元数据 MySQL 连接串；为空则走内存模式。
+	// MetaDSN 是元数据 MySQL 连接串；为空则控制面只在内存，进程退出后任务元数据丢失。
 	MetaDSN string
 	// Mode 支持 standalone/cluster。
 	Mode string

--- a/internal/replication/README.md
+++ b/internal/replication/README.md
@@ -1,13 +1,15 @@
 # internal/replication Module
 
 ## Files
-- `mysql_runner.go`: 复制主执行流程。
+- `mysql_runner.go`: 复制主执行流程（含 idle lag 上报、heartbeat 跳过落盘）。
+- `source_identity.go`: MySQL/MariaDB 源库身份与永久错误分类。
 - `resolver.go`: 起点解析。
 - 其余 `*_test.go`: 复制、恢复、上传等行为测试。
   其中 `mysql_runner_run_test.go` 重点覆盖 runner 级起点选择、checkpoint 推进/失败、错误传播与停止清理语义。
 
 ## Exports
 - Runner 启停与进度上报。
+- MariaDB 身份：`mariadb:<server_id>:<gtid_domain_id>`；MySQL 仍用 `server_uuid`。
 - 文件落盘、checkpoint 对接、上传触发。
 
 ## Dependencies

--- a/internal/replication/mysql_runner.go
+++ b/internal/replication/mysql_runner.go
@@ -1,7 +1,7 @@
 // Package replication provides module-level functionality for replication.
-// input: source replication config, task state, checkpoint/file store dependencies
-// output: replication run control, local binlog artifacts, and upload/recovery signals
-// pos: data-plane runtime that consumes MySQL binlog stream and emits durable outputs
+// input: source replication config, flavor-aware identity, checkpoint/file store dependencies
+// output: replication run control, durable local artifacts, idle lag progress, and permanent source errors
+// pos: data-plane runtime that consumes MySQL/MariaDB binlog stream and emits durable outputs
 // note: if this file changes, update this header and module README.md.
 package replication
 
@@ -200,17 +200,17 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 	// source_server_uuid 作为 object key 的稳定维度，避免 cluster_key 相同但源实例切换时冲突。
 	sourceServerUUID, err := r.fetcher.FetchServerUUID(ctx, task.Source)
 	if err != nil {
-		return err
+		return classifySourceError(err)
 	}
 	sourceServerUUID = strings.TrimSpace(sourceServerUUID)
 	if sourceServerUUID == "" {
-		return errors.New("empty source server_uuid")
+		return tasks.NewPermanentError(tasks.CodeSourceIdentityUnavailable, "empty source server_uuid")
 	}
 
 	// 先解析请求的 start strategy（LATEST/FILE_POS/GTID）。
 	start, err := ResolveStart(ctx, task, r.fetcher)
 	if err != nil {
-		return err
+		return classifySourceError(err)
 	}
 	if r.checkpointStore != nil {
 		// 持久化 checkpoint 优先级更高，保证重启后的 resumability。
@@ -277,6 +277,13 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 			return nil
 		}
 		sourceEventAt := sourceEventTime(event)
+
+		if event.Header.EventType == replication.HEARTBEAT_EVENT || event.Header.EventType == replication.HEARTBEAT_LOG_EVENT_V2 {
+			if r.progressReporter != nil {
+				r.progressReporter.ReportReplicationProgress(task.ID, sourceEventAt, currentFile, currentPos)
+			}
+			return nil
+		}
 
 		if event.Header.EventType == replication.ROTATE_EVENT {
 			rotate, ok := event.Event.(*replication.RotateEvent)
@@ -393,7 +400,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 		return fmt.Errorf("unsupported resolved start mode: %s", start.Mode)
 	}
 	if err != nil {
-		return err
+		return classifySourceError(err)
 	}
 
 	if onReady != nil {
@@ -405,29 +412,61 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 		// SynchronousEventHandler 模式下，事件由 syncer 内部 goroutine 推送到 handler。
 		// 这里阻塞等待错误或取消，保持任务生命周期。
 		for {
-			_, err := streamer.GetEvent(ctx)
+			event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos)
 			if err != nil {
 				if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 					return nil
 				}
 				return err
 			}
+			if event == nil {
+				continue
+			}
 		}
 	}
 
 	// Step 5: 异步模式主循环（逐条拉取并处理事件）。
 	for {
-		event, err := streamer.GetEvent(ctx)
+		event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos)
 		if err != nil {
 			if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 				return nil
 			}
 			return err
 		}
+		if event == nil {
+			continue
+		}
 		if err := handleEvent(event); err != nil {
 			return err
 		}
 	}
+}
+
+const idlePollInterval = 2 * time.Second
+
+func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, taskID, file string, pos uint32) (*replication.BinlogEvent, error) {
+	eventCtx, cancel := context.WithTimeout(ctx, idlePollInterval)
+	event, err := streamer.GetEvent(eventCtx)
+	cancel()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			// No event for idlePollInterval means the dump is at tip.
+			// Use wall clock so last-event age on a silent master is not reported as lag.
+			if r.progressReporter != nil {
+				r.progressReporter.ReportReplicationProgress(taskID, time.Now().UTC(), file, pos)
+			}
+			return nil, nil
+		}
+		return nil, classifySourceError(err)
+	}
+	return event, nil
 }
 
 // finalizeSealedFile 负责 open 文件 seal、元数据落库以及 best-effort 上传。
@@ -631,13 +670,16 @@ func (f *mysqlStatusFetcher) FetchMasterStatus(_ context.Context, source tasks.S
 	addr := fmt.Sprintf("%s:%d", source.Host, source.Port)
 	conn, err := sqlclient.Connect(addr, source.User, source.Password, "")
 	if err != nil {
-		return MasterStatus{}, err
+		return MasterStatus{}, classifySourceError(err)
 	}
 	defer conn.Close()
 
 	result, err := conn.Execute("SHOW MASTER STATUS")
-	if err != nil {
-		return MasterStatus{}, err
+	if err != nil || result == nil || result.Resultset == nil || result.Resultset.RowNumber() == 0 {
+		result, err = conn.Execute("SHOW BINLOG STATUS")
+		if err != nil {
+			return MasterStatus{}, classifySourceError(err)
+		}
 	}
 	if result == nil || result.Resultset == nil || result.Resultset.RowNumber() == 0 {
 		return MasterStatus{}, errors.New("empty master status")
@@ -658,32 +700,43 @@ func (f *mysqlStatusFetcher) FetchMasterStatus(_ context.Context, source tasks.S
 	}, nil
 }
 
-// FetchServerUUID 读取源库 server_uuid（用于 object key 维度）。
+// FetchServerUUID 读取源库身份（MySQL server_uuid；MariaDB 使用 server_id+gtid_domain_id）。
 func (f *mysqlStatusFetcher) FetchServerUUID(_ context.Context, source tasks.SourceConfig) (string, error) {
 	addr := fmt.Sprintf("%s:%d", source.Host, source.Port)
 	conn, err := sqlclient.Connect(addr, source.User, source.Password, "")
 	if err != nil {
-		return "", err
+		return "", classifySourceError(err)
 	}
 	defer conn.Close()
 
-	result, err := conn.Execute("SHOW VARIABLES LIKE 'server_uuid'")
+	logBin, err := queryVariable(conn, "log_bin")
+	if err != nil {
+		return "", classifySourceError(err)
+	}
+	serverUUID, _ := queryVariable(conn, "server_uuid")
+	serverID, _ := queryVariable(conn, "server_id")
+	domainID, _ := queryVariable(conn, "gtid_domain_id")
+	return resolveSourceIdentity(source.Flavor, logBin, serverUUID, serverID, domainID)
+}
+
+func queryVariable(conn *sqlclient.Conn, name string) (string, error) {
+	switch name {
+	case "log_bin", "server_uuid", "server_id", "gtid_domain_id":
+	default:
+		return "", fmt.Errorf("unsupported variable %q", name)
+	}
+	result, err := conn.Execute("SHOW VARIABLES LIKE '" + name + "'")
 	if err != nil {
 		return "", err
 	}
 	if result == nil || result.Resultset == nil || result.Resultset.RowNumber() == 0 {
-		return "", errors.New("empty server_uuid")
+		return "", nil
 	}
-
 	value, err := result.GetString(0, 1)
 	if err != nil {
 		return "", err
 	}
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", errors.New("empty server_uuid")
-	}
-	return value, nil
+	return strings.TrimSpace(value), nil
 }
 
 // effectiveStartFromCheckpoint 在 checkpoint 可用时覆盖请求起点。

--- a/internal/replication/source_identity.go
+++ b/internal/replication/source_identity.go
@@ -1,0 +1,70 @@
+// Package replication provides module-level functionality for replication.
+// input: source connection results, flavor, log_bin and identity variables
+// output: stable source identity strings and permanent source configuration errors
+// pos: flavor-aware source probe used before binlog dump starts
+// note: if this file changes, update this header and module README.md.
+package replication
+
+import (
+	"fmt"
+	"strings"
+
+	"binlog_server/internal/tasks"
+)
+
+func isAccessDeniedMessage(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(msg, "ERROR 1045") ||
+		strings.Contains(msg, "Error 1045") ||
+		strings.Contains(lower, "access denied")
+}
+
+func classifySourceError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if tasks.IsPermanent(err) {
+		return err
+	}
+	if isAccessDeniedMessage(err.Error()) {
+		return tasks.NewPermanentError(tasks.CodeSourceAccessDenied, err.Error())
+	}
+	return err
+}
+
+func isLogBinEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "on", "1", "true":
+		return true
+	default:
+		return false
+	}
+}
+
+func isMariaDBFlavor(flavor string) bool {
+	return strings.EqualFold(strings.TrimSpace(flavor), "mariadb")
+}
+
+// resolveSourceIdentity maps probed variables to a stable identity.
+// MariaDB 11 has no @@server_uuid; identity is mariadb:<server_id>:<gtid_domain_id>.
+func resolveSourceIdentity(flavor, logBin, serverUUID, serverID, domainID string) (string, error) {
+	if !isLogBinEnabled(logBin) {
+		return "", tasks.NewPermanentError(tasks.CodeSourceLogBinOff, "log_bin is off")
+	}
+	if isMariaDBFlavor(flavor) {
+		serverID = strings.TrimSpace(serverID)
+		if serverID == "" {
+			return "", tasks.NewPermanentError(tasks.CodeSourceIdentityUnavailable, "empty mariadb server_id")
+		}
+		domainID = strings.TrimSpace(domainID)
+		if domainID == "" {
+			domainID = "0"
+		}
+		return fmt.Sprintf("mariadb:%s:%s", serverID, domainID), nil
+	}
+	serverUUID = strings.TrimSpace(serverUUID)
+	if serverUUID == "" {
+		return "", tasks.NewPermanentError(tasks.CodeSourceIdentityUnavailable, "empty server_uuid")
+	}
+	return serverUUID, nil
+}

--- a/internal/replication/source_identity_test.go
+++ b/internal/replication/source_identity_test.go
@@ -1,0 +1,63 @@
+// Package replication provides module-level functionality for replication.
+// input: flavor/log_bin/identity fixtures and go-mysql style error strings
+// output: source identity resolution and permanent-error classification assertions
+// pos: unit tests for MariaDB/MySQL source probe semantics
+// note: if this file changes, update this header and module README.md.
+package replication
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"binlog_server/internal/tasks"
+)
+
+func TestResolveSourceIdentity_MariaDBUsesServerID(t *testing.T) {
+	id, err := resolveSourceIdentity("mariadb", "ON", "", "1", "0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "mariadb:1:0" {
+		t.Fatalf("unexpected identity %q", id)
+	}
+}
+
+func TestResolveSourceIdentity_LogBinOffIsPermanent(t *testing.T) {
+	_, err := resolveSourceIdentity("mariadb", "OFF", "", "1", "0")
+	if !tasks.IsPermanent(err) {
+		t.Fatalf("expected permanent error, got %v", err)
+	}
+	var pe *tasks.PermanentError
+	if !errors.As(err, &pe) || pe.Code != tasks.CodeSourceLogBinOff {
+		t.Fatalf("expected SOURCE_LOG_BIN_OFF, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "log_bin is off") {
+		t.Fatalf("expected log_bin off message, got %v", err)
+	}
+}
+
+func TestResolveSourceIdentity_MySQLRequiresServerUUID(t *testing.T) {
+	_, err := resolveSourceIdentity("mysql", "ON", "", "1", "0")
+	if !tasks.IsPermanent(err) {
+		t.Fatalf("expected permanent empty server_uuid, got %v", err)
+	}
+	id, err := resolveSourceIdentity("mysql", "1", "abc-uuid", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "abc-uuid" {
+		t.Fatalf("unexpected identity %q", id)
+	}
+}
+
+func TestClassifySourceError_AccessDenied(t *testing.T) {
+	err := classifySourceError(errors.New("handleAuthResult: ERROR 1045 (28000): Access denied for user 'repl'@'127.0.0.1'"))
+	if !tasks.IsPermanent(err) {
+		t.Fatalf("expected permanent error, got %v", err)
+	}
+	var pe *tasks.PermanentError
+	if !errors.As(err, &pe) || pe.Code != tasks.CodeSourceAccessDenied {
+		t.Fatalf("expected SOURCE_ACCESS_DENIED, got %v", err)
+	}
+}

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -2,8 +2,9 @@
 
 ## Files
 - `scheduler.go`: 调度器核心类型、选项注入与通用辅助函数。
-- `scheduler_task_ops.go`: 任务 CRUD 与配置更新（非运行时生命周期）。
-- `scheduler_lifecycle.go`: 启停、运行协程与重试退避生命周期流程。
+- `scheduler_task_ops.go`: 任务 CRUD 与配置更新（含整包 CreateTaskFromSpec）。
+- `scheduler_lifecycle.go`: 启停、运行协程、重试退避与不可恢复 FAILED。
+- `errors.go`: 永久错误类型（1045 / log_bin off / 身份不可用）。
 - `scheduler_cluster_lease.go`: cluster lease 续租与降级/失租处理。
 - `scheduler_observability.go`: 复制进度、checkpoint、事件/文件/运行历史查询。
 - `scheduler_retry_upload.go`: 上传失败补偿重试与失败原因聚合。
@@ -13,6 +14,8 @@
 
 ## Exports
 - 任务 CRUD、启动停止、状态推进。
+- `CreateTaskFromSpec`：整包校验后才 persist。
+- `FAILED` 可再次 `StartTask`（改完源库配置后）。
 - 事件记录、文件元信息、上传补偿。
 - `WithInternalCallTimeouts`：注入内部调用超时（read/write/lease/upload），用于 store/lease/uploader 依赖边界治理。
 - Stop 路径 lease release 使用独立超时上下文（不复用已取消 runner ctx）。

--- a/internal/tasks/errors.go
+++ b/internal/tasks/errors.go
@@ -1,0 +1,49 @@
+// Package tasks provides module-level functionality for tasks.
+// input: runner/source failure strings and typed operator error codes
+// output: permanent (non-retryable) errors that stop the task state machine
+// pos: shared error types used by scheduler retry policy and source probing
+// note: if this file changes, update this header and module README.md.
+package tasks
+
+import "errors"
+
+const (
+	// CodeSourceAccessDenied is MySQL/MariaDB ERROR 1045.
+	CodeSourceAccessDenied = "SOURCE_ACCESS_DENIED"
+	// CodeSourceLogBinOff is an unrecoverable source configuration error.
+	CodeSourceLogBinOff = "SOURCE_LOG_BIN_OFF"
+	// CodeSourceIdentityUnavailable is a missing source identity after probing.
+	CodeSourceIdentityUnavailable = "SOURCE_IDENTITY_UNAVAILABLE"
+	// CodeInvalidRequest is a create/update validation failure.
+	CodeInvalidRequest = "INVALID_REQUEST"
+)
+
+// PermanentError is an unrecoverable task error that must not enter RETRY_BACKOFF.
+type PermanentError struct {
+	Code    string
+	Message string
+}
+
+func (e *PermanentError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Code == "" {
+		return e.Message
+	}
+	if e.Message == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.Message
+}
+
+// NewPermanentError constructs an unrecoverable operator-facing error.
+func NewPermanentError(code, message string) error {
+	return &PermanentError{Code: code, Message: message}
+}
+
+// IsPermanent reports whether err (or any wrapped error) is unrecoverable.
+func IsPermanent(err error) bool {
+	var pe *PermanentError
+	return errors.As(err, &pe)
+}

--- a/internal/tasks/model.go
+++ b/internal/tasks/model.go
@@ -1,11 +1,14 @@
 // Package tasks provides module-level functionality for tasks.
-// input: task commands/events, runner callbacks, store/lease/uploader dependencies
-// output: task state transitions, scheduling decisions, and execution coordination
+// input: task JSON payloads, runner callbacks, store/lease/uploader dependencies
+// output: task/start/source models including gtid alias decoding
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // State 表示任务生命周期状态。
 type State string
@@ -104,11 +107,36 @@ type SourceConfig struct {
 }
 
 // StartConfig 描述复制起点策略。
+// Canonical GTID field is gtid_set; gtid is accepted as an input alias.
 type StartConfig struct {
 	Mode    StartMode `json:"mode"`
 	File    string    `json:"file,omitempty"`
 	Pos     uint32    `json:"pos,omitempty"`
 	GTIDSet string    `json:"gtid_set,omitempty"`
+}
+
+type startConfigJSON struct {
+	Mode    StartMode `json:"mode"`
+	File    string    `json:"file,omitempty"`
+	Pos     uint32    `json:"pos,omitempty"`
+	GTIDSet string    `json:"gtid_set,omitempty"`
+	GTID    string    `json:"gtid,omitempty"`
+}
+
+// UnmarshalJSON accepts both gtid_set and the api.md alias gtid.
+func (s *StartConfig) UnmarshalJSON(data []byte) error {
+	var raw startConfigJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	s.Mode = raw.Mode
+	s.File = raw.File
+	s.Pos = raw.Pos
+	s.GTIDSet = raw.GTIDSet
+	if s.GTIDSet == "" {
+		s.GTIDSet = raw.GTID
+	}
+	return nil
 }
 
 // Storage 描述本地存储策略。

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -34,6 +34,8 @@ var ErrFilePosRequired = errors.New("file/pos is required")
 var ErrGTIDSetRequired = errors.New("gtid_set is required")
 var ErrInvalidStartMode = errors.New("invalid start mode")
 var ErrInvalidRetentionDays = errors.New("invalid retention_days")
+var ErrSourcePasswordRequired = errors.New("source.password is required")
+var ErrSourceRequired = errors.New("source.host/port/user/password is required")
 
 var clusterKeyAllowedPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 

--- a/internal/tasks/scheduler_lifecycle.go
+++ b/internal/tasks/scheduler_lifecycle.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: start/stop commands, runner callbacks, and runtime cancellation signals
-// output: task state transitions across STARTING/RUNNING/RETRY/STOPPING lifecycle
+// input: start/stop commands, runner callbacks, permanent/retryable errors, cancellation signals
+// output: task state transitions across STARTING/RUNNING/RETRY/FAILED/STOPPING lifecycle
 // pos: scheduler execution lifecycle orchestration excluding lease-renew loop details
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"log"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 func (s *Scheduler) StartTask(id string) error {
@@ -29,7 +31,7 @@ func (s *Scheduler) StartTask(id string) error {
 		s.runner != nil &&
 		s.leaseManager != nil
 	// 仅允许 claim “干净的 dispatch STARTING 任务”，避免误接管非预期中间态。
-	if task.State != StateCreated && task.State != StateStopped && task.State != StateRetryBackoff && !canClaimDispatched {
+	if task.State != StateCreated && task.State != StateStopped && task.State != StateRetryBackoff && task.State != StateFailed && !canClaimDispatched {
 		s.mu.Unlock()
 		return fmt.Errorf("cannot start from state %s", task.State)
 	}
@@ -85,6 +87,7 @@ func (s *Scheduler) StartTask(id string) error {
 	}
 
 	task.State = StateStarting
+	task.LastError = ""
 	task.UpdatedAt = time.Now()
 	// 注意：这里仅表示“已发起启动流程”，不是“runner 已 ready”。
 	s.tasks[id] = task
@@ -303,11 +306,20 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 			return
 		}
 
+		errMsg := err.Error()
+		zap.L().Error("runner error", zap.String("task_id", id), zap.Error(err))
+		s.appendEventLocked(id, "TASK_RUNNER_ERROR", "runner error", errMsg)
+		if IsPermanent(err) {
+			_ = s.markFailedLocked(id, errMsg)
+			s.mu.Unlock()
+			return
+		}
+
 		current.State = StateRetryBackoff
-		current.LastError = err.Error()
+		current.LastError = errMsg
 		current.UpdatedAt = time.Now()
 		s.tasks[id] = current
-		s.appendEventLocked(id, "TASK_RUNNER_ERROR", "runner error", err.Error())
+		s.appendEventLocked(id, "TASK_RETRY_BACKOFF", "task entered retry backoff", errMsg)
 		_ = s.persistTaskLocked(current)
 		s.mu.Unlock()
 
@@ -403,6 +415,33 @@ func (s *Scheduler) failSafeStopLocked(id, eventType, message string) {
 		cancel()
 		delete(s.cancels, id)
 	}
+}
+
+// markFailedLocked 将任务收敛到 FAILED，用于不可恢复的源库/配置错误。
+// StartTask 允许从 FAILED 再次启动，方便值班改完密码/配置后重试。
+func (s *Scheduler) markFailedLocked(id, message string) error {
+	task, ok := s.tasks[id]
+	if !ok {
+		return nil
+	}
+	if task.State == StateFailed {
+		task.LastError = message
+		s.tasks[id] = task
+		return s.persistTaskLocked(task)
+	}
+	task.State = StateFailed
+	task.LastError = message
+	task.OwnerWorkerID = ""
+	task.Epoch = 0
+	task.RunID = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[id] = task
+	s.appendEventLocked(id, "TASK_FAILED", "task failed", message)
+	if cancel, ok := s.cancels[id]; ok {
+		cancel()
+		delete(s.cancels, id)
+	}
+	return s.persistTaskLocked(task)
 }
 
 // markStoppedLocked 将任务收敛到最终 STOPPED 并清理运行时 ownership 字段。

--- a/internal/tasks/scheduler_task_ops.go
+++ b/internal/tasks/scheduler_task_ops.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: task mutation requests and persisted task snapshots from TaskStore
-// output: validated task CRUD/config updates persisted into scheduler state
+// input: task mutation requests, full create specs, and persisted task snapshots from TaskStore
+// output: validated task CRUD/config updates persisted only after whole-spec validation
 // pos: scheduler task-management operations layer (non-runner lifecycle actions)
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -13,6 +13,15 @@ import (
 )
 
 func (s *Scheduler) CreateTask(name, clusterKey string) (Task, error) {
+	return s.createTask(name, clusterKey, nil, nil, nil, false)
+}
+
+// CreateTaskFromSpec 在一次校验通过后才落库；HTTP 400 路径不得留下半成品任务。
+func (s *Scheduler) CreateTaskFromSpec(name string, clusterKey string, source *SourceConfig, start *StartConfig, storage *Storage) (Task, error) {
+	return s.createTask(name, clusterKey, source, start, storage, true)
+}
+
+func (s *Scheduler) createTask(name, clusterKey string, source *SourceConfig, start *StartConfig, storage *Storage, requireSource bool) (Task, error) {
 	validatedName, err := normalizeAndValidateTaskName(name)
 	if err != nil {
 		return Task{}, err
@@ -21,6 +30,48 @@ func (s *Scheduler) CreateTask(name, clusterKey string) (Task, error) {
 	if err != nil {
 		return Task{}, err
 	}
+
+	var validatedSource SourceConfig
+	if requireSource {
+		if source == nil {
+			return Task{}, ErrSourceRequired
+		}
+		if source.Password == "" {
+			return Task{}, ErrSourcePasswordRequired
+		}
+		validatedSource, err = normalizeAndValidateSourceConfig(*source)
+		if err != nil {
+			return Task{}, err
+		}
+		validatedSource.Password = source.Password
+	} else if source != nil {
+		validatedSource, err = normalizeAndValidateSourceConfig(*source)
+		if err != nil {
+			return Task{}, err
+		}
+		validatedSource.Password = source.Password
+	}
+
+	validatedStart := StartConfig{Mode: StartModeLatest}
+	if start != nil {
+		validatedStart, err = normalizeAndValidateStartConfig(*start)
+		if err != nil {
+			return Task{}, err
+		}
+	}
+
+	validatedStorage := Storage{RetentionDays: defaultRetentionDays}
+	if storage != nil {
+		candidate := *storage
+		if candidate.RetentionDays == 0 && candidate.Dir == "" {
+			candidate.RetentionDays = defaultRetentionDays
+		}
+		validatedStorage, err = normalizeAndValidateStorage(candidate)
+		if err != nil {
+			return Task{}, err
+		}
+	}
+
 	if err := s.syncTasksFromStore(); err != nil {
 		return Task{}, err
 	}
@@ -39,13 +90,10 @@ func (s *Scheduler) CreateTask(name, clusterKey string) (Task, error) {
 		Name:       validatedName,
 		ClusterKey: validatedClusterKey,
 		State:      StateCreated,
-		Start: StartConfig{
-			Mode: StartModeLatest,
-		},
-		Storage: Storage{
-			RetentionDays: defaultRetentionDays,
-		},
-		UpdatedAt: now,
+		Source:     validatedSource,
+		Start:      validatedStart,
+		Storage:    validatedStorage,
+		UpdatedAt:  now,
 	}
 	s.tasks[id] = task
 	s.appendEventLocked(id, "TASK_CREATED", "task created", "")

--- a/internal/tasks/scheduler_test.go
+++ b/internal/tasks/scheduler_test.go
@@ -16,6 +16,49 @@ import (
 	"binlog_server/internal/binlog"
 )
 
+func TestScheduler_CreateTaskFromSpecDoesNotPersistOnInvalidStart(t *testing.T) {
+	s := NewScheduler()
+	source := SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl", Password: "secret"}
+	start := StartConfig{Mode: StartModeGTID}
+	_, err := s.CreateTaskFromSpec("repro-400-create", "repro-400-create", &source, &start, nil)
+	if !errors.Is(err, ErrGTIDSetRequired) {
+		t.Fatalf("expected ErrGTIDSetRequired, got %v", err)
+	}
+	if got := len(s.ListTasks()); got != 0 {
+		t.Fatalf("expected no persisted task, got %d", got)
+	}
+}
+
+func TestScheduler_StartTaskFromFailed(t *testing.T) {
+	s := NewScheduler(WithRunner(&fakeRunner{started: make(chan Task, 1)}))
+	task, err := s.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl", Password: "secret"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	s.mu.Lock()
+	if err := s.markFailedLocked(task.ID, "SOURCE_ACCESS_DENIED: denied"); err != nil {
+		s.mu.Unlock()
+		t.Fatalf("markFailedLocked: %v", err)
+	}
+	s.mu.Unlock()
+	if err := s.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask from FAILED: %v", err)
+	}
+	got, err := s.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.State != StateStarting && got.State != StateRunning {
+		t.Fatalf("expected STARTING/RUNNING after restart, got %s", got.State)
+	}
+	if got.LastError != "" {
+		t.Fatalf("expected last_error cleared, got %q", got.LastError)
+	}
+}
+
 // TestScheduler_StartTaskTransitionsToRunning 验证相关行为。
 func TestScheduler_StartTaskTransitionsToRunning(t *testing.T) {
 	s := NewScheduler(WithRunner(&fakeRunner{started: make(chan Task, 1)}))


### PR DESCRIPTION
## 描述

独立 review 后：#11/#10 是真 bug；#13 部分是真问题；#9 是文档；#12 主要是 standalone 无 `meta_dsn` 的既有设计，不是 crash bug。

本 PR **没有**合入 #14 的文件控制面（`file_store.go`）、没有改 `POST /start` 204→200、没有把 `storage.dir` 改成 400。

## 关联 Issue

- Fixes #9
- Fixes #10
- Fixes #11
- Fixes #13
- Relates to #12 (documented as in-memory control plane; closing as not a defect)

## 改动

### #11 创建校验
- `CreateTaskFromSpec` 整包校验通过后才落库
- HTTP 400 JSON `{"error","code"}`，不落库，不再静默改成 LATEST
- 缺 source / password / FILE_POS file/pos / GTID `gtid_set` → 400
- 接受 `gtid` 作为 `gtid_set` 别名

### #10 MariaDB
- 先探 `log_bin`；关闭则 `SOURCE_LOG_BIN_OFF`
- MariaDB 身份 `mariadb:<server_id>:<gtid_domain_id>`
- `SHOW MASTER STATUS` 失败时 fallback `SHOW BINLOG STATUS`

### #13 失败路径
- bind 失败 `SilenceUsage` / `SilenceErrors`，main 仍 `log.Fatal` 一行
- ERROR 1045 → `SOURCE_ACCESS_DENIED` → `FAILED`（**可再次 Start**，改完密码不用删任务）
- dump 2s 无事件视为追上，lag=0 / NORMAL（不引入 IDLE，避免 dashboard 掉健康计数）
- heartbeat 事件不写入备份文件
- `GET /api/health` → `{"status":"ok"}`，保留 `/healthz`
- runner 错误 zap error 级别

### #9 文档
- Quick Start：下载 tarball → checksums → 解压子目录 → `./binlog-server`
- `go run` 移到 Development
- `deployment.md` 去掉 `your-org` 和错误资产名
- 落地页 `#deployment` 写真实安装命令；`/docs` `/deployment` `/guide` hash 落到该段

### #12 不改架构
- 文档写明：无 `meta_dsn` 时控制面在内存；要重启可恢复请配 `meta_dsn`
- `storage.dir` 仍忽略，路径 `{data_dir}/{task_id}/`

## 测试

```bash
go test ./...
go vet ./...
go test -race ./internal/tasks ./internal/api ./internal/replication ./internal/app
```

本环境未跑 `make e2e-quick`（需要 Docker）。

## 配置兼容

- API 创建现在要求 `source.password`
- `FAILED` 可 `POST /start` 再拉起（以前没有这条路径）
- `POST /start` 仍是 204

## 回滚

```bash
git revert df98d0d
```