### PR TITLE
refactor: centralize e2e database topology

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,10 +57,15 @@ jobs:
       - name: Unit Tests
         run: go test ./...
 
+      - name: E2E Topology Contract
+        run: make e2e-topology-check
+
       - name: sqlc Verify
         run: make sqlc-verify
 
       - name: E2E Suite
+        env:
+          E2E_MYSQL57_PORT: 23306
         run: |
           E2E_DIR="./tmp/e2e/data-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           E2E_SERVER_LOG="/tmp/binlog-server.log" E2E_DATA_DIR="$E2E_DIR" ./scripts/e2e/run-suite.sh --profile "$E2E_PROFILE"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test build build-linux check-linux-compat check-linux-release-archive ui-build release-assets e2e-quick e2e-full e2e-observability e2e migrate-up migrate-down migrate-version migrate-force sqlc-generate sqlc-verify
+.PHONY: help test build build-linux check-linux-compat check-linux-release-archive ui-build release-assets e2e-topology-check e2e-quick e2e-full e2e-observability e2e migrate-up migrate-down migrate-version migrate-force sqlc-generate sqlc-verify
 
 VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo devel)
 BUILD_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
@@ -15,6 +15,7 @@ help:
 	@echo "  make check-linux-release-archive VERSION=vX.Y.Z # verify required assets and glibc safety in the Linux amd64 release tar.gz"
 	@echo "  make ui-build                   # build frontend and sync to internal/ui/static"
 	@echo "  make release-assets VERSION=v0.1.0 # build release archives + checksums for darwin/linux amd64/arm64"
+	@echo "  make e2e-topology-check         # validate E2E database topology without Docker"
 	@echo "  make e2e-quick                  # run quick e2e (smoke,compression)"
 	@echo "  make e2e-full                   # run full e2e (smoke,compression,orchestrator,semisync)"
 	@echo "  make e2e-observability          # run observability e2e (smoke-observability)"
@@ -69,6 +70,9 @@ ui-build:
 
 release-assets:
 	VERSION="$(VERSION)" BUILD_COMMIT="$(BUILD_COMMIT)" BUILD_DATE="$(BUILD_DATE)" ./scripts/release-assets.sh
+
+e2e-topology-check:
+	./scripts/e2e/topology-contract-test.sh
 
 e2e-quick:
 	./scripts/e2e/run-suite.sh --profile quick

--- a/deploy/e2e/docker-compose.yml
+++ b/deploy/e2e/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       MYSQL_ROOT_HOST: "%"
       TZ: UTC
     ports:
-      - "13307:3306"
+      - "${E2E_MYSQL80_PORT:-13307}:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
@@ -47,7 +47,7 @@ services:
       MYSQL_ROOT_HOST: "%"
       TZ: UTC
     ports:
-      - "13308:3306"
+      - "${E2E_PERCONA57_PORT:-13308}:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
@@ -66,7 +66,7 @@ services:
       MYSQL_ROOT_HOST: "%"
       TZ: UTC
     ports:
-      - "13309:3306"
+      - "${E2E_PERCONA80_PORT:-13309}:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
@@ -86,7 +86,7 @@ services:
       MYSQL_ROOT_HOST: "%"
       TZ: UTC
     ports:
-      - "13316:3306"
+      - "${E2E_META_PRIMARY_PORT:-13316}:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
@@ -108,7 +108,7 @@ services:
       MYSQL_ROOT_HOST: "%"
       TZ: UTC
     ports:
-      - "13317:3306"
+      - "${E2E_META_REPLICA_PORT:-13317}:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
@@ -128,8 +128,8 @@ services:
       meta-replica:
         condition: service_healthy
     ports:
-      - "6036:6036"
-      - "16036:16036"
+      - "${E2E_META_PROXYSQL_ADMIN_PORT:-6036}:6036"
+      - "${E2E_META_PROXYSQL_PORT:-16036}:16036"
     volumes:
       - ./proxysql/proxysql-meta.cnf:/etc/proxysql.cnf:ro
 

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -57,6 +57,7 @@ make e2e-quick
 make e2e-full
 make e2e-observability
 make e2e SCENARIOS=smoke,compression
