### PR TITLE
docs: prepare v0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Maintenance rules:
 
 ## [Unreleased]
 
+## [v0.4.3] - 2026-08-30
+
+### Fixed
+
+- Metadata/source isolation now treats `localhost`, IPv4 loopback literals in `127/8`, and IPv6 loopback literals such as `::1` as one same-port endpoint identity without DNS resolution; create, update, and start reject aliases, and source lookup returns the same matches.
+
 ## [v0.4.2] - 2026-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ For tagged public releases, download the archive that matches your platform from
 - `binlog-server_<version>_linux_amd64.tar.gz`
 - `binlog-server_<version>_linux_arm64.tar.gz`
 
-The real asset name is `binlog-server_<ver>_<os>_<arch>.tar.gz` (for example `binlog-server_0.4.2_linux_amd64.tar.gz`). The release page also provides `checksums.txt`; verify it before extracting. The tarball contains a versioned subdirectory:
+The real asset name is `binlog-server_<ver>_<os>_<arch>.tar.gz` (for example `binlog-server_0.4.3_linux_amd64.tar.gz`). The release page also provides `checksums.txt`; verify it before extracting. The tarball contains a versioned subdirectory:
 
 ```text
-binlog-server_0.4.2_linux_amd64/
+binlog-server_0.4.3_linux_amd64/
   binlog-server
   migrate
   migrations/
@@ -95,7 +95,7 @@ This is the shortest path for release operators. You do not need Go installed.
 ### 1. Download, verify, extract, run
 
 ```bash
-VER=0.4.2
+VER=0.4.3
 OS=linux          # linux | darwin
 ARCH=amd64        # amd64 | arm64
 
@@ -325,7 +325,7 @@ go run ./cmd/binlog-server
 BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
 
 # Prepare a local set of release assets
-make release-assets VERSION=v0.4.2
+make release-assets VERSION=v0.4.3
 ```
 
 ## Development Validation

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -65,10 +65,10 @@ Binlog Server 是一个面向 MySQL binlog 备份与拉流场景的服务：负�
 - `binlog-server_<version>_linux_amd64.tar.gz`
 - `binlog-server_<version>_linux_arm64.tar.gz`
 
-真实资产名是 `binlog-server_<ver>_<os>_<arch>.tar.gz`（例如 `binlog-server_0.4.2_linux_amd64.tar.gz`）。同一页提供 `checksums.txt`，先校验再解压。压缩包里有一层版本子目录：
+真实资产名是 `binlog-server_<ver>_<os>_<arch>.tar.gz`（例如 `binlog-server_0.4.3_linux_amd64.tar.gz`）。同一页提供 `checksums.txt`，先校验再解压。压缩包里有一层版本子目录：
 
 ```text
-binlog-server_0.4.2_linux_amd64/
+binlog-server_0.4.3_linux_amd64/
   binlog-server
   migrate
   migrations/
@@ -94,7 +94,7 @@ binlog-server_0.4.2_linux_amd64/
 ### 1. 下载、校验、解压、运行
 
 ```bash
-VER=0.4.2
+VER=0.4.3
 OS=linux          # linux | darwin
 ARCH=amd64        # amd64 | arm64
 
@@ -324,7 +324,7 @@ go run ./cmd/binlog-server
 BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
 
 # 本地准备一组 release 产物
-make release-assets VERSION=v0.4.2
+make release-assets VERSION=v0.4.3
 ```
 
 ## 开发验证入口

