### PR TITLE
fix: guard loopback metadata source aliases (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This is the shortest path for release operators. You do not need Go installed.
 - A release tarball for your platform from GitHub Releases
 - A reachable MySQL or MariaDB instance with `log_bin` enabled
 
-> **Metadata isolation is mandatory:** when `meta_dsn` is configured, its MySQL instance must be separate from every replication source and must never be added to the backup task set. The server rejects an exact matching TCP `host:port`; aliases and proxies still require operator isolation.
+> **Metadata isolation is mandatory:** when `meta_dsn` is configured, its MySQL instance must be separate from every replication source and must never be added to the backup task set. The server rejects an exact matching TCP `host:port` and treats `localhost` plus explicit loopback literals (`127/8` and `::1`, including bracketed IPv6) as the same endpoint class; other aliases and proxies still require operator isolation.
 
 ### 1. Download, verify, extract, run
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -89,7 +89,7 @@ binlog-server_0.4.2_linux_amd64/
 - GitHub Releases 上对应平台的 tarball
 - 一台已开启 `log_bin` 的 MySQL 或 MariaDB
 
-> **metadata 必须隔离：** 配置 `meta_dsn` 时，它必须使用独立 MySQL 实例，且绝不能加入 binlog 备份任务集。服务会拒绝 TCP `host:port` 完全相同的 source；别名和代理场景仍需由运维保证实例隔离。
+> **metadata 必须隔离：** 配置 `meta_dsn` 时，它必须使用独立 MySQL 实例，且绝不能加入 binlog 备份任务集。服务会拒绝 TCP `host:port` 完全相同的 source，并将 `localhost` 与显式 loopback literal（`127/8`、`::1`，包括带括号的 IPv6）视为同一端点类别；其他别名和代理场景仍需由运维保证实例隔离。
 
 ### 1. 下载、校验、解压、运行
 

--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -8,7 +8,7 @@
 | `rate_limiter.go` | 基于 IP 的令牌桶限流器 |
 | `metrics_prometheus.go` | `/metrics` 采集与输出（基于 `prometheus/client_golang`） |
 | `tracing.go` | HTTP 入站 tracing middleware（OTel span） |
-| `handlers_tasks.go` | 任务相关 API 处理（CRUD、启动停止、checkpoint 等） |
+| `handlers_tasks.go` | 任务相关 API 处理（CRUD、启动停止、checkpoint、loopback-aware source lookup 等） |
 | `handlers_cluster.go` | 集群观测与控制相关 API（workers、overview） |
 | `swagger_docs_only.go` | swagger 注释占位 |
 
@@ -27,6 +27,7 @@
 ## Features
 - 认证：支持 Bearer Token 或 API Key；`/healthz` 默认匿名，`/metrics` 与 `/api/*` 可配置保护
 - 创建任务：`CreateTaskFromSpec` 整包校验通过后才落库；400 返回 JSON `{"error","code"}`
+- source lookup：`GET /api/sources/lookup` 使用 tasks 共享 loopback 分类归并 localhost 与显式 loopback literal，端口仍严格匹配；非 loopback host 保持修剪后的原文精确匹配且不做 DNS 解析。
 - 健康检查：`GET /healthz` 文本 `ok`；`GET /api/health` JSON `{"status":"ok"}`
 - 文件观测：`GET /api/tasks/{id}/files` 返回当前 `OPEN` segment 与历史 `SEALED` 文件。
 - 限流：基于 IP 的令牌桶限流，默认 100 req/s，burst 200

--- a/internal/api/handlers_tasks.go
+++ b/internal/api/handlers_tasks.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
-// input: HTTP requests, router params, scheduler/task service interfaces
-// output: REST API JSON responses including structured 400 bodies for create validation
+// input: HTTP requests, router params, scheduler/task service interfaces, shared source endpoint identity
+// output: REST API JSON responses including loopback-equivalent source lookup and structured 400 bodies
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -150,7 +150,7 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 // @Summary Lookup tasks by source host and port
 // @Tags Dashboard
 // @Produce json
-// @Param host query string true "MySQL source host (required)"
+// @Param host query string true "MySQL source host (required); localhost and explicit loopback literals (127/8, ::1, including bracketed IPv6) share one identity, other hosts match exact spelling"
 // @Param port query int true "MySQL source port (required, 1-65535)"
 // @Success 200 {object} sourceLookupResponse
 // @Failure 400 {string} string
@@ -184,7 +184,9 @@ func (s *Server) handleSourceLookup(w http.ResponseWriter, r *http.Request) {
 		TaskIDs: []string{},
 	}
 	for _, task := range s.tasks.ListTasks() {
-		if task.Source.Host != host || task.Source.Port != port {
+		sameHost := task.Source.Host == host ||
+			(tasks.IsLoopbackHost(task.Source.Host) && tasks.IsLoopbackHost(host))
+		if !sameHost || task.Source.Port != port {
 			continue
 		}
 		resp.TaskIDs = append(resp.TaskIDs, task.ID)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
-// input: HTTP requests, router params, scheduler/task service interfaces
-// output: REST API responses and status codes for task/cluster operations
+// input: HTTP requests, router params, scheduler/task service interfaces, shared source endpoint identity
+// output: REST API responses and regression coverage for task/cluster operations and source lookup
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -1854,6 +1854,82 @@ func TestAPI_SourceLookup(t *testing.T) {
 	}
 	if int(notFoundBody["count"].(float64)) != 0 {
 		t.Fatalf("expected count=0, got %v", notFoundBody["count"])
+	}
+}
+
+func TestAPI_SourceLookupUsesLoopbackEndpointIdentity(t *testing.T) {
+	scheduler := tasks.NewScheduler()
+	handler := NewServer(scheduler)
+
+	sources := []struct {
+		name string
+		host string
+		port uint16
+	}{
+		{name: "localhost", host: "localhost", port: 3306},
+		{name: "ipv4 loopback", host: "127.255.255.255", port: 3306},
+		{name: "ipv6 loopback", host: "::1", port: 3306},
+		{name: "loopback different port", host: "127.0.0.3", port: 3307},
+		{name: "non-loopback primary", host: "db-primary.example", port: 3306},
+		{name: "non-loopback secondary", host: "db-secondary.example", port: 3306},
+		{name: "non-loopback bracketed ipv6", host: "[2001:db8::1]", port: 3306},
+	}
+	for _, source := range sources {
+		task, err := scheduler.CreateTask(source.name, strings.ReplaceAll(source.name, " ", "-"))
+		if err != nil {
+			t.Fatalf("CreateTask %q returned error: %v", source.name, err)
+		}
+		if err := scheduler.ConfigureSource(task.ID, tasks.SourceConfig{Host: source.host, Port: source.port, User: "repl"}); err != nil {
+			t.Fatalf("ConfigureSource %q returned error: %v", source.name, err)
+		}
+	}
+
+	lookup := func(t *testing.T, host string, port uint16) (bool, int, string) {
+		t.Helper()
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/sources/lookup?host=%s&port=%d", host, port), nil)
+		handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("lookup %s:%d returned %d body=%s", host, port, resp.Code, resp.Body.String())
+		}
+		var body struct {
+			Exists  bool     `json:"exists"`
+			Count   int      `json:"count"`
+			TaskIDs []string `json:"task_ids"`
+		}
+		if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode lookup %s:%d response: %v", host, port, err)
+		}
+		return body.Exists, body.Count, strings.Join(body.TaskIDs, ",")
+	}
+
+	cases := []struct {
+		name     string
+		host     string
+		port     uint16
+		wantIDs  string
+		wantSize int
+	}{
+		{name: "ipv4 loopback identity", host: "127.0.0.1", port: 3306, wantIDs: "1,2,3", wantSize: 3},
+		{name: "uppercase localhost", host: "LOCALHOST", port: 3306, wantIDs: "1,2,3", wantSize: 3},
+		{name: "trailing dot localhost", host: "localhost.", port: 3306, wantIDs: "1,2,3", wantSize: 3},
+		{name: "bracketed ipv6 identity", host: "[::1]", port: 3306, wantIDs: "1,2,3", wantSize: 3},
+		{name: "different port succeeds", host: "localhost", port: 3307, wantIDs: "4", wantSize: 1},
+		{name: "port mismatch", host: "localhost", port: 3308, wantIDs: "", wantSize: 0},
+		{name: "non-loopback exact host", host: "db-primary.example", port: 3306, wantIDs: "5", wantSize: 1},
+		{name: "non-loopback case remains exact", host: "DB-PRIMARY.EXAMPLE", port: 3306, wantIDs: "", wantSize: 0},
+		{name: "non-loopback trailing dot remains exact", host: "db-primary.example.", port: 3306, wantIDs: "", wantSize: 0},
+		{name: "non-loopback different host", host: "db-unknown.example", port: 3306, wantIDs: "", wantSize: 0},
+		{name: "non-loopback bracketed ipv6 exact", host: "[2001:db8::1]", port: 3306, wantIDs: "7", wantSize: 1},
+		{name: "non-loopback ipv6 brackets remain exact", host: "2001:db8::1", port: 3306, wantIDs: "", wantSize: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists, count, taskIDs := lookup(t, tc.host, tc.port)
+			if exists != (tc.wantSize > 0) || count != tc.wantSize || taskIDs != tc.wantIDs {
+				t.Fatalf("lookup %s:%d got exists=%v count=%d task_ids=%q, want exists=%v count=%d task_ids=%q", tc.host, tc.port, exists, count, taskIDs, tc.wantSize > 0, tc.wantSize, tc.wantIDs)
+			}
+		})
 	}
 }
 

