### PR TITLE
fix: honor go.mod version in vulncheck action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
+          go-version-input: ""
           go-version-file: "go.mod"
           go-package: ./...
 


### PR DESCRIPTION
## Summary
- clear govulncheck-action's default `stable` input
- let `go-version-file: go.mod` select Go 1.26.7

## Verification
- `git diff --check`
- three-level documentation check
- Standards review: 0 findings
- Spec review: 0 findings