--- a/docs/guide/admin/deployment.md
+++ b/docs/guide/admin/deployment.md
@@ -49,7 +49,7 @@ FLUSH PRIVILEGES;
 
 ```bash
 # 推荐：下载 GitHub Release tarball（不需要 Go）
-VER=0.4.2
+VER=0.4.3
 OS=linux          # linux | darwin
 ARCH=amd64        # amd64 | arm64
 curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"

--- a/docs/guide/reference/api.md
+++ b/docs/guide/reference/api.md
@@ -440,7 +440,7 @@ curl "http://localhost:8080/api/workers?limit=10"
       "session_id": "abc123",
       "role": "worker",
       "host": "10.0.1.1",
-      "version": "v0.4.2",
+      "version": "v0.4.3",
       "status": "ONLINE",
       "expires_at": "2024-01-01T10:10:00Z",
       "updated_at": "2024-01-01T10:00:00Z"

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -514,7 +514,7 @@
   <section class="hero">
     <div class="container" style="position:relative;">
       <div class="hero-badge animate-fade-up" style="animation-delay:0.05s;">
-        <span class="tag tag-new" data-i18n="heroBadge">v0.4.2 — latest release</span>
+        <span class="tag tag-new" data-i18n="heroBadge">v0.4.3 — latest release</span>
       </div>
       <h1 class="animate-fade-up" style="animation-delay:0.12s;" data-i18n="heroTitle">MySQL binlog backup control plane
 for real operations</h1>
@@ -547,7 +547,7 @@ Signals        Checkpoint / Lag / Events / Workers / Metrics</code>
 verify, extract, run</h2>
       <p class="section-sub" data-i18n="deploySub">Operators do not need Go. Real assets are named <code>binlog-server_&lt;ver&gt;_&lt;os&gt;_&lt;arch&gt;.tar.gz</code> and extract into a versioned subdirectory. Full write-up: <a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/admin/deployment.md">docs/guide/admin/deployment.md</a>.</p>
       <div class="hero-code">
-        <code data-i18n="deployCode">VER=0.4.2 OS=linux ARCH=amd64
+        <code data-i18n="deployCode">VER=0.4.3 OS=linux ARCH=amd64
 curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz
 curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
@@ -784,19 +784,19 @@ better UI, better ops, better reliability</h2>
           <h3 data-i18n="releaseLeftTitle">Release timeline</h3>
           <div class="timeline">
             <div class="timeline-item">
+              <div class="timeline-date">2026-08-30</div>
+              <div class="timeline-version">v0.4.3</div>
+              <p data-i18n="release1">Loopback aliases can no longer bypass metadata/source isolation, and source lookup uses the same endpoint identity.</p>
+            </div>
+            <div class="timeline-item">
               <div class="timeline-date">2026-08-21</div>
               <div class="timeline-version">v0.4.2</div>
-              <p data-i18n="release1">Operator dogfood patch: MariaDB can start, invalid creates no longer persist as LATEST, and Quick Start installs the release tarball.</p>
+              <p data-i18n="release2">Operator dogfood patch: MariaDB can start, invalid creates no longer persist as LATEST, and Quick Start installs the release tarball.</p>
             </div>
             <div class="timeline-item">
               <div class="timeline-date">2026-03-30</div>
               <div class="timeline-version">v0.4.1</div>
-              <p data-i18n="release2">Frontend audit fixes restored button and tag styling, and expanded Playwright coverage for split views and retry-upload flows.</p>
-            </div>
-            <div class="timeline-item">
-              <div class="timeline-date">2026-03-29</div>
-              <div class="timeline-version">v0.4.0</div>
-              <p data-i18n="release3">The operations console received a visual polish pass that improved hierarchy, density, and readability without changing backend contracts.</p>
+              <p data-i18n="release3">Frontend audit fixes restored button and tag styling, and expanded Playwright coverage for split views and retry-upload flows.</p>
             </div>
           </div>
         </div>
@@ -908,8 +908,8 @@ and into a real product surface</h2>
         deployLabel: 'Quick Start',
         deployTitle: 'Download the release tarball,\nverify, extract, run',
         deploySub: 'Operators do not need Go. Real assets are named binlog-server_<ver>_<os>_<arch>.tar.gz and extract into a versioned subdirectory.',
-        deployCode: 'VER=0.4.2 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
-        heroBadge: 'v0.4.2 — latest release',
+        deployCode: 'VER=0.4.3 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
+        heroBadge: 'v0.4.3 — latest release',
         heroTitle: 'MySQL binlog backup control plane\nfor real operations',
         heroSub: 'BinlogServer centralizes MySQL binlog backup behind one service. Run local-first durable capture, inspect state through API and embedded UI, scale into cluster roles, export metrics, and archive sealed files with optional S3-compatible upload.',
         heroPrimary: 'Open Deployment Guide',
@@ -1000,9 +1000,9 @@ and into a real product surface</h2>
         changelogTitle: 'Recent work trends toward\nbetter UI, better ops, better reliability',
         changelogSub: 'The recent story is not random feature sprawl. It is clearer operator workflows, stronger frontend validation, and more production-minded behavior.',
         releaseLeftTitle: 'Release timeline',
-        release1: 'Operator dogfood patch: MariaDB can start, invalid creates no longer persist as LATEST, and Quick Start installs the release tarball.',
-        release2: 'Frontend audit fixes restored button and tag styling, and expanded Playwright coverage for split views and retry-upload flows.',
-        release3: 'The operations console received a visual polish pass that improved hierarchy, density, and readability without changing backend contracts.',
+        release1: 'Loopback aliases can no longer bypass metadata/source isolation, and source lookup uses the same endpoint identity.',
+        release2: 'Operator dogfood patch: MariaDB can start, invalid creates no longer persist as LATEST, and Quick Start installs the release tarball.',
+        release3: 'Frontend audit fixes restored button and tag styling, and expanded Playwright coverage for split views and retry-upload flows.',
         releaseRightTitle: 'What the homepage should emphasize',
         releaseFocus1Date: 'Current direction',
         releaseFocus1Title: 'Control plane maturity',
@@ -1049,8 +1049,8 @@ and into a real product surface</h2>
         deployLabel: '快速开始',
         deployTitle: '下载 release tarball，\n校验、解压、运行',
         deploySub: '值班不需要安装 Go。真实资产名是 binlog-server_<ver>_<os>_<arch>.tar.gz，解压后在一层版本子目录里。',
-        deployCode: 'VER=0.4.2 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
-        heroBadge: 'v0.4.2 — 最新发布',
+        deployCode: 'VER=0.4.3 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
+        heroBadge: 'v0.4.3 — 最新发布',
         heroTitle: '面向真实运维的\nMySQL binlog 备份控制平面',
         heroSub: 'BinlogServer 把 MySQL binlog 备份集中到一个服务里：本地优先的可靠采集、通过 API 与内置 UI 可见的运行状态、可扩展到集群角色的执行模型、Prometheus 指标，以及可选的兼容 S3 的归档上传。',
         heroPrimary: '打开部署指南',
@@ -1141,9 +1141,9 @@ and into a real product surface</h2>
         changelogTitle: '近期工作明显朝着\n更好的 UI、更好的运维、更好的可靠性前进',
         changelogSub: '最近的变化不是零散功能堆砌，而是更清晰的运维流程、更强的前端验证，以及更偏生产的行为。',
         releaseLeftTitle: '版本时间线',
-        release1: '值班 dogfood 补丁：MariaDB 可以启动，非法创建不再落成 LATEST，Quick Start 改为安装 release tarball。',
-        release2: '前端审计修复恢复了按钮与标签样式，并补强了 split view 与 retry-upload 流程的 Playwright 覆盖。',
-        release3: '运维控制台完成了一轮视觉抛光，在不改变后端契约的前提下提升了层次、密度与可读性。',
+        release1: 'loopback 别名不再能够绕过 metadata/source 隔离检查，source lookup 也使用同一套端点身份规则。',
+        release2: '值班 dogfood 补丁：MariaDB 可以启动，非法创建不再落成 LATEST，Quick Start 改为安装 release tarball。',
+        release3: '前端审计修复恢复了按钮与标签样式，并补强了 split view 与 retry-upload 流程的 Playwright 覆盖。',
         releaseRightTitle: '首页应该强调什么',
         releaseFocus1Date: '当前方向',
         releaseFocus1Title: '控制平面成熟度',

--- a/docs/releases/release-notes-v0.4.3.md
+++ b/docs/releases/release-notes-v0.4.3.md
@@ -1,0 +1,22 @@
+# Binlog Server v0.4.3
+
+Release date: 2026-08-30
+
+Binlog Server `v0.4.3` closes a metadata/source isolation bypass where equivalent loopback host spellings could be treated as different sources.
+
+## Highlights
+
+- Metadata/source checks now treat `localhost`, IPv4 loopback literals in `127/8`, and IPv6 loopback literals such as `::1` as one same-port endpoint identity. Bracketed or expanded IPv6 and normalized `localhost` spellings are covered; arbitrary hostnames are not resolved through DNS.
+- Create, source configuration/update, and start reject a source in the metadata endpoint's loopback class. Rejected creates are not persisted, and a different port remains allowed.
+- Source lookup uses the same loopback identity, so aliases return the same task matches. Non-loopback hosts keep their existing exact-text behavior.
+
+## Upgrade Notes
+
+- No schema migration is required for `v0.4.3`.
+- Existing stored source host text is not rewritten. Keep the metadata MySQL instance separate from every replication source.
+
+## Chinese Release Notes
+
+Chinese version:
+
+https://github.com/Fanduzi/BinlogServer/blob/main/docs/releases/v0.4.3.zh-CN.md

--- a/docs/releases/v0.4.3.zh-CN.md
+++ b/docs/releases/v0.4.3.zh-CN.md
@@ -1,0 +1,18 @@
+# Binlog Server v0.4.3 中文发布说明
+
+> 对应版本：`v0.4.3`
+
+发布日期：2026-08-30
+
+`v0.4.3` 修复了 metadata/source 隔离检查可被等价 loopback 主机写法绕过的问题。
+
+## 核心变化
+
+- metadata/source 检查在端口相同时，将 `localhost`、`127/8` 内的 IPv4 loopback 字面量，以及 `::1` 等 IPv6 loopback 字面量视为同一个端点身份；带括号或展开形式的 IPv6、规范化后的 `localhost` 写法也覆盖在内，不会通过 DNS 解析任意主机名。
+- 创建任务、配置或更新 source、启动任务都会拒绝 metadata 端点所在 loopback 类别的 source；被拒绝的创建不会落库，不同端口仍然允许。
+- source lookup 使用同一套 loopback 身份规则，因此不同别名会返回同一组任务；非 loopback 主机继续保持原有的精确文本匹配。
+
+## 升级影响
+
+- `v0.4.3` 无 schema 变更，不需要执行数据库迁移。
+- 不会改写已有任务中保存的 source host 文本。metadata MySQL 实例仍必须与所有复制源保持隔离。


### PR DESCRIPTION
## Summary
- add English and Chinese v0.4.3 release notes for the loopback metadata/source isolation fix
- refresh current-version install, landing, deployment, API, and changelog surfaces
- preserve historical v0.4.2 notes and timeline entry

Refs #33

## Verification
- go test ./... (308 passed)
- go test -race ./internal/tasks ./internal/api ./internal/replication
- go vet ./...
- goreleaser check
- git diff --check
- staged three-level-doc check
- independent Standards and Spec reviews: PASS, P0/P1/P2 0

## Delivery
This PR prepares the tag-triggered release only. Issue #33 remains open until v0.4.3 is tagged, the release workflow succeeds, and GitHub Release assets are verified.