--- a/internal/swaggerdocs/README.md
+++ b/internal/swaggerdocs/README.md
@@ -6,6 +6,7 @@
 
 ## Exports
 - swagger 文档元数据供 API 文档页面消费，`BinlogFile` 包含 `OPEN/SEALED` state。
+- `/api/sources/lookup` 文档说明 localhost 与显式 loopback literal 共用 host identity，其他 host 按原文字面匹配。
 
 ## Dependencies
 - Upstream: `internal/api` 注释与接口定义。

--- a/internal/swaggerdocs/docs.go
+++ b/internal/swaggerdocs/docs.go
@@ -101,7 +101,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "MySQL source host",
+                        "description": "MySQL source host (required); localhost and explicit loopback literals (127/8, ::1, including bracketed IPv6) share one identity, other hosts match exact spelling",
                         "name": "host",
                         "in": "query",
                         "required": true

--- a/internal/swaggerdocs/swagger.json
+++ b/internal/swaggerdocs/swagger.json
@@ -90,7 +90,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "MySQL source host",
+                        "description": "MySQL source host (required); localhost and explicit loopback literals (127/8, ::1, including bracketed IPv6) share one identity, other hosts match exact spelling",
                         "name": "host",
                         "in": "query",
                         "required": true

--- a/internal/swaggerdocs/swagger.yaml
+++ b/internal/swaggerdocs/swagger.yaml
@@ -438,7 +438,9 @@ paths:
   /api/sources/lookup:
     get:
       parameters:
