### PR TITLE
refactor: centralize task lifecycle transitions

### DIFF
--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -4,6 +4,7 @@
 - `scheduler.go`: 调度器核心类型、选项注入与通用辅助函数。
 - `scheduler_task_ops.go`: 任务 CRUD 与配置更新（含整包 CreateTaskFromSpec）。
 - `scheduler_lifecycle.go`: 启停、运行协程、重试退避与不可恢复 FAILED。
+- `scheduler_transitions.go`: 私有生命周期转换规则（状态、事件、错误、ownership 与持久化）。
 - `errors.go`: 永久错误类型（1045 / log_bin off / 身份不可用）。
 - `scheduler_cluster_lease.go`: cluster lease 续租与降级/失租处理。
 - `scheduler_observability.go`: 复制进度、checkpoint、事件/文件/运行历史查询。
@@ -23,6 +24,7 @@
 - `WithMetadataSourceEndpoint`：注入 metadata TCP 端点，并在任务 create/update/start 时拒绝同端点 source。
 - Stop 路径 lease release 使用独立超时上下文（不复用已取消 runner ctx）。
 - cluster fail-safe stop 一旦进入 `STOPPING/STOPPED`，会拒绝后续正常复制进度上报，避免失租后继续暴露健康运行态进度。
+- runner/lease 的自动转换保持 best-effort 持久化语义，并统一记录持久化失败日志。
 
 ## Dependencies
 - Upstream: `internal/api`, `internal/app`。

--- a/internal/tasks/runner_test.go
+++ b/internal/tasks/runner_test.go
@@ -1,7 +1,7 @@
 // Package tasks provides module-level functionality for tasks.
-// input: task commands/events, runner callbacks, store/lease/uploader dependencies
-// output: task state transitions, scheduling decisions, and execution coordination
-// pos: core domain orchestration layer governing backup task lifecycle and policies
+// input: task commands/events, retryable/permanent runner callbacks, store/lease/uploader dependencies
+// output: runner invocation, retry, readiness, stop, and permanent-failure assertions
+// pos: public Scheduler seam tests for runner-driven task lifecycle behavior
 // note: if this file changes, update this header and module README.md.
 package tasks
 
@@ -31,6 +31,25 @@ type failOnceRunner struct {
 	mu              sync.Mutex
 	calls           int
 	secondRunNotify chan struct{}
+}
+
+type permanentFailureRunner struct {
+	mu    sync.Mutex
+	calls int
+}
+
+// Run returns an unrecoverable source error.
+func (r *permanentFailureRunner) Run(context.Context, Task) error {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	return NewPermanentError(CodeSourceAccessDenied, "denied")
+}
+
+func (r *permanentFailureRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
 }
 
 // Run 实现对应功能逻辑。