+make e2e-topology-check
 ```
 
 ## 脚本列表
@@ -69,6 +70,8 @@ make e2e SCENARIOS=smoke,compression
 - `smoke-orchestrator.sh`: 验证 orchestrator 拓扑里是否误纳入 binlog 拉流客户端。
 - `smoke-semisync.sh`: 验证 `semi_sync=true` 时的 client 挂载与停任务后主库提交阻塞到 timeout。
 - `setup-meta-replication.sh`: 初始化 meta-primary/meta-replica GTID 主从复制与 ProxySQL 监控账号。
+- `lib-topology.sh`: 解析并校验统一的数据库 host、端口、共享凭据和 metadata DSN。
+- `topology-contract-test.sh`: 无需 Docker，验证拓扑默认值、覆盖优先级、direct/failover 选择、端口校验及 Compose 兜底一致性。
 - `smoke-meta-failover.sh`: 触发 orchestrator 切主，验证元数据库 failover 后 checkpoint 继续推进。
 - `smoke-meta-failover-override.sh`: 用非默认 `E2E_API/E2E_ORC_API` 地址（localhost）覆盖并执行 failover 场景。
 - `smoke-observability.sh`: 验证 `/metrics` 核心指标存在，且 `task_state_count` 与 `checkpoint_age_seconds` 随状态/时间变化。
@@ -85,12 +88,19 @@ make e2e SCENARIOS=smoke,compression
 
 - `E2E_DATA_DIR`: e2e 数据目录（默认 `./tmp/e2e/data-suite-<timestamp>`）。
 - `E2E_SERVER_LOG`: `run-suite.sh` 启动后端时的日志路径（默认 `/tmp/binlog-server-e2e-suite.log`）。
-- `E2E_META_DSN`: metadata DSN 覆盖值；默认连接独立的 `meta-primary`（`127.0.0.1:13316`），不得指向任一 source。
-- `E2E_MYSQL57_PORT`: 所有 mysql57 source 场景使用的宿主机端口（默认 `13306`），本机端口冲突时可覆盖。
+- `E2E_SOURCE_HOST` / `E2E_SOURCE_USER` / `E2E_SOURCE_PASS`: source 任务共享连接参数，默认 `127.0.0.1` / `repl` / `replpass`。
+- `E2E_MYSQL57_PORT` / `E2E_MYSQL80_PORT`: MySQL 5.7/8.0 宿主机端口，默认 `13306` / `13307`。
+- `E2E_PERCONA57_PORT` / `E2E_PERCONA80_PORT`: Percona 5.7/8.0 宿主机端口，默认 `13308` / `13309`。
+- `E2E_META_HOST` / `E2E_META_USER` / `E2E_META_PASS` / `E2E_META_DB`: metadata 连接参数，默认 `127.0.0.1` / `meta` / `metapass` / `binlog_meta`。
+- `E2E_META_PRIMARY_PORT` / `E2E_META_REPLICA_PORT`: metadata 主从宿主机端口，默认 `13316` / `13317`。
+- `E2E_META_PROXYSQL_ADMIN_PORT` / `E2E_META_PROXYSQL_PORT`: ProxySQL 管理端口和 SQL 端口，默认 `6036` / `16036`。
+- `E2E_META_DSN`: 完整 metadata DSN 覆盖值，优先级高于上述 metadata 分项；未设置时由具名的 `direct` 或 `failover` 拓扑生成。
 - `SEMISYNC_TIMEOUT_MS`: `smoke-semisync.sh` 使用的半同步 timeout（默认 `7000`）。
 - `E2E_WORKER_ID`: `smoke-cluster-roles.sh` 中 worker 进程上报的 worker_id（默认 `e2e-worker-1`）。
 - `E2E_WORKER_OFFLINE_WAIT_SEC`: `smoke-cluster-roles.sh` 停 worker 后等待离线判定的秒数（默认 `20`）。
 - `E2E_WORKER_HEALTH_ADDR`: `smoke-cluster-roles.sh` 中 worker health probe 地址（默认 `127.0.0.1:18081`）。
+
+所有正式 E2E 入口都会加载 `lib-topology.sh`，必填值不能为空，端口必须处于 `1-65535`。Compose 保留同值兜底，仅用于直接执行 `docker compose ... ps/logs` 等排障命令；`make e2e-topology-check` 会阻止两处默认值漂移。
 
 ## smoke-cluster-roles 场景说明
 

--- a/scripts/e2e/down.sh
+++ b/scripts/e2e/down.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go) and e2e environment/service dependencies
-# output: deterministic e2e orchestration, scenario execution, and verification logs
-# pos: integration-test automation layer validating end-to-end system behavior
+# input: Docker and the canonical E2E database topology
+# output: removed E2E containers and volumes
+# pos: E2E environment teardown adapter
 # note: if this file changes, update this header and module README.md.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 
 cd "$ROOT_DIR"
 # 清理容器 + volume，确保下次 e2e 从干净状态启动。

--- a/scripts/e2e/lib-migration.sh
+++ b/scripts/e2e/lib-migration.sh
@@ -1,17 +1,10 @@
 #!/usr/bin/env bash
-# input: metadata DSN targeting the isolated e2e metadata database and local Go tooling
-# output: deterministic e2e orchestration, scenario execution, and verification logs
-# pos: integration-test automation layer validating end-to-end system behavior
+# input: canonical E2E database topology, metadata DSN, and local Go tooling
+# output: metadata DSN masking and schema-migration helpers
+# pos: shared metadata migration adapter for E2E orchestration and standalone scenarios
 # note: if this file changes, update this header and module README.md.
 
-e2e_default_meta_dsn() {
-  local port="${1:-13316}"
-  local host="${E2E_META_HOST:-127.0.0.1}"
-  local user="${E2E_META_USER:-meta}"
-  local pass="${E2E_META_PASS:-metapass}"
-  local db="${E2E_META_DB:-binlog_meta}"
-  printf '%s:%s@tcp(%s:%s)/%s?parseTime=true' "$user" "$pass" "$host" "$port" "$db"
-}
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib-topology.sh"
 
 e2e_mask_dsn() {
   local dsn="$1"
@@ -21,7 +14,7 @@ e2e_mask_dsn() {
 
 e2e_ensure_meta_schema() {
   local root_dir="$1"
-  local dsn="${2:-$(e2e_default_meta_dsn 13316)}"
+  local dsn="${2:-$(e2e_meta_dsn direct)}"
 
   command -v go >/dev/null 2>&1 || { echo "missing command: go" >&2; exit 1; }
   echo "[e2e] migrate meta schema dsn=$(e2e_mask_dsn "$dsn")"

--- a/scripts/e2e/lib-topology.sh
+++ b/scripts/e2e/lib-topology.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# input: optional E2E database endpoint and credential environment overrides
+# output: validated/exported E2E database topology and direct/failover metadata DSNs
+# pos: canonical database-topology contract shared by E2E orchestration and scenarios
+# note: if this file changes, update this header and module README.md.
+
+e2e_require_value() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "$name is required" >&2
+    return 1
+  fi
+}
+
+e2e_require_port() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ ! "$value" =~ ^[0-9]+$ ]] || (( 10#$value < 1 || 10#$value > 65535 )); then
+    echo "$name must be an integer between 1 and 65535: $value" >&2
+    return 1
+  fi
+}
+
+e2e_topology_init() {
+  E2E_SOURCE_HOST="${E2E_SOURCE_HOST-127.0.0.1}"
+  E2E_SOURCE_USER="${E2E_SOURCE_USER-repl}"
+  E2E_SOURCE_PASS="${E2E_SOURCE_PASS-replpass}"
+
+  E2E_MYSQL57_PORT="${E2E_MYSQL57_PORT-13306}"
+  E2E_MYSQL80_PORT="${E2E_MYSQL80_PORT-13307}"
+  E2E_PERCONA57_PORT="${E2E_PERCONA57_PORT-13308}"
+  E2E_PERCONA80_PORT="${E2E_PERCONA80_PORT-13309}"
+
+  E2E_META_HOST="${E2E_META_HOST-127.0.0.1}"
+  E2E_META_USER="${E2E_META_USER-meta}"
+  E2E_META_PASS="${E2E_META_PASS-metapass}"
+  E2E_META_DB="${E2E_META_DB-binlog_meta}"
+  E2E_META_PRIMARY_PORT="${E2E_META_PRIMARY_PORT-13316}"
+  E2E_META_REPLICA_PORT="${E2E_META_REPLICA_PORT-13317}"
+  E2E_META_PROXYSQL_ADMIN_PORT="${E2E_META_PROXYSQL_ADMIN_PORT-6036}"
+  E2E_META_PROXYSQL_PORT="${E2E_META_PROXYSQL_PORT-16036}"
+
+  local required_values=(
+    E2E_SOURCE_HOST E2E_SOURCE_USER E2E_SOURCE_PASS
+    E2E_META_HOST E2E_META_USER E2E_META_PASS E2E_META_DB
+  )
+  local ports=(
+    E2E_MYSQL57_PORT E2E_MYSQL80_PORT E2E_PERCONA57_PORT E2E_PERCONA80_PORT
+    E2E_META_PRIMARY_PORT E2E_META_REPLICA_PORT
+    E2E_META_PROXYSQL_ADMIN_PORT E2E_META_PROXYSQL_PORT
+  )
+  local name
+  for name in "${required_values[@]}"; do
+    e2e_require_value "$name" || return 1
+  done
+  for name in "${ports[@]}"; do
+    e2e_require_port "$name" || return 1
+  done
+
+  export "${required_values[@]}" "${ports[@]}"
+}
+
+e2e_meta_dsn() {
+  local topology="${1:-direct}"
+  if [[ -n "${E2E_META_DSN:-}" ]]; then
+    printf '%s' "$E2E_META_DSN"
+    return 0
+  fi
+
+  local port
+  case "$topology" in
+    direct) port="$E2E_META_PRIMARY_PORT" ;;
+    failover) port="$E2E_META_PROXYSQL_PORT" ;;
+    *)
+      echo "unsupported metadata topology: $topology" >&2
+      return 1
+      ;;
+  esac
+  printf '%s:%s@tcp(%s:%s)/%s?parseTime=true' \
+    "$E2E_META_USER" "$E2E_META_PASS" "$E2E_META_HOST" "$port" "$E2E_META_DB"
+}
+
+e2e_topology_init

--- a/scripts/e2e/run-suite.sh
+++ b/scripts/e2e/run-suite.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go), source databases, and an isolated metadata database
+# input: local tooling, canonical E2E database topology, scenarios, and profile selection
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -236,10 +236,10 @@ main() {
   "$ROOT_DIR/scripts/e2e/up.sh"
 
   if has_scenario "meta-failover" "${scenarios[@]}" || has_scenario "meta-failover-override" "${scenarios[@]}"; then
-    META_DSN="${E2E_META_DSN:-$(e2e_default_meta_dsn 16036)}"
+    META_DSN="$(e2e_meta_dsn failover)"
     "$ROOT_DIR/scripts/e2e/setup-meta-replication.sh"
   elif [[ -z "$META_DSN" ]]; then
-    META_DSN="${E2E_META_DSN:-$(e2e_default_meta_dsn 13316)}"
+    META_DSN="$(e2e_meta_dsn direct)"
   fi
   e2e_ensure_meta_schema "$ROOT_DIR" "$META_DSN"
 

--- a/scripts/e2e/setup-meta-replication.sh
+++ b/scripts/e2e/setup-meta-replication.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go) and e2e environment/service dependencies
-# output: deterministic e2e orchestration, scenario execution, and verification logs
-# pos: integration-test automation layer validating end-to-end system behavior
+# input: Docker, awk, and the canonical E2E database topology
+# output: configured metadata replication and ProxySQL readiness
+# pos: metadata failover topology setup adapter
 # note: if this file changes, update this header and module README.md.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }

--- a/scripts/e2e/smoke-cluster-roles.sh
+++ b/scripts/e2e/smoke-cluster-roles.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: isolated metadata DSN, optional E2E_MYSQL57_PORT override, and cluster-role e2e dependencies
+# input: canonical E2E database topology and cluster-role e2e dependencies
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -8,7 +8,6 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
 API="${E2E_API:-http://127.0.0.1:18080}"
-MYSQL57_PORT="${E2E_MYSQL57_PORT:-13306}"
 DATA_DIR="${E2E_DATA_DIR:-$ROOT_DIR/tmp/e2e/data-cluster-roles-$(date +%s)}"
 WORKER_ID="${E2E_WORKER_ID:-e2e-worker-1}"
 WORKER_OFFLINE_WAIT_SEC="${E2E_WORKER_OFFLINE_WAIT_SEC:-20}"
@@ -24,7 +23,8 @@ CHECKPOINT_HTTP_CODE=""
 CHECKPOINT_HTTP_BODY=""
 
 source "$ROOT_DIR/scripts/e2e/lib-migration.sh"
-META_DSN="${E2E_META_DSN:-$(e2e_default_meta_dsn 13316)}"
+MYSQL57_PORT="$E2E_MYSQL57_PORT"
+META_DSN="$(e2e_meta_dsn direct)"
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }
@@ -154,7 +154,7 @@ create_task() {
   local resp
   resp="$(curl -fsS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"e2e-cluster-roles-${RUN_TAG}\",\"cluster_key\":\"e2e-cluster-roles-${RUN_TAG}\",\"source\":{\"host\":\"127.0.0.1\",\"port\":${MYSQL57_PORT},\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
+    -d "{\"name\":\"e2e-cluster-roles-${RUN_TAG}\",\"cluster_key\":\"e2e-cluster-roles-${RUN_TAG}\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":${MYSQL57_PORT},\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
 
   local id
   id="$(printf '%s' "$resp" | jq -r '.id // empty')"

--- a/scripts/e2e/smoke-compression.sh
+++ b/scripts/e2e/smoke-compression.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go) and e2e environment/service dependencies
+# input: local tooling, e2e services, and the canonical E2E database topology
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -7,6 +7,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 API="http://127.0.0.1:18080"
 DATA_DIR="${E2E_DATA_DIR:-$ROOT_DIR/tmp/e2e/data}"
 
@@ -43,7 +44,7 @@ create_task_file_pos() {
   # 从 FILE/POS 起点拉取，确保我们明确验证“一个完整 binlog 文件”的一致性。
   resp=$(curl -sS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"$name\",\"cluster_key\":\"$name\",\"source\":{\"host\":\"127.0.0.1\",\"port\":$port,\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":$sid},\"start\":{\"mode\":\"FILE_POS\",\"file\":\"$file\",\"pos\":$pos},\"storage\":{\"retention_days\":7}}")
+    -d "{\"name\":\"$name\",\"cluster_key\":\"$name\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":$port,\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":$sid},\"start\":{\"mode\":\"FILE_POS\",\"file\":\"$file\",\"pos\":$pos},\"storage\":{\"retention_days\":7}}")
 
   local id
   id=$(json_get_str "$resp" "id" "ID")
@@ -235,7 +236,7 @@ verify_one_source() {
 run_tag="$(date +%s)"
 
 # 只对 8.0 系列做压缩事务专项（5.7 不支持该特性）。
-verify_one_source "mysql80" "13307" "320801" "binlog_e2e_80" "$run_tag"
-verify_one_source "percona80" "13309" "320802" "binlog_e2e_percona80" "$run_tag"
+verify_one_source "mysql80" "$E2E_MYSQL80_PORT" "320801" "binlog_e2e_80" "$run_tag"
+verify_one_source "percona80" "$E2E_PERCONA80_PORT" "320802" "binlog_e2e_percona80" "$run_tag"
 
 echo "[compression] success: mysql80/percona80 compressed transaction replicated and md5 matched"

--- a/scripts/e2e/smoke-control-plane-failover.sh
+++ b/scripts/e2e/smoke-control-plane-failover.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: isolated metadata DSN, optional E2E_MYSQL57_PORT override, and control-plane failover dependencies
+# input: canonical E2E database topology and control-plane failover dependencies
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -8,7 +8,6 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
 API="${E2E_API:-http://127.0.0.1:18080}"
-MYSQL57_PORT="${E2E_MYSQL57_PORT:-13306}"
 DATA_DIR="${E2E_DATA_DIR:-$ROOT_DIR/tmp/e2e/data-control-plane-failover-$(date +%s)}"
 WORKER_ID="${E2E_WORKER_ID:-e2e-worker-1}"
 WORKER_HEALTH_ADDR="${E2E_WORKER_HEALTH_ADDR:-127.0.0.1:18081}"
@@ -23,7 +22,8 @@ CHECKPOINT_HTTP_CODE=""
 CHECKPOINT_HTTP_BODY=""
 
 source "$ROOT_DIR/scripts/e2e/lib-migration.sh"
-META_DSN="${E2E_META_DSN:-$(e2e_default_meta_dsn 13316)}"
+MYSQL57_PORT="$E2E_MYSQL57_PORT"
+META_DSN="$(e2e_meta_dsn direct)"
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }
@@ -129,7 +129,7 @@ create_task() {
   local resp
   resp="$(curl -fsS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"e2e-control-plane-failover-${RUN_TAG}\",\"cluster_key\":\"e2e-control-plane-failover-${RUN_TAG}\",\"source\":{\"host\":\"127.0.0.1\",\"port\":${MYSQL57_PORT},\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
+    -d "{\"name\":\"e2e-control-plane-failover-${RUN_TAG}\",\"cluster_key\":\"e2e-control-plane-failover-${RUN_TAG}\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":${MYSQL57_PORT},\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
 
   local id
   id="$(printf '%s' "$resp" | jq -r '.id // empty')"

--- a/scripts/e2e/smoke-invalid-inputs.sh
+++ b/scripts/e2e/smoke-invalid-inputs.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# input: local tooling, optional E2E_MYSQL57_PORT override, and invalid-input e2e dependencies
+# input: local tooling, invalid-input dependencies, and the canonical E2E database topology
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 API="${E2E_API:-http://127.0.0.1:18080}"
-MYSQL57_PORT="${E2E_MYSQL57_PORT:-13306}"
+MYSQL57_PORT="$E2E_MYSQL57_PORT"
 RUN_TAG="$(date +%s)"
 BASE_CLUSTER_KEY="e2e-invalid-input-base-${RUN_TAG}"
 UPDATED_CLUSTER_KEY="e2e-invalid-input-updated-${RUN_TAG}"
@@ -83,9 +85,9 @@ assert_task_baseline_unchanged() {
 
   [[ "$actual_name" == "$BASE_NAME" ]] || { echo "task $task_id name changed unexpectedly: $actual_name" >&2; exit 1; }
   [[ "$actual_key" == "$BASE_CLUSTER_KEY" ]] || { echo "task $task_id cluster_key changed unexpectedly: $actual_key" >&2; exit 1; }
-  [[ "$actual_host" == "127.0.0.1" ]] || { echo "task $task_id source.host changed unexpectedly: $actual_host" >&2; exit 1; }
+  [[ "$actual_host" == "$E2E_SOURCE_HOST" ]] || { echo "task $task_id source.host changed unexpectedly: $actual_host" >&2; exit 1; }
   [[ "$actual_port" == "$MYSQL57_PORT" ]] || { echo "task $task_id source.port changed unexpectedly: $actual_port" >&2; exit 1; }
-  [[ "$actual_user" == "repl" ]] || { echo "task $task_id source.user changed unexpectedly: $actual_user" >&2; exit 1; }
+  [[ "$actual_user" == "$E2E_SOURCE_USER" ]] || { echo "task $task_id source.user changed unexpectedly: $actual_user" >&2; exit 1; }
   [[ "$actual_start" == "LATEST" ]] || { echo "task $task_id start.mode changed unexpectedly: $actual_start" >&2; exit 1; }
   [[ "$actual_retention" == "7" ]] || { echo "task $task_id storage.retention_days changed unexpectedly: $actual_retention" >&2; exit 1; }
 }
@@ -96,7 +98,7 @@ create_valid_task() {
   local name="$BASE_NAME"
   local payload
   payload="$(cat <<JSON
-{"name":"$name","cluster_key":"$BASE_CLUSTER_KEY","source":{"host":"127.0.0.1","port":$MYSQL57_PORT,"user":"repl","password":"replpass","flavor":"mysql","server_id":$sid},"start":{"mode":"LATEST"},"storage":{"retention_days":7}}
+{"name":"$name","cluster_key":"$BASE_CLUSTER_KEY","source":{"host":"$E2E_SOURCE_HOST","port":$MYSQL57_PORT,"user":"$E2E_SOURCE_USER","password":"$E2E_SOURCE_PASS","flavor":"mysql","server_id":$sid},"start":{"mode":"LATEST"},"storage":{"retention_days":7}}
 JSON
 )"
   local resp
@@ -114,7 +116,7 @@ JSON
 }
 
 echo "[invalid-inputs] verify create rejects invalid cluster_key"
-assert_post_400 "{\"name\":\"invalid-a\",\"cluster_key\":\"../bad\",\"source\":{\"host\":\"127.0.0.1\",\"port\":${MYSQL57_PORT},\"user\":\"repl\",\"flavor\":\"mysql\",\"server_id\":410001}}"
+assert_post_400 "{\"name\":\"invalid-a\",\"cluster_key\":\"../bad\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":${MYSQL57_PORT},\"user\":\"$E2E_SOURCE_USER\",\"flavor\":\"mysql\",\"server_id\":410001}}"
 
 echo "[invalid-inputs] verify create rejects invalid source.host"
 assert_post_400 "{\"name\":\"invalid-b\",\"cluster_key\":\"invalid-b\",\"source\":{\"host\":\"bad host\",\"port\":${MYSQL57_PORT},\"user\":\"repl\",\"flavor\":\"mysql\",\"server_id\":410002}}"

--- a/scripts/e2e/smoke-meta-failover.sh
+++ b/scripts/e2e/smoke-meta-failover.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go) and e2e environment/service dependencies
+# input: local tooling, failover services, and the canonical E2E database topology
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -7,6 +7,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 API="${E2E_API:-http://127.0.0.1:18080}"
 ORC_API="${E2E_ORC_API:-http://127.0.0.1:13000/api}"
 
@@ -118,7 +119,7 @@ create_task() {
   local resp
   if ! resp="$(curl -fsS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"$task_name\",\"cluster_key\":\"$task_name\",\"source\":{\"host\":\"127.0.0.1\",\"port\":13307,\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":$sid},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"; then
+    -d "{\"name\":\"$task_name\",\"cluster_key\":\"$task_name\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":$E2E_MYSQL80_PORT,\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":$sid},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"; then
     echo "create task request failed" >&2
     exit 1
   fi

--- a/scripts/e2e/smoke-observability.sh
+++ b/scripts/e2e/smoke-observability.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling, optional E2E_MYSQL57_PORT override, and observability e2e dependencies
+# input: local tooling, observability dependencies, and the canonical E2E database topology
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -7,8 +7,9 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 API="${E2E_API:-http://127.0.0.1:18080}"
-MYSQL57_PORT="${E2E_MYSQL57_PORT:-13306}"
+MYSQL57_PORT="$E2E_MYSQL57_PORT"
 RUN_TAG="$(date +%s)"
 
 need_cmd() {
@@ -94,7 +95,7 @@ create_task() {
   local resp
   resp="$(curl -fsS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"e2e-observability-${RUN_TAG}\",\"cluster_key\":\"e2e-observability-${RUN_TAG}\",\"source\":{\"host\":\"127.0.0.1\",\"port\":${MYSQL57_PORT},\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
+    -d "{\"name\":\"e2e-observability-${RUN_TAG}\",\"cluster_key\":\"e2e-observability-${RUN_TAG}\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":${MYSQL57_PORT},\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
   local id
   id="$(printf '%s' "$resp" | jq -r '.id // empty')"
   if [[ -z "$id" || "$id" == "null" ]]; then

--- a/scripts/e2e/smoke-orchestrator.sh
+++ b/scripts/e2e/smoke-orchestrator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go) and e2e environment/service dependencies
+# input: local tooling, e2e services, and the canonical E2E database topology
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -7,6 +7,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 API="http://127.0.0.1:18080"
 ORC_API="http://127.0.0.1:13000/api"
 DISCOVER_HOST="mysql80"
@@ -86,7 +87,7 @@ create_task() {
   # 创建一个 LATEST 起点任务，使 binlog_server 与 source 建立 dump 连接。
   resp=$(curl -sS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"$task_name\",\"cluster_key\":\"$task_name\",\"source\":{\"host\":\"127.0.0.1\",\"port\":13307,\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":330901},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")
+    -d "{\"name\":\"$task_name\",\"cluster_key\":\"$task_name\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":$E2E_MYSQL80_PORT,\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":330901},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")
   local id
   id=$(json_get_str "$resp" "id" "ID")
   if [[ -z "$id" || "$id" == "null" ]]; then

--- a/scripts/e2e/smoke-retry-upload.sh
+++ b/scripts/e2e/smoke-retry-upload.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: isolated metadata DSN, optional E2E_MYSQL57_PORT override, and retry-upload e2e dependencies
+# input: canonical E2E database topology and retry-upload e2e dependencies
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -8,7 +8,6 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
 API="${E2E_API:-http://127.0.0.1:18080}"
-MYSQL57_PORT="${E2E_MYSQL57_PORT:-13306}"
 DATA_DIR="${E2E_DATA_DIR:-$ROOT_DIR/tmp/e2e/data-retry-upload-$(date +%s)}"
 RUN_TAG="$(date +%s)"
 
@@ -26,7 +25,8 @@ CHECKPOINT_HTTP_CODE=""
 CHECKPOINT_HTTP_BODY=""
 
 source "$ROOT_DIR/scripts/e2e/lib-migration.sh"
-META_DSN="${E2E_META_DSN:-$(e2e_default_meta_dsn 13316)}"
+MYSQL57_PORT="$E2E_MYSQL57_PORT"
+META_DSN="$(e2e_meta_dsn direct)"
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }
@@ -169,7 +169,7 @@ create_task() {
   local name="e2e-retry-upload-${RUN_TAG}"
   local payload
   payload="$(cat <<JSON
-{"name":"$name","cluster_key":"$name","source":{"host":"127.0.0.1","port":$MYSQL57_PORT,"user":"repl","password":"replpass","flavor":"mysql","server_id":$sid},"start":{"mode":"LATEST"},"storage":{"retention_days":7}}
+{"name":"$name","cluster_key":"$name","source":{"host":"$E2E_SOURCE_HOST","port":$MYSQL57_PORT,"user":"$E2E_SOURCE_USER","password":"$E2E_SOURCE_PASS","flavor":"mysql","server_id":$sid},"start":{"mode":"LATEST"},"storage":{"retention_days":7}}
 JSON
 )"
   local resp

--- a/scripts/e2e/smoke-semisync.sh
+++ b/scripts/e2e/smoke-semisync.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go) and e2e environment/service dependencies
+# input: local tooling, e2e services, and the canonical E2E database topology
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -7,9 +7,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 API="http://127.0.0.1:18080"
 SOURCE_SERVICE="mysql80"
-SOURCE_PORT="13307"
+SOURCE_PORT="$E2E_MYSQL80_PORT"
 SEMISYNC_TIMEOUT_MS="${SEMISYNC_TIMEOUT_MS:-7000}"
 task_id=""
 mode=""
@@ -150,7 +151,7 @@ create_semisync_task() {
   local resp id
   resp=$(curl -sS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"$name\",\"cluster_key\":\"$name\",\"source\":{\"host\":\"127.0.0.1\",\"port\":$SOURCE_PORT,\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":$sid,\"semi_sync\":true},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")
+    -d "{\"name\":\"$name\",\"cluster_key\":\"$name\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":$SOURCE_PORT,\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":$sid,\"semi_sync\":true},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")
   id=$(json_get_str "$resp" "id" "ID")
   if [[ -z "$id" || "$id" == "null" ]]; then
     echo "create task failed: $resp" >&2

--- a/scripts/e2e/smoke-worker-crash-recovery.sh
+++ b/scripts/e2e/smoke-worker-crash-recovery.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: isolated metadata DSN, optional E2E_MYSQL57_PORT override, and worker crash-recovery dependencies
+# input: canonical E2E database topology and worker crash-recovery dependencies
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -8,7 +8,6 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
 API="${E2E_API:-http://127.0.0.1:18080}"
-MYSQL57_PORT="${E2E_MYSQL57_PORT:-13306}"
 DATA_DIR="${E2E_DATA_DIR:-$ROOT_DIR/tmp/e2e/data-worker-crash-recovery-$(date +%s)}"
 WORKER_SHARED_DIR="${E2E_WORKER_SHARED_DIR:-$DATA_DIR/worker-shared}"
 WORKER1_ID="${E2E_WORKER1_ID:-e2e-worker-crash-1}"
@@ -28,7 +27,8 @@ CHECKPOINT_HTTP_CODE=""
 CHECKPOINT_HTTP_BODY=""
 
 source "$ROOT_DIR/scripts/e2e/lib-migration.sh"
-META_DSN="${E2E_META_DSN:-$(e2e_default_meta_dsn 13316)}"
+MYSQL57_PORT="$E2E_MYSQL57_PORT"
+META_DSN="$(e2e_meta_dsn direct)"
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }
@@ -119,7 +119,7 @@ create_task() {
   local resp
   resp="$(curl -fsS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"e2e-worker-crash-${RUN_TAG}\",\"cluster_key\":\"e2e-worker-crash-${RUN_TAG}\",\"source\":{\"host\":\"127.0.0.1\",\"port\":${MYSQL57_PORT},\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
+    -d "{\"name\":\"e2e-worker-crash-${RUN_TAG}\",\"cluster_key\":\"e2e-worker-crash-${RUN_TAG}\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":${MYSQL57_PORT},\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":${sid}},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")"
 
   local id
   id="$(printf '%s' "$resp" | jq -r '.id // empty')"

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling, e2e services, and optional E2E_MYSQL57_PORT host-port override
+# input: local tooling, e2e services, and the canonical E2E database topology
 # output: deterministic e2e orchestration, scenario execution, and verification logs
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -7,6 +7,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 API="http://127.0.0.1:18080"
 
 need_cmd() {
@@ -26,7 +27,7 @@ create_task() {
   local resp
   resp=$(curl -sS -X POST "$API/api/tasks" \
     -H 'Content-Type: application/json' \
-    -d "{\"name\":\"$name\",\"cluster_key\":\"$name\",\"source\":{\"host\":\"127.0.0.1\",\"port\":$port,\"user\":\"repl\",\"password\":\"replpass\",\"flavor\":\"mysql\",\"server_id\":$sid},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")
+    -d "{\"name\":\"$name\",\"cluster_key\":\"$name\",\"source\":{\"host\":\"$E2E_SOURCE_HOST\",\"port\":$port,\"user\":\"$E2E_SOURCE_USER\",\"password\":\"$E2E_SOURCE_PASS\",\"flavor\":\"mysql\",\"server_id\":$sid},\"start\":{\"mode\":\"LATEST\"},\"storage\":{\"retention_days\":7}}")
 
   local id
   id=$(printf '%s' "$resp" | jq -r '.id // empty')
@@ -57,10 +58,10 @@ wait_running() {
 
 echo "[e2e] create + start tasks"
 # 每个 source 使用固定唯一 server_id，避免 replication client 冲突。
-id57=$(create_task "e2e-mysql57" "${E2E_MYSQL57_PORT:-13306}" 310101)
-id80=$(create_task "e2e-mysql80" 13307 310102)
-idp57=$(create_task "e2e-percona57" 13308 310103)
-idp80=$(create_task "e2e-percona80" 13309 310104)
+id57=$(create_task "e2e-mysql57" "$E2E_MYSQL57_PORT" 310101)
+id80=$(create_task "e2e-mysql80" "$E2E_MYSQL80_PORT" 310102)
+idp57=$(create_task "e2e-percona57" "$E2E_PERCONA57_PORT" 310103)
+idp80=$(create_task "e2e-percona80" "$E2E_PERCONA80_PORT" 310104)
 
 wait_running "$id57"
 wait_running "$id80"

--- a/scripts/e2e/topology-contract-test.sh
+++ b/scripts/e2e/topology-contract-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# input: canonical E2E topology module and Compose adapter defaults
+# output: fast contract assertions for defaults, overrides, topology selection, and validation
+# pos: no-Docker regression check for the E2E database-topology boundary
+# note: if this file changes, update this header and module README.md.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TOPOLOGY_LIB="$ROOT_DIR/scripts/e2e/lib-topology.sh"
+COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+
+fail() {
+  echo "[topology-contract] $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  [[ "$actual" == "$expected" ]] || fail "$label: expected '$expected', got '$actual'"
+}
+
+compose_default() {
+  local name="$1"
+  local marker="\${${name}:-"
+  local line value
+  while IFS= read -r line; do
+    if [[ "$line" == *"$marker"* ]]; then
+      value="${line#*"$marker"}"
+      printf '%s' "${value%%\}*}"
+      return 0
+    fi
+  done <"$COMPOSE_FILE"
+  return 1
+}
+
+topology_vars=(
+  E2E_SOURCE_HOST E2E_SOURCE_USER E2E_SOURCE_PASS
+  E2E_MYSQL57_PORT E2E_MYSQL80_PORT E2E_PERCONA57_PORT E2E_PERCONA80_PORT
+  E2E_META_HOST E2E_META_USER E2E_META_PASS E2E_META_DB
+  E2E_META_PRIMARY_PORT E2E_META_REPLICA_PORT
+  E2E_META_PROXYSQL_ADMIN_PORT E2E_META_PROXYSQL_PORT E2E_META_DSN
+)
+for name in "${topology_vars[@]}"; do
+  unset "$name"
+done
+source "$TOPOLOGY_LIB"
+
+assert_eq "127.0.0.1" "$E2E_SOURCE_HOST" "default source host"
+assert_eq "repl" "$E2E_SOURCE_USER" "default source user"
+assert_eq "replpass" "$E2E_SOURCE_PASS" "default source password"
+assert_eq "meta:metapass@tcp(127.0.0.1:13316)/binlog_meta?parseTime=true" "$(e2e_meta_dsn direct)" "direct metadata DSN"
+assert_eq "meta:metapass@tcp(127.0.0.1:16036)/binlog_meta?parseTime=true" "$(e2e_meta_dsn failover)" "failover metadata DSN"
+
+port_vars=(
+  E2E_MYSQL57_PORT E2E_MYSQL80_PORT E2E_PERCONA57_PORT E2E_PERCONA80_PORT
+  E2E_META_PRIMARY_PORT E2E_META_REPLICA_PORT
+  E2E_META_PROXYSQL_ADMIN_PORT E2E_META_PROXYSQL_PORT
+)
+for name in "${port_vars[@]}"; do
+  assert_eq "${!name}" "$(compose_default "$name")" "$name Compose fallback"
+done
+
+override_dsn="$(
+  E2E_META_HOST=db.example E2E_META_USER=user E2E_META_PASS=pass E2E_META_DB=custom \
+  E2E_META_PRIMARY_PORT=23016 bash -c 'source "$1"; e2e_meta_dsn direct' _ "$TOPOLOGY_LIB"
+)"
+assert_eq "user:pass@tcp(db.example:23016)/custom?parseTime=true" "$override_dsn" "component override"
+
+full_dsn="custom:secret@tcp(metadata.example:3306)/custom?parseTime=true"
+actual_dsn="$(E2E_META_DSN="$full_dsn" bash -c 'source "$1"; e2e_meta_dsn failover' _ "$TOPOLOGY_LIB")"
+assert_eq "$full_dsn" "$actual_dsn" "full DSN precedence"
+
+for bad_port in 0 65536 abc; do
+  if E2E_MYSQL57_PORT="$bad_port" bash -c 'source "$1"' _ "$TOPOLOGY_LIB" >/dev/null 2>&1; then
+    fail "invalid port accepted: $bad_port"
+  fi
+done
+if E2E_SOURCE_HOST= bash -c 'source "$1"' _ "$TOPOLOGY_LIB" >/dev/null 2>&1; then
+  fail "empty required value accepted"
+fi
+if bash -c 'source "$1"; e2e_meta_dsn unknown' _ "$TOPOLOGY_LIB" >/dev/null 2>&1; then
+  fail "unknown metadata topology accepted"
+fi
+
+echo "[topology-contract] PASS"

--- a/scripts/e2e/up.sh
+++ b/scripts/e2e/up.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# input: local tooling (docker/curl/jq/go) and e2e environment/service dependencies
+# input: Docker and the canonical E2E database topology
 # output: four source databases plus an isolated metadata database ready for e2e scenarios
 # pos: integration-test automation layer validating end-to-end system behavior
 # note: if this file changes, update this header and module README.md.
@@ -7,6 +7,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
 
 # 这里只拉起 source MySQL 和独立 metadata MySQL，避免启动 orchestrator 等按需服务。
 services=(mysql57 mysql80 percona57 percona80 meta-primary)


### PR DESCRIPTION
## Summary
- centralize E2E database topology defaults and overrides
- migrate Compose and scenario consumers to the topology module
- add a no-Docker topology contract check

## Verification
- `make e2e-topology-check`
- `bash -n scripts/e2e/*.sh`
- `docker compose config` with `E2E_MYSQL57_PORT=23306`
- `go test ./...`
- `go vet ./...`
- `E2E_MYSQL57_PORT=23306 make e2e-quick`
- three-level documentation checker

Closes #18