-      - description: MySQL source host
+      - description: MySQL source host (required); localhost and explicit loopback
+          literals (127/8, ::1, including bracketed IPv6) share one identity, other
+          hosts match exact spelling
         in: query
         name: host
         required: true

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -11,7 +11,7 @@
 - `scheduler_retry_upload.go`: 上传失败补偿重试与失败原因聚合。
 - `model.go`: 任务领域模型与状态定义。
 - 各 `*_test.go`: 状态机、租约、上传重试、事件等测试。
-- `source_guard_test.go`: metadata/source 同端点拒绝策略的公开任务接口回归测试。
+- `source_guard_test.go`: metadata/source 同端点拒绝策略的公开任务接口回归测试，覆盖 localhost、127/8、::1 与 IPv6 括号表示。
 - `event_store_test.go` 中 fake store 为并发安全实现，用于 `-race` 校验稳定性。
 
 ## Exports
@@ -21,7 +21,8 @@
 - 事件记录、文件元信息、上传补偿。
 - `BinlogFile.State` 暴露 `OPEN/SEALED` 生命周期，运行中 `/files` 可见当前 segment。
 - `WithInternalCallTimeouts`：注入内部调用超时（read/write/lease/upload），用于 store/lease/uploader 依赖边界治理。
-- `WithMetadataSourceEndpoint`：注入 metadata TCP 端点，并在任务 create/update/start 时拒绝同端点 source。
+- `IsLoopbackHost`：只用字面规则识别 localhost、显式 loopback literal（127/8、::1）及有效 IPv6 括号表示，不做 DNS 解析，供 metadata guard 与 source lookup 共享。
+- `WithMetadataSourceEndpoint`：注入 metadata TCP 端点，并在任务 create/update/configure/start 时拒绝同端点 source。
 - Stop 路径 lease release 使用独立超时上下文（不复用已取消 runner ctx）。
 - cluster fail-safe stop 一旦进入 `STOPPING/STOPPED`，会拒绝后续正常复制进度上报，避免失租后继续暴露健康运行态进度。
 - runner/lease 的自动转换保持 best-effort 持久化语义，并统一记录持久化失败日志。

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: task commands/events, metadata source policy, runner callbacks, store/lease/uploader dependencies
-// output: validated task state transitions, scheduling decisions, and execution coordination
+// input: task commands/events, loopback-aware metadata source policy, runner callbacks, store/lease/uploader dependencies
+// output: source validation decisions, task state transitions, scheduling decisions, and execution coordination
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -516,8 +517,34 @@ func (s *Scheduler) validateMetadataSourceEndpoint(source SourceConfig) error {
 	return nil
 }
 