@@ -249,6 +268,64 @@ func TestScheduler_AutoRetryAfterRunnerError(t *testing.T) {
 
 	if err := s.StopTask(task.ID); err != nil {
 		t.Fatalf("StopTask returned error: %v", err)
+	}
+}
+
+// TestScheduler_PermanentRunnerErrorTransitionsToFailed verifies that permanent
+// runner errors stop the retry loop and retain the operator-facing reason.
+func TestScheduler_PermanentRunnerErrorTransitionsToFailed(t *testing.T) {
+	runner := &permanentFailureRunner{}
+	s := NewScheduler(WithRunner(runner))
+
+	task, err := s.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	if err := s.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask returned error: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, err := s.GetTask(task.ID)
+		if err != nil {
+			t.Fatalf("GetTask returned error: %v", err)
+		}
+		if got.State == StateFailed {
+			if got.LastError != "SOURCE_ACCESS_DENIED: denied" {
+				t.Fatalf("expected permanent error detail, got %q", got.LastError)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected state %s, got %s", StateFailed, got.State)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	events, err := s.ListEvents(task.ID, 0)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	var runnerErrorIndex, failedIndex = -1, -1
+	for i, event := range events {
+		switch event.Type {
+		case "TASK_RUNNER_ERROR":
+			runnerErrorIndex = i
+		case "TASK_FAILED":
+			failedIndex = i
+		case "TASK_RETRY_BACKOFF":
+			t.Fatal("permanent runner error must not enter retry backoff")
+		}
+	}
+	if runnerErrorIndex < 0 || failedIndex != runnerErrorIndex+1 {
+		t.Fatalf("expected TASK_RUNNER_ERROR immediately followed by TASK_FAILED, got %#v", events)
+	}
+	if calls := runner.callCount(); calls != 1 {
+		t.Fatalf("expected runner called once, got %d", calls)
 	}
 }
 

--- a/internal/tasks/scheduler_cluster_lease.go
+++ b/internal/tasks/scheduler_cluster_lease.go
@@ -1,7 +1,7 @@
 // Package tasks provides module-level functionality for tasks.
 // input: lease renew ticks and lease manager renew responses/errors
-// output: lease-degraded/lost state transitions and fail-safe stop triggers
-// pos: scheduler cluster lease-maintenance loop separated from generic lifecycle flow
+// output: lease renewal decisions delegated to centralized lifecycle transitions
+// pos: scheduler cluster lease-maintenance loop separated from transition recipes
 // note: if this file changes, update this header and module README.md.
 package tasks
 
@@ -18,7 +18,7 @@ func (s *Scheduler) renewLeaseLoop(ctx context.Context, id, workerID string, epo
 		if r := recover(); r != nil {
 			log.Printf("lease renew loop panic task=%s worker=%s epoch=%d panic=%v stack=%s", id, workerID, epoch, r, debug.Stack())
 			s.mu.Lock()
-			s.failSafeStopLocked(id, "TASK_LEASE_RENEW_PANIC", fmt.Sprintf("lease renew loop panic: %v", r))
+			logTransitionPersistError(id, StateStopping, s.failSafeStopLocked(id, "TASK_LEASE_RENEW_PANIC", fmt.Sprintf("lease renew loop panic: %v", r)))
 			s.mu.Unlock()
 		}
 	}()
@@ -43,15 +43,7 @@ func (s *Scheduler) renewLeaseLoop(ctx context.Context, id, workerID string, epo
 				// 从降级状态恢复后，清空降级计时并收敛回 RUNNING。
 				degradedSince = time.Time{}
 				s.mu.Lock()
-				task, exists := s.tasks[id]
-				if exists && task.State == StateLeaseDegraded {
-					task.State = StateRunning
-					task.LastError = ""
-					task.UpdatedAt = time.Now()
-					s.tasks[id] = task
-					s.appendEventLocked(id, "TASK_LEASE_RENEWED", "lease renewed", "")
-					_ = s.persistTaskLocked(task)
-				}
+				logTransitionPersistError(id, StateRunning, s.markLeaseRenewedLocked(id))
 				s.mu.Unlock()
 			}
 			continue
@@ -60,7 +52,7 @@ func (s *Scheduler) renewLeaseLoop(ctx context.Context, id, workerID string, epo
 		if err == nil && !ok {
 			// lease 被抢占/丢失：立刻 fail-safe stop，避免双写同一任务。
 			s.mu.Lock()
-			s.failSafeStopLocked(id, "TASK_LEASE_LOST", "lease lost")
+			logTransitionPersistError(id, StateStopping, s.failSafeStopLocked(id, "TASK_LEASE_LOST", "lease lost"))
 			s.mu.Unlock()
 			return
 		}
@@ -68,17 +60,7 @@ func (s *Scheduler) renewLeaseLoop(ctx context.Context, id, workerID string, epo
 		// Step 2: 续租报错进入 LEASE_DEGRADED，并开始 grace 计时。
 		now := time.Now()
 		s.mu.Lock()
-		task, exists := s.tasks[id]
-		if exists && task.State != StateStopping && task.State != StateStopped {
-			if task.State != StateLeaseDegraded {
-				task.State = StateLeaseDegraded
-				s.appendEventLocked(id, "TASK_LEASE_DEGRADED", "lease renew failed", err.Error())
-			}
-			task.LastError = err.Error()
-			task.UpdatedAt = now
-			s.tasks[id] = task
-			_ = s.persistTaskLocked(task)
-		}
+		logTransitionPersistError(id, StateLeaseDegraded, s.markLeaseDegradedLocked(id, err.Error(), now))
 		s.mu.Unlock()
 
 		if degradedSince.IsZero() {
@@ -88,7 +70,7 @@ func (s *Scheduler) renewLeaseLoop(ctx context.Context, id, workerID string, epo
 		if now.Sub(degradedSince) >= s.leaseGrace {
 			// 超过 grace 仍无法续租，必须停止，优先保证文件语义与单执行安全。
 			s.mu.Lock()
-			s.failSafeStopLocked(id, "TASK_LEASE_GRACE_EXCEEDED", "lease renew grace exceeded")
+			logTransitionPersistError(id, StateStopping, s.failSafeStopLocked(id, "TASK_LEASE_GRACE_EXCEEDED", "lease renew grace exceeded"))
 			s.mu.Unlock()
 			return
 		}

--- a/internal/tasks/scheduler_lifecycle.go
+++ b/internal/tasks/scheduler_lifecycle.go
@@ -1,7 +1,7 @@
 // Package tasks provides module-level functionality for tasks.
 // input: start/stop commands, metadata source policy, runner callbacks, permanent/retryable errors, cancellation signals
-// output: guarded task state transitions across STARTING/RUNNING/RETRY/FAILED/STOPPING lifecycle
-// pos: scheduler execution lifecycle orchestration excluding lease-renew loop details
+// output: guarded start/stop, runner retry, and cancellation orchestration
+// pos: scheduler execution loop delegating state mutations to scheduler_transitions.go
 // note: if this file changes, update this header and module README.md.
 package tasks
 
@@ -52,15 +52,7 @@ func (s *Scheduler) StartTask(id string) error {
 			s.mu.Unlock()
 			return ErrRunnerNotConfigured
 		}
-		task.State = StateStarting
-		task.LastError = ""
-		task.OwnerWorkerID = ""
-		task.Epoch = 0
-		task.RunID = ""
-		task.UpdatedAt = time.Now()
-		s.tasks[id] = task
-		s.appendEventLocked(id, "TASK_START_DISPATCHED", "task start dispatched to worker", "")
-		if err := s.persistTaskLocked(task); err != nil {
+		if err := s.markStartDispatchedLocked(task); err != nil {
 			s.mu.Unlock()
 			return err
 		}
@@ -90,13 +82,8 @@ func (s *Scheduler) StartTask(id string) error {
 		task.RunID = fmt.Sprintf("%s-%d", id, time.Now().UnixNano())
 	}
 
-	task.State = StateStarting
-	task.LastError = ""
-	task.UpdatedAt = time.Now()
 	// 注意：这里仅表示“已发起启动流程”，不是“runner 已 ready”。
-	s.tasks[id] = task
-	s.appendEventLocked(id, "TASK_STARTED", "task started", "")
-	if err := s.persistTaskLocked(task); err != nil {
+	if err := s.markStartingLocked(task); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -199,15 +186,7 @@ func (s *Scheduler) MarkRetryableError(id, msg string) error {
 		return fmt.Errorf("cannot mark retryable error from state %s", task.State)
 	}
 
-	task.State = StateRetryBackoff
-	task.LastError = msg
-	task.UpdatedAt = time.Now()
-	s.tasks[id] = task
-	s.appendEventLocked(id, "TASK_RETRY_BACKOFF", "task entered retry backoff", msg)
-	if err := s.persistTaskLocked(task); err != nil {
-		return err
-	}
-	return nil
+	return s.markRetryBackoffLocked(task, msg)
 }
 
 // StopTask 请求停止任务（两阶段：STOPPING -> STOPPED）。
@@ -230,15 +209,11 @@ func (s *Scheduler) StopTask(id string) error {
 		delete(s.cancels, id)
 	}
 
-	task.State = StateStopping
-	task.UpdatedAt = time.Now()
-	s.tasks[id] = task
 	// 常见误解：
 	// “调用 StopTask 后应立刻看到 STOPPED”并不成立。这里先写 STOPPING，
 	// 只有 run goroutine 真正退出后才会转为 STOPPED，确保状态语义等于“执行已结束”。
 	// 两阶段停止：先对外可见 STOPPING，再等待 run goroutine defer 收敛到 STOPPED。
-	s.appendEventLocked(id, "TASK_STOPPING", "task stopping", "")
-	if err := s.persistTaskLocked(task); err != nil {
+	if err := s.markStoppingLocked(task); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -269,7 +244,7 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 		// 收到 stop 请求后，直到执行 goroutine 真退出才收敛到 STOPPED。
 		// 这样 API 层的 STOPPED 表示“执行路径已结束”，而不是“仅发出停止请求”。
 		if currentTask, ok := s.tasks[id]; ok && currentTask.State == StateStopping {
-			_ = s.markStoppedLocked(id)
+			logTransitionPersistError(id, StateStopped, s.markStoppedLocked(id))
 			if s.leaseManager != nil && currentTask.OwnerWorkerID != "" && currentTask.Epoch > 0 {
 				releaseOwner = currentTask.OwnerWorkerID
 				releaseEpoch = currentTask.Epoch
@@ -314,17 +289,12 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 		zap.L().Error("runner error", zap.String("task_id", id), zap.Error(err))
 		s.appendEventLocked(id, "TASK_RUNNER_ERROR", "runner error", errMsg)
 		if IsPermanent(err) {
-			_ = s.markFailedLocked(id, errMsg)
+			logTransitionPersistError(id, StateFailed, s.markFailedLocked(id, errMsg))
 			s.mu.Unlock()
 			return
 		}
 
-		current.State = StateRetryBackoff
-		current.LastError = errMsg
-		current.UpdatedAt = time.Now()
-		s.tasks[id] = current
-		s.appendEventLocked(id, "TASK_RETRY_BACKOFF", "task entered retry backoff", errMsg)
-		_ = s.persistTaskLocked(current)
+		logTransitionPersistError(id, StateRetryBackoff, s.markRetryBackoffLocked(current, errMsg))
 		s.mu.Unlock()
 
 		// Step 2: 指数退避等待，避免瞬时故障导致热重试风暴。
@@ -350,12 +320,8 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 			return
 		}
 		// Step 3: 重试前先回到 STARTING，等待下一轮 runner ready 回调。
-		current.State = StateStarting
-		current.UpdatedAt = time.Now()
-		s.tasks[id] = current
 		// 重试前先回到 STARTING，等 runner onReady 后再切 RUNNING。
-		s.appendEventLocked(id, "TASK_RETRYING", "retrying runner", "")
-		_ = s.persistTaskLocked(current)
+		logTransitionPersistError(id, StateStarting, s.markRetryingLocked(&current))
 		task = current
 		s.mu.Unlock()
 	}
@@ -368,23 +334,7 @@ func (s *Scheduler) runRunner(ctx context.Context, id string, task Task) error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		current, ok := s.tasks[id]
-		if !ok {
-			return
-		}
-		if current.State == StateStopped || current.State == StateStopping {
-			return
-		}
-		if current.State == StateRunning {
-			return
-		}
-
-		current.State = StateRunning
-		current.LastError = ""
-		current.UpdatedAt = time.Now()
-		s.tasks[id] = current
-		s.appendEventLocked(id, "TASK_RUNNING", "runner is running", "")
-		_ = s.persistTaskLocked(current)
+		logTransitionPersistError(id, StateRunning, s.markRunnerReadyLocked(id))
 	}
 
 	if n, ok := s.runner.(runnerWithNotify); ok {
@@ -396,76 +346,6 @@ func (s *Scheduler) runRunner(ctx context.Context, id string, task Task) error {
 	// 该路径可能出现“短暂 RUNNING 后立即失败”；失败会在 runTask 的错误分支回收状态。
 	onReady()
 	return s.runner.Run(ctx, task)
-}
-
-// renewLeaseLoop 在 cluster 模式下周期续租，并处理降级/失租停机。
-
-func (s *Scheduler) failSafeStopLocked(id, eventType, message string) {
-	task, ok := s.tasks[id]
-	if !ok {
-		return
-	}
-	if task.State == StateStopping || task.State == StateStopped {
-		return
-	}
-	task.State = StateStopping
-	task.LastError = message
-	task.UpdatedAt = time.Now()
-	s.tasks[id] = task
-	s.appendEventLocked(id, eventType, message, "")
-	_ = s.persistTaskLocked(task)
-	if cancel, ok := s.cancels[id]; ok {
-		// 这里只发取消信号；最终 STOPPED 由 runTask defer 统一收敛。
-		cancel()
-		delete(s.cancels, id)
-	}
-}
-
-// markFailedLocked 将任务收敛到 FAILED，用于不可恢复的源库/配置错误。
-// StartTask 允许从 FAILED 再次启动，方便值班改完密码/配置后重试。
-func (s *Scheduler) markFailedLocked(id, message string) error {
-	task, ok := s.tasks[id]
-	if !ok {
-		return nil
-	}
-	if task.State == StateFailed {
-		task.LastError = message
-		s.tasks[id] = task
-		return s.persistTaskLocked(task)
-	}
-	task.State = StateFailed
-	task.LastError = message
-	task.OwnerWorkerID = ""
-	task.Epoch = 0
-	task.RunID = ""
-	task.UpdatedAt = time.Now()
-	s.tasks[id] = task
-	s.appendEventLocked(id, "TASK_FAILED", "task failed", message)
-	if cancel, ok := s.cancels[id]; ok {
-		cancel()
-		delete(s.cancels, id)
-	}
-	return s.persistTaskLocked(task)
-}
-
-// markStoppedLocked 将任务收敛到最终 STOPPED 并清理运行时 ownership 字段。
-func (s *Scheduler) markStoppedLocked(id string) error {
-	task, ok := s.tasks[id]
-	if !ok {
-		return nil
-	}
-	if task.State == StateStopped {
-		return nil
-	}
-	task.State = StateStopped
-	// STOPPED 是“无执行归属”的稳定终态，清空运行时 ownership 字段。
-	task.OwnerWorkerID = ""
-	task.Epoch = 0
-	task.RunID = ""
-	task.UpdatedAt = time.Now()
-	s.tasks[id] = task
-	s.appendEventLocked(id, "TASK_STOPPED", "task stopped", "")
-	return s.persistTaskLocked(task)
 }
 
 // isClosed 判断 channel 是否已关闭（nil 视为已关闭）。

--- a/internal/tasks/scheduler_transitions.go
+++ b/internal/tasks/scheduler_transitions.go
@@ -1,0 +1,167 @@
+// Package tasks provides module-level functionality for tasks.
+// input: locked task snapshots plus runner and lease lifecycle signals
+// output: private state/event/persistence transitions plus best-effort persistence failure logs
+// pos: centralized lifecycle transition recipes shared by scheduler orchestration loops
+// note: if this file changes, update this header and module README.md.
+package tasks
+
+import (
+	"log"
+	"time"
+)
+
+func (s *Scheduler) markStartDispatchedLocked(task Task) error {
+	task.State = StateStarting
+	task.LastError = ""
+	task.OwnerWorkerID = ""
+	task.Epoch = 0
+	task.RunID = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[task.ID] = task
+	s.appendEventLocked(task.ID, "TASK_START_DISPATCHED", "task start dispatched to worker", "")
+	return s.persistTaskLocked(task)
+}
+
+func (s *Scheduler) markStartingLocked(task Task) error {
+	task.State = StateStarting
+	task.LastError = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[task.ID] = task
+	s.appendEventLocked(task.ID, "TASK_STARTED", "task started", "")
+	return s.persistTaskLocked(task)
+}
+
+func (s *Scheduler) markRetryBackoffLocked(task Task, message string) error {
+	task.State = StateRetryBackoff
+	task.LastError = message
+	task.UpdatedAt = time.Now()
+	s.tasks[task.ID] = task
+	s.appendEventLocked(task.ID, "TASK_RETRY_BACKOFF", "task entered retry backoff", message)
+	return s.persistTaskLocked(task)
+}
+
+func (s *Scheduler) markRetryingLocked(task *Task) error {
+	task.State = StateStarting
+	task.UpdatedAt = time.Now()
+	s.tasks[task.ID] = *task
+	s.appendEventLocked(task.ID, "TASK_RETRYING", "retrying runner", "")
+	return s.persistTaskLocked(*task)
+}
+
+func (s *Scheduler) markRunnerReadyLocked(id string) error {
+	task, ok := s.tasks[id]
+	if !ok || task.State == StateStopped || task.State == StateStopping || task.State == StateRunning {
+		return nil
+	}
+	task.State = StateRunning
+	task.LastError = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[id] = task
+	s.appendEventLocked(id, "TASK_RUNNING", "runner is running", "")
+	return s.persistTaskLocked(task)
+}
+
+func (s *Scheduler) markStoppingLocked(task Task) error {
+	task.State = StateStopping
+	task.UpdatedAt = time.Now()
+	s.tasks[task.ID] = task
+	s.appendEventLocked(task.ID, "TASK_STOPPING", "task stopping", "")
+	return s.persistTaskLocked(task)
+}
+
+func (s *Scheduler) markLeaseDegradedLocked(id, message string, now time.Time) error {
+	task, ok := s.tasks[id]
+	if !ok || task.State == StateStopping || task.State == StateStopped {
+		return nil
+	}
+	if task.State != StateLeaseDegraded {
+		task.State = StateLeaseDegraded
+		s.appendEventLocked(id, "TASK_LEASE_DEGRADED", "lease renew failed", message)
+	}
+	task.LastError = message
+	task.UpdatedAt = now
+	s.tasks[id] = task
+	return s.persistTaskLocked(task)
+}
+
+func (s *Scheduler) markLeaseRenewedLocked(id string) error {
+	task, ok := s.tasks[id]
+	if !ok || task.State != StateLeaseDegraded {
+		return nil
+	}
+	task.State = StateRunning
+	task.LastError = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[id] = task
+	s.appendEventLocked(id, "TASK_LEASE_RENEWED", "lease renewed", "")
+	return s.persistTaskLocked(task)
+}
+
+func (s *Scheduler) failSafeStopLocked(id, eventType, message string) error {
+	task, ok := s.tasks[id]
+	if !ok || task.State == StateStopping || task.State == StateStopped {
+		return nil
+	}
+	task.State = StateStopping
+	task.LastError = message
+	task.UpdatedAt = time.Now()
+	s.tasks[id] = task
+	s.appendEventLocked(id, eventType, message, "")
+	err := s.persistTaskLocked(task)
+	if cancel, ok := s.cancels[id]; ok {
+		// 这里只发取消信号；最终 STOPPED 由 runTask defer 统一收敛。
+		cancel()
+		delete(s.cancels, id)
+	}
+	return err
+}
+
+func logTransitionPersistError(id string, state State, err error) {
+	if err != nil {
+		log.Printf("persist task transition failed task=%s state=%s err=%v", id, state, err)
+	}
+}
+
+// markFailedLocked 将任务收敛到 FAILED，用于不可恢复的源库/配置错误。
+// StartTask 允许从 FAILED 再次启动，方便值班改完密码/配置后重试。
+func (s *Scheduler) markFailedLocked(id, message string) error {
+	task, ok := s.tasks[id]
+	if !ok {
+		return nil
+	}
+	if task.State == StateFailed {
+		task.LastError = message
+		s.tasks[id] = task
+		return s.persistTaskLocked(task)
+	}
+	task.State = StateFailed
+	task.LastError = message
+	task.OwnerWorkerID = ""
+	task.Epoch = 0
+	task.RunID = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[id] = task
+	s.appendEventLocked(id, "TASK_FAILED", "task failed", message)
+	if cancel, ok := s.cancels[id]; ok {
+		cancel()
+		delete(s.cancels, id)
+	}
+	return s.persistTaskLocked(task)
+}
+
+// markStoppedLocked 将任务收敛到最终 STOPPED 并清理运行时 ownership 字段。
+func (s *Scheduler) markStoppedLocked(id string) error {
+	task, ok := s.tasks[id]
+	if !ok || task.State == StateStopped {
+		return nil
+	}
+	task.State = StateStopped
+	// STOPPED 是“无执行归属”的稳定终态，清空运行时 ownership 字段。
+	task.OwnerWorkerID = ""
+	task.Epoch = 0
+	task.RunID = ""
+	task.UpdatedAt = time.Now()
+	s.tasks[id] = task
+	s.appendEventLocked(id, "TASK_STOPPED", "task stopped", "")
+	return s.persistTaskLocked(task)
+}


### PR DESCRIPTION
## Summary
- centralize private task lifecycle transition logic while preserving public Scheduler, Runner, LeaseManager, TaskStore, and EventStore APIs
- add a regression test for permanent runner errors transitioning to FAILED
- preserve existing event ordering, retry timing, lease-loss behavior, and persistence semantics

## Verification
- `go test ./...`
- `go test -race ./internal/tasks ./internal/api ./internal/replication ./internal/app`
- `go vet ./...`
- three-level documentation check
- `make e2e-quick` with topology ports 14306-14317, 6136, 17036