+// normalizeEndpointHost compares endpoint spellings without DNS resolution.
 func normalizeEndpointHost(host string) string {
-	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	normalized := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if isLoopbackHost(normalized) {
+		return "127.0.0.1"
+	}
+	return normalized
+}
+
+// IsLoopbackHost reports whether host is localhost or a loopback IP literal.
+// It intentionally does not resolve arbitrary hostnames.
+func IsLoopbackHost(host string) bool {
+	return isLoopbackHost(host)
+}
+
+func isLoopbackHost(host string) bool {
+	normalized := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if normalized == "localhost" {
+		return true
+	}
+	if len(normalized) >= 2 && normalized[0] == '[' && normalized[len(normalized)-1] == ']' {
+		normalized = normalized[1 : len(normalized)-1]
+		if !strings.Contains(normalized, ":") {
+			return false
+		}
+	}
+	ip := net.ParseIP(normalized)
+	return ip != nil && ip.IsLoopback()
 }
 
 // normalizeAndValidateStartConfig 归一化并校验起点配置。

--- a/internal/tasks/source_guard_test.go
+++ b/internal/tasks/source_guard_test.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: scheduler metadata endpoint policy and task source configurations
-// output: regression coverage preventing metadata/source replication feedback loops
+// input: scheduler metadata endpoint policy and loopback source configurations
+// output: regression coverage preventing metadata/source replication feedback loops across endpoint spellings
 // pos: public task-service boundary tests for metadata source isolation
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -31,6 +31,99 @@ func TestScheduler_CreateRejectsMetadataSource(t *testing.T) {
 	}
 	if got := len(s.ListTasks()); got != 0 {
 		t.Fatalf("rejected create persisted %d tasks", got)
+	}
+}
+
+func TestScheduler_CreateRejectsLocalhostMetadataSource(t *testing.T) {
+	s := NewScheduler(WithMetadataSourceEndpoint("127.0.0.1", 3306))
+
+	_, err := s.CreateTaskFromSpec(
+		"localhost-source",
+		"localhost-source",
+		&SourceConfig{Host: "localhost", Port: 3306, User: "repl", Password: "secret"},
+		nil,
+		nil,
+	)
+
+	if !errors.Is(err, ErrInvalidSourceConfig) {
+		t.Fatalf("expected ErrInvalidSourceConfig, got %v", err)
+	}
+	if got := len(s.ListTasks()); got != 0 {
+		t.Fatalf("rejected create persisted %d tasks", got)
+	}
+}
+
+func TestScheduler_CreateRejectsLoopbackMetadataSources(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadataHost string
+		sourceHost   string
+	}{
+		{name: "ipv4 loopback alias", metadataHost: "127.0.0.1", sourceHost: "127.0.0.2"},
+		{name: "ipv4 loopback lower bound", metadataHost: "localhost", sourceHost: "127.0.0.0"},
+		{name: "ipv4 loopback upper bound", metadataHost: "localhost", sourceHost: "127.255.255.255"},
+		{name: "ipv6 loopback", metadataHost: "localhost", sourceHost: "::1"},
+		{name: "bracketed ipv6 loopback", metadataHost: "[::1]", sourceHost: "[::1]"},
+		{name: "expanded ipv6 loopback", metadataHost: "localhost", sourceHost: "0:0:0:0:0:0:0:1"},
+		{name: "uppercase localhost", metadataHost: "127.0.0.1", sourceHost: "LOCALHOST"},
+		{name: "trailing dot localhost", metadataHost: "127.0.0.1", sourceHost: "localhost."},
+		{name: "metadata uppercase and trailing dot", metadataHost: "LOCALHOST.", sourceHost: "127.0.0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScheduler(WithMetadataSourceEndpoint(tt.metadataHost, 3306))
+			_, err := s.CreateTaskFromSpec(
+				"unsafe-source",
+				"unsafe-source",
+				&SourceConfig{Host: tt.sourceHost, Port: 3306, User: "repl", Password: "secret"},
+				nil,
+				nil,
+			)
+
+			if !errors.Is(err, ErrInvalidSourceConfig) {
+				t.Fatalf("expected ErrInvalidSourceConfig, got %v", err)
+			}
+			if got := len(s.ListTasks()); got != 0 {
+				t.Fatalf("rejected create persisted %d tasks", got)
+			}
+		})
+	}
+}
+
+func TestScheduler_AllowsLoopbackMetadataSourceOnDifferentPort(t *testing.T) {
+	s := NewScheduler(WithMetadataSourceEndpoint("127.0.0.1", 3306))
+
+	task, err := s.CreateTaskFromSpec(
+		"different-port-source",
+		"different-port-source",
+		&SourceConfig{Host: "localhost", Port: 3307, User: "repl", Password: "secret"},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateTaskFromSpec returned error: %v", err)
+	}
+	if task.Source.Host != "localhost" || task.Source.Port != 3307 {
+		t.Fatalf("unexpected source after allowed create: %+v", task.Source)
+	}
+}
+
+func TestScheduler_AllowsBracketedHostnameOnMetadataPort(t *testing.T) {
+	s := NewScheduler(WithMetadataSourceEndpoint("localhost", 3306))
+
+	task, err := s.CreateTaskFromSpec(
+		"bracketed-hostname-source",
+		"bracketed-hostname-source",
+		&SourceConfig{Host: "[localhost]", Port: 3306, User: "repl", Password: "secret"},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateTaskFromSpec returned error: %v", err)
+	}
+	if task.Source.Host != "[localhost]" {
+		t.Fatalf("unexpected source after allowed create: %+v", task.Source)
 	}
 }
 
@@ -104,5 +197,78 @@ func TestScheduler_UpdateRejectsMetadataSource(t *testing.T) {
 	}
 	if got.Source.Host != safe.Host || got.Source.Port != safe.Port {
 		t.Fatalf("rejected update mutated source: %+v", got.Source)
+	}
+}
+
+func TestScheduler_UpdateRejectsLoopbackMetadataSource(t *testing.T) {
+	s := NewScheduler(WithMetadataSourceEndpoint("localhost", 3306))
+	safe := SourceConfig{Host: "192.0.2.10", Port: 3307, User: "repl", Password: "secret"}
+	task, err := s.CreateTaskFromSpec("safe-source", "safe-source", &safe, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateTaskFromSpec returned error: %v", err)
+	}
+	unsafe := SourceConfig{Host: "127.255.255.254", Port: 3306, User: "repl"}
+
+	_, err = s.UpdateTask(task.ID, TaskPatch{ClusterKey: task.ClusterKey, Source: &unsafe})
+
+	if !errors.Is(err, ErrInvalidSourceConfig) {
+		t.Fatalf("expected ErrInvalidSourceConfig, got %v", err)
+	}
+	got, err := s.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.Source.Host != safe.Host || got.Source.Port != safe.Port {
+		t.Fatalf("rejected update mutated source: %+v", got.Source)
+	}
+}
+
+func TestScheduler_ConfigureRejectsBracketedIPv6MetadataSource(t *testing.T) {
+	s := NewScheduler(WithMetadataSourceEndpoint("::1", 3306))
+	task, err := s.CreateTask("safe-source", "safe-source")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+
+	err = s.ConfigureSource(task.ID, SourceConfig{Host: "[::1]", Port: 3306, User: "repl", Password: "secret"})
+
+	if !errors.Is(err, ErrInvalidSourceConfig) {
+		t.Fatalf("expected ErrInvalidSourceConfig, got %v", err)
+	}
+	got, err := s.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.Source.Host != "" {
+		t.Fatalf("rejected source mutated task: %+v", got.Source)
+	}
+}
+
+func TestScheduler_StartRejectsLoopbackMetadataSource(t *testing.T) {
+	store := newFakeStore()
+	store.tasks["33"] = Task{
+		ID:         "33",
+		Name:       "legacy-unsafe-source",
+		ClusterKey: "legacy-unsafe-source",
+		State:      StateStopped,
+		Source:     SourceConfig{Host: "127.0.0.2", Port: 3306, User: "repl", Password: "secret"},
+		Start:      StartConfig{Mode: StartModeLatest},
+	}
+	s := NewScheduler(WithStore(store), WithMetadataSourceEndpoint("localhost", 3306))
+	if err := s.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+
+	err := s.StartTask("33")
+
+	if !errors.Is(err, ErrInvalidSourceConfig) {
+		t.Fatalf("expected ErrInvalidSourceConfig, got %v", err)
+	}
+	got, err := s.GetTask("33")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.State != StateStopped {
+		t.Fatalf("rejected start changed state to %s", got.State)
 	}
 }


### PR DESCRIPTION
Refs #33\n\n## Summary\n- classify localhost and explicit loopback literals (127/8 and ::1) as one metadata/source endpoint class without DNS\n- apply the shared loopback classification to create, update, configure, start, and source lookup\n- preserve exact non-loopback lookup behavior and port separation\n- synchronize public docs and surgical Swagger descriptions\n\n## Verification\n- go build ./...\n- go test ./... -count=1: 308 passed\n- go test -race ./internal/tasks ./internal/api ./internal/replication -count=1: 193 passed\n- go vet ./...\n- go mod tidy -diff\n- three-level documentation check\n- make e2e-quick with isolated ports: smoke and compression passed, exit 0\n- independent Standards review: PASS, P0/P1/P2 0\n- independent Spec review: PASS, P0/P1/P2 0\n\n## Compatibility\nNo schema, dependency, configuration, status-code, error-code, or state-machine changes. Arbitrary DNS aliases and proxies remain operator-managed.