### PR TITLE
fix(tasks): fail after repeated source disconnects (#37)

### DIFF
--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -36,9 +36,9 @@
 ## Validation Pilot (P4)
 - Gin binding + validator 校验：
   - `/api/sources/lookup`（`host`/`port` 必填 + 端口格式校验）
-- `/api/tasks/{id}/files/retry-upload`（`limit` 范围 1..1000，默认 100）
-- task、replication 与 dashboard 响应保留 `FAILED` 状态及稳定的源错误 `last_error`，供管理台直接展示。
+  - `/api/tasks/{id}/files/retry-upload`（`limit` 范围 1..1000，默认 100）
   - `/api/tasks/{id}/upload-failures/reasons`（`limit` 范围 1..200，默认 20）
+- task、replication 与 dashboard 响应保留 `FAILED` 状态及稳定的源错误 `last_error`，供管理台直接展示。
 
 ## Update Rule
 - 路由、请求/响应结构、认证/限流配置变化时，更新本文件。

--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -36,7 +36,8 @@
 ## Validation Pilot (P4)
 - Gin binding + validator 校验：
   - `/api/sources/lookup`（`host`/`port` 必填 + 端口格式校验）
-  - `/api/tasks/{id}/files/retry-upload`（`limit` 范围 1..1000，默认 100）
+- `/api/tasks/{id}/files/retry-upload`（`limit` 范围 1..1000，默认 100）
+- task、replication 与 dashboard 响应保留 `FAILED` 状态及稳定的源错误 `last_error`，供管理台直接展示。
   - `/api/tasks/{id}/upload-failures/reasons`（`limit` 范围 1..200，默认 20）
 
 ## Update Rule

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
-// input: HTTP requests, router params, scheduler/task service interfaces, shared source endpoint identity
-// output: REST API responses and regression coverage for task/cluster operations and source lookup
+// input: HTTP requests, router params, scheduler/task service interfaces, task/error states, and shared source endpoint identity
+// output: REST/dashboard responses, operator error visibility, task/cluster status codes, and source lookup regression coverage
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -2091,6 +2091,63 @@ func TestAPI_Dashboard(t *testing.T) {
 	}
 	if len(tasksAny) != 2 {
 		t.Fatalf("expected 2 dashboard tasks, got %d", len(tasksAny))
+	}
+}
+
+func TestAPI_SourceUnreachableFailureIsVisibleToDashboard(t *testing.T) {
+	const lastError = "SOURCE_UNREACHABLE: GetEvent: unexpected EOF"
+	store := newFakeAPIRunHistoryStore()
+	store.tasks["37"] = tasks.Task{
+		ID:         "37",
+		Name:       "unreachable-source",
+		ClusterKey: "unreachable-source-key",
+		State:      tasks.StateFailed,
+		LastError:  lastError,
+		Source:     tasks.SourceConfig{Host: "203.0.113.1", Port: 3306, User: "repl"},
+	}
+	scheduler := tasks.NewScheduler(tasks.WithStore(store))
+	if err := scheduler.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	handler := NewServer(scheduler)
+
+	taskResp := httptest.NewRecorder()
+	handler.ServeHTTP(taskResp, httptest.NewRequest(http.MethodGet, "/api/tasks/37", nil))
+	if taskResp.Code != http.StatusOK {
+		t.Fatalf("expected task 200, got %d body=%s", taskResp.Code, taskResp.Body.String())
+	}
+	var taskBody tasks.Task
+	if err := json.Unmarshal(taskResp.Body.Bytes(), &taskBody); err != nil {
+		t.Fatalf("decode task response: %v", err)
+	}
+	if taskBody.State != tasks.StateFailed || taskBody.LastError != lastError {
+		t.Fatalf("expected FAILED/SOURCE_UNREACHABLE task response, got state=%s last_error=%q", taskBody.State, taskBody.LastError)
+	}
+
+	replicationResp := httptest.NewRecorder()
+	handler.ServeHTTP(replicationResp, httptest.NewRequest(http.MethodGet, "/api/tasks/37/replication", nil))
+	if replicationResp.Code != http.StatusOK {
+		t.Fatalf("expected replication 200, got %d body=%s", replicationResp.Code, replicationResp.Body.String())
+	}
+	var replicationBody taskReplicationResponse
+	if err := json.Unmarshal(replicationResp.Body.Bytes(), &replicationBody); err != nil {
+		t.Fatalf("decode replication response: %v", err)
+	}
+	if replicationBody.State != tasks.StateFailed || replicationBody.Status != "ABNORMAL" || replicationBody.Reason != "RUNNER_ERROR" || replicationBody.LastError != lastError {
+		t.Fatalf("unexpected replication response: %#v", replicationBody)
+	}
+
+	dashboardResp := httptest.NewRecorder()
+	handler.ServeHTTP(dashboardResp, httptest.NewRequest(http.MethodGet, "/api/dashboard", nil))
+	if dashboardResp.Code != http.StatusOK {
+		t.Fatalf("expected dashboard 200, got %d body=%s", dashboardResp.Code, dashboardResp.Body.String())
+	}
+	var dashboardBody dashboardResponse
+	if err := json.Unmarshal(dashboardResp.Body.Bytes(), &dashboardBody); err != nil {
+		t.Fatalf("decode dashboard response: %v", err)
+	}
+	if len(dashboardBody.Tasks) != 1 || dashboardBody.Tasks[0].Task.State != tasks.StateFailed || dashboardBody.Tasks[0].Task.LastError != lastError || dashboardBody.Tasks[0].Replication.LastError != lastError {
+		t.Fatalf("expected dashboard FAILED/SOURCE_UNREACHABLE visibility, got %#v", dashboardBody.Tasks)
 	}
 }
 

--- a/internal/replication/README.md
+++ b/internal/replication/README.md
@@ -2,13 +2,14 @@
 
 ## Files
 - `mysql_runner.go`: 复制主执行流程（含 open segment 元数据及进度更新、idle lag 上报、heartbeat 跳过落盘）。
-- `source_identity.go`: MySQL/MariaDB 源库身份与永久错误分类。
+- `source_identity.go`: MySQL/MariaDB 源库身份，以及永久认证/配置错误与可重试网络错误分类。
 - `resolver.go`: 起点解析。
 - 其余 `*_test.go`: 复制、恢复、上传等行为测试。
   其中 `mysql_runner_run_test.go` 重点覆盖 runner 级起点选择、checkpoint 推进/失败、错误传播与停止清理语义。
 
 ## Exports
 - Runner 启停与进度上报。
+- 源网络超时、拒绝和主机不可达统一暴露 `SOURCE_UNREACHABLE`，本地文件/metadata/lease 错误保持原分类。
 - MariaDB 身份：`mariadb:<server_id>:<gtid_domain_id>`；MySQL 仍用 `server_uuid`。
 - 文件落盘、checkpoint 对接、随落盘进度更新的 OPEN/SEALED 生命周期元数据、上传触发。
 

--- a/internal/replication/README.md
+++ b/internal/replication/README.md
@@ -9,7 +9,7 @@
 
 ## Exports
 - Runner 启停与进度上报。
-- 源网络超时、拒绝和主机不可达统一暴露 `SOURCE_UNREACHABLE`，本地文件/metadata/lease 错误保持原分类。
+- 源网络超时、拒绝、主机不可达及复制流 EOF/UnexpectedEOF 统一暴露 `SOURCE_UNREACHABLE`，本地文件/metadata/lease 错误保持原分类。
 - MariaDB 身份：`mariadb:<server_id>:<gtid_domain_id>`；MySQL 仍用 `server_uuid`。
 - 文件落盘、checkpoint 对接、随落盘进度更新的 OPEN/SEALED 生命周期元数据、上传触发。
 

--- a/internal/replication/source_identity.go
+++ b/internal/replication/source_identity.go
@@ -1,12 +1,14 @@
 // Package replication provides module-level functionality for replication.
-// input: source connection results, flavor, log_bin and identity variables
-// output: stable source identity strings and permanent source configuration errors
-// pos: flavor-aware source probe used before binlog dump starts
+// input: source connection results, network failures, flavor, log_bin and identity variables
+// output: stable source identity strings and typed permanent/retryable source errors
+// pos: flavor-aware source probe and operator-error classification boundary
 // note: if this file changes, update this header and module README.md.
 package replication
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"strings"
 
 	"binlog_server/internal/tasks"
@@ -28,6 +30,10 @@ func classifySourceError(err error) error {
 	}
 	if isAccessDeniedMessage(err.Error()) {
 		return tasks.NewPermanentError(tasks.CodeSourceAccessDenied, err.Error())
+	}
+	var networkErr *net.OpError
+	if errors.As(err, &networkErr) {
+		return tasks.NewRetryableSourceError(tasks.CodeSourceUnreachable, err.Error())
 	}
 	return err
 }

--- a/internal/replication/source_identity.go
+++ b/internal/replication/source_identity.go
@@ -1,5 +1,5 @@
 // Package replication provides module-level functionality for replication.
-// input: source connection results, network failures, flavor, log_bin and identity variables
+// input: source connection results, network/stream disconnects, flavor, log_bin and identity variables
 // output: stable source identity strings and typed permanent/retryable source errors
 // pos: flavor-aware source probe and operator-error classification boundary
 // note: if this file changes, update this header and module README.md.
@@ -8,6 +8,7 @@ package replication
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 
@@ -32,7 +33,7 @@ func classifySourceError(err error) error {
 		return tasks.NewPermanentError(tasks.CodeSourceAccessDenied, err.Error())
 	}
 	var networkErr *net.OpError
-	if errors.As(err, &networkErr) {
+	if errors.As(err, &networkErr) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return tasks.NewRetryableSourceError(tasks.CodeSourceUnreachable, err.Error())
 	}
 	return err

--- a/internal/replication/source_identity_test.go
+++ b/internal/replication/source_identity_test.go
@@ -1,5 +1,5 @@
 // Package replication provides module-level functionality for replication.
-// input: flavor/log_bin/identity fixtures plus source-network and go-mysql error values
+// input: flavor/log_bin/identity fixtures plus wrapped source-network and stream-read errors
 // output: source identity plus permanent/retryable operator-error classification assertions
 // pos: unit tests for MariaDB/MySQL source probe semantics
 // note: if this file changes, update this header and module README.md.
@@ -7,6 +7,8 @@ package replication
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -80,5 +82,18 @@ func TestClassifySourceError_UnreachableNetwork(t *testing.T) {
 	diskErr := &os.PathError{Op: "write", Path: "/data/binlog", Err: syscall.ENOSPC}
 	if got := classifySourceError(diskErr); got != diskErr {
 		t.Fatalf("local disk error must not be classified as source unreachable: %v", got)
+	}
+}
+
+func TestClassifySourceError_StreamDisconnect(t *testing.T) {
+	for _, err := range []error{
+		fmt.Errorf("GetEvent: read packet header: %w", io.EOF),
+		fmt.Errorf("GetEvent: %w", fmt.Errorf("read packet body: %w", io.ErrUnexpectedEOF)),
+	} {
+		classified := classifySourceError(err)
+		var sourceErr *tasks.RetryableSourceError
+		if !errors.As(classified, &sourceErr) || sourceErr.Code != tasks.CodeSourceUnreachable {
+			t.Fatalf("expected SOURCE_UNREACHABLE for wrapped stream disconnect, got %v", classified)
+		}
 	}
 }

--- a/internal/replication/source_identity_test.go
+++ b/internal/replication/source_identity_test.go
@@ -1,13 +1,16 @@
 // Package replication provides module-level functionality for replication.
-// input: flavor/log_bin/identity fixtures and go-mysql style error strings
-// output: source identity resolution and permanent-error classification assertions
+// input: flavor/log_bin/identity fixtures plus source-network and go-mysql error values
+// output: source identity plus permanent/retryable operator-error classification assertions
 // pos: unit tests for MariaDB/MySQL source probe semantics
 // note: if this file changes, update this header and module README.md.
 package replication
 
 import (
 	"errors"
+	"net"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 
 	"binlog_server/internal/tasks"
@@ -59,5 +62,23 @@ func TestClassifySourceError_AccessDenied(t *testing.T) {
 	var pe *tasks.PermanentError
 	if !errors.As(err, &pe) || pe.Code != tasks.CodeSourceAccessDenied {
 		t.Fatalf("expected SOURCE_ACCESS_DENIED, got %v", err)
+	}
+}
+
+func TestClassifySourceError_UnreachableNetwork(t *testing.T) {
+	for _, errno := range []syscall.Errno{syscall.ETIMEDOUT, syscall.ECONNREFUSED, syscall.EHOSTUNREACH} {
+		err := classifySourceError(&net.OpError{Op: "dial", Net: "tcp", Err: errno})
+		var sourceErr *tasks.RetryableSourceError
+		if !errors.As(err, &sourceErr) || sourceErr.Code != tasks.CodeSourceUnreachable {
+			t.Fatalf("%v: expected SOURCE_UNREACHABLE, got %v", errno, err)
+		}
+		if tasks.IsPermanent(err) {
+			t.Fatalf("%v: unreachable source must remain retryable", errno)
+		}
+	}
+
+	diskErr := &os.PathError{Op: "write", Path: "/data/binlog", Err: syscall.ENOSPC}
+	if got := classifySourceError(diskErr); got != diskErr {
+		t.Fatalf("local disk error must not be classified as source unreachable: %v", got)
 	}
 }

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -18,7 +18,7 @@
 - 任务 CRUD、启动停止、状态推进。
 - `CreateTaskFromSpec`：整包校验后才 persist。
 - `FAILED` 可再次 `StartTask`（改完源库配置后）。
-- `SOURCE_UNREACHABLE` 连续失败最多重试 10 次；runner ready 会清零进程内连续失败计数，服务重启后重新计数。
+- 仅 `SOURCE_UNREACHABLE` 连续失败最多重试 10 次；runner ready 会清零进程内连续失败计数，服务重启后重新计数，其他 retryable source code 不共享此封顶。
 - 事件记录、文件元信息、上传补偿。
 - `BinlogFile.State` 暴露 `OPEN/SEALED` 生命周期，运行中 `/files` 可见当前 segment。
 - `WithInternalCallTimeouts`：注入内部调用超时（read/write/lease/upload），用于 store/lease/uploader 依赖边界治理。

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -3,9 +3,9 @@
 ## Files
 - `scheduler.go`: 调度器核心类型、选项注入与通用辅助函数。
 - `scheduler_task_ops.go`: 任务 CRUD 与配置更新（含整包 CreateTaskFromSpec）。
-- `scheduler_lifecycle.go`: 启停、运行协程、重试退避与不可恢复 FAILED。
+- `scheduler_lifecycle.go`: 启停、运行协程、重试退避，以及连续 10 次源不可达后的 FAILED（runner ready 后重新计数）。
 - `scheduler_transitions.go`: 私有生命周期转换规则（状态、事件、错误、ownership 与持久化）。
-- `errors.go`: 永久错误类型（1045 / log_bin off / 身份不可用）。
+- `errors.go`: 稳定操作员错误类型（永久的 1045 / log_bin off / 身份不可用，以及可重试的 `SOURCE_UNREACHABLE`）。
 - `scheduler_cluster_lease.go`: cluster lease 续租与降级/失租处理。
 - `scheduler_observability.go`: 复制进度、checkpoint、事件/文件/运行历史查询。
 - `scheduler_retry_upload.go`: 上传失败补偿重试与失败原因聚合。
@@ -18,6 +18,7 @@
 - 任务 CRUD、启动停止、状态推进。
 - `CreateTaskFromSpec`：整包校验后才 persist。
 - `FAILED` 可再次 `StartTask`（改完源库配置后）。
+- `SOURCE_UNREACHABLE` 连续失败最多重试 10 次；runner ready 会清零进程内连续失败计数，服务重启后重新计数。
 - 事件记录、文件元信息、上传补偿。
 - `BinlogFile.State` 暴露 `OPEN/SEALED` 生命周期，运行中 `/files` 可见当前 segment。
 - `WithInternalCallTimeouts`：注入内部调用超时（read/write/lease/upload），用于 store/lease/uploader 依赖边界治理。

--- a/internal/tasks/errors.go
+++ b/internal/tasks/errors.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: runner/source failures and stable operator error codes
-// output: typed permanent and retryable source errors used by task retry policy
+// output: typed permanent/retryable source errors and the SOURCE_UNREACHABLE budget predicate
 // pos: shared operator-error types used by scheduler retry policy and source probing
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -38,10 +38,10 @@ func NewRetryableSourceError(code, message string) error {
 	return &RetryableSourceError{Code: code, Message: message}
 }
 
-// IsRetryableSourceError reports whether err is a classified retryable source failure.
-func IsRetryableSourceError(err error) bool {
+// IsSourceUnreachable reports whether err consumes the unreachable-source retry budget.
+func IsSourceUnreachable(err error) bool {
 	var sourceErr *RetryableSourceError
-	return errors.As(err, &sourceErr)
+	return errors.As(err, &sourceErr) && sourceErr.Code == CodeSourceUnreachable
 }
 
 // PermanentError is an unrecoverable task error that must not enter RETRY_BACKOFF.

--- a/internal/tasks/errors.go
+++ b/internal/tasks/errors.go
@@ -1,7 +1,7 @@
 // Package tasks provides module-level functionality for tasks.
-// input: runner/source failure strings and typed operator error codes
-// output: permanent (non-retryable) errors that stop the task state machine
-// pos: shared error types used by scheduler retry policy and source probing
+// input: runner/source failures and stable operator error codes
+// output: typed permanent and retryable source errors used by task retry policy
+// pos: shared operator-error types used by scheduler retry policy and source probing
 // note: if this file changes, update this header and module README.md.
 package tasks
 
@@ -10,6 +10,8 @@ import "errors"
 const (
 	// CodeSourceAccessDenied is MySQL/MariaDB ERROR 1045.
 	CodeSourceAccessDenied = "SOURCE_ACCESS_DENIED"
+	// CodeSourceUnreachable is a retryable source network failure.
+	CodeSourceUnreachable = "SOURCE_UNREACHABLE"
 	// CodeSourceLogBinOff is an unrecoverable source configuration error.
 	CodeSourceLogBinOff = "SOURCE_LOG_BIN_OFF"
 	// CodeSourceIdentityUnavailable is a missing source identity after probing.
@@ -17,6 +19,30 @@ const (
 	// CodeInvalidRequest is a create/update validation failure.
 	CodeInvalidRequest = "INVALID_REQUEST"
 )
+
+// RetryableSourceError is a source failure that may recover without operator action.
+type RetryableSourceError struct {
+	Code    string
+	Message string
+}
+
+func (e *RetryableSourceError) Error() string {
+	if e.Message == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.Message
+}
+
+// NewRetryableSourceError constructs a retryable operator-facing source error.
+func NewRetryableSourceError(code, message string) error {
+	return &RetryableSourceError{Code: code, Message: message}
+}
+
+// IsRetryableSourceError reports whether err is a classified retryable source failure.
+func IsRetryableSourceError(err error) bool {
+	var sourceErr *RetryableSourceError
+	return errors.As(err, &sourceErr)
+}
 
 // PermanentError is an unrecoverable task error that must not enter RETRY_BACKOFF.
 type PermanentError struct {

--- a/internal/tasks/runner_test.go
+++ b/internal/tasks/runner_test.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task commands/events, retryable/permanent runner callbacks, store/lease/uploader dependencies
-// output: runner invocation, retry cap/reset, readiness, stop, and permanent-failure assertions
+// output: runner invocation, code-specific retry cap/reset, readiness, stop, and permanent-failure assertions
 // pos: public Scheduler seam tests for runner-driven task lifecycle behavior
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -39,14 +39,35 @@ type permanentFailureRunner struct {
 }
 
 type unreachableRunner struct {
-	mu    sync.Mutex
-	calls int
+	mu        sync.Mutex
+	calls     int
+	attempted chan int
+	release   chan struct{}
 }
 
 type readyResetRunner struct {
 	mu      sync.Mutex
 	calls   int
 	resumed chan struct{}
+}
+
+type otherRetryableSourceRunner struct {
+	mu       sync.Mutex
+	calls    int
+	eleventh chan struct{}
+}
+
+func (r *otherRetryableSourceRunner) Run(ctx context.Context, _ Task) error {
+	r.mu.Lock()
+	r.calls++
+	call := r.calls
+	r.mu.Unlock()
+	if call == 11 {
+		close(r.eleventh)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return NewRetryableSourceError("SOURCE_THROTTLED", "source busy")
 }
 
 func (r *readyResetRunner) Run(context.Context, Task) error {
@@ -71,10 +92,23 @@ func (r *readyResetRunner) RunWithNotify(ctx context.Context, _ Task, onReady fu
 	return ctx.Err()
 }
 
-func (r *unreachableRunner) Run(context.Context, Task) error {
+func (r *unreachableRunner) Run(ctx context.Context, _ Task) error {
 	r.mu.Lock()
 	r.calls++
+	call := r.calls
 	r.mu.Unlock()
+	if r.attempted != nil {
+		select {
+		case r.attempted <- call:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	return NewRetryableSourceError(CodeSourceUnreachable, "dial tcp: connection refused")
 }
 
@@ -376,19 +410,65 @@ func TestScheduler_PermanentRunnerErrorTransitionsToFailed(t *testing.T) {
 }
 
 func TestScheduler_UnreachableSourceFailsAfterTenConsecutiveAttempts(t *testing.T) {
-	runner := &unreachableRunner{}
-	s := NewScheduler(WithRunner(runner), WithRetryBackoff(time.Millisecond, time.Millisecond))
-
-	task, err := s.CreateTask("cluster-a", "cluster-a-key")
-	if err != nil {
-		t.Fatalf("CreateTask returned error: %v", err)
+	task := Task{
+		ID:         "37",
+		Name:       "restored-task",
+		ClusterKey: "cluster-a-key",
+		State:      StateRetryBackoff,
+		LastError:  "SOURCE_UNREACHABLE: previous process",
+		Source:     SourceConfig{Host: "203.0.113.1", Port: 3306, User: "repl"},
 	}
-	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "203.0.113.1", Port: 3306, User: "repl"}); err != nil {
-		t.Fatalf("ConfigureSource returned error: %v", err)
+	store := &schedulerTestStore{tasks: map[string]Task{task.ID: task}}
+	runner := &unreachableRunner{attempted: make(chan int), release: make(chan struct{})}
+	s := NewScheduler(WithStore(store), WithRunner(runner), WithRetryBackoff(time.Millisecond, time.Millisecond))
+	if err := s.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
 	}
 	if err := s.StartTask(task.ID); err != nil {
 		t.Fatalf("StartTask returned error: %v", err)
 	}
+	t.Cleanup(func() { _ = s.StopTask(task.ID) })
+
+	expectAttempt := func(want int) {
+		t.Helper()
+		select {
+		case got := <-runner.attempted:
+			if got != want {
+				t.Fatalf("expected attempt %d, got %d", want, got)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for attempt %d", want)
+		}
+	}
+	assertEventCounts := func(wantRunnerErrors, wantRetries, wantFailed int) {
+		t.Helper()
+		events, err := s.ListEvents(task.ID, 0)
+		if err != nil {
+			t.Fatalf("ListEvents returned error: %v", err)
+		}
+		counts := map[string]int{}
+		for _, event := range events {
+			counts[event.Type]++
+		}
+		if counts["TASK_RUNNER_ERROR"] != wantRunnerErrors || counts["TASK_RETRY_BACKOFF"] != wantRetries || counts["TASK_RETRYING"] != wantRetries || counts["TASK_FAILED"] != wantFailed {
+			t.Fatalf("unexpected retry event counts at attempt %d: %#v", wantRunnerErrors, counts)
+		}
+	}
+
+	expectAttempt(1)
+	runner.release <- struct{}{}
+	expectAttempt(2)
+	assertEventCounts(1, 1, 0)
+
+	for attempt := 2; attempt < 9; attempt++ {
+		runner.release <- struct{}{}
+		expectAttempt(attempt + 1)
+	}
+	runner.release <- struct{}{}
+	expectAttempt(10)
+	assertEventCounts(9, 9, 0)
+
+	runner.release <- struct{}{}
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
@@ -408,9 +488,16 @@ func TestScheduler_UnreachableSourceFailsAfterTenConsecutiveAttempts(t *testing.
 		}
 		time.Sleep(time.Millisecond)
 	}
-
+	assertEventCounts(10, 9, 1)
 	if calls := runner.callCount(); calls != 10 {
 		t.Fatalf("expected 10 runner attempts, got %d", calls)
+	}
+	events, err := s.ListEvents(task.ID, 0)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	if n := len(events); n < 2 || events[n-2].Type != "TASK_RUNNER_ERROR" || events[n-1].Type != "TASK_FAILED" {
+		t.Fatalf("expected exhaustion to end with runner error then failed, got %#v", events)
 	}
 }
 
@@ -441,6 +528,32 @@ func TestScheduler_RunnerReadyResetsConsecutiveSourceFailures(t *testing.T) {
 	}
 	if got.State != StateRunning || got.LastError != "" {
 		t.Fatalf("expected resumed runner to be RUNNING without error, got state=%s last_error=%q", got.State, got.LastError)
+	}
+	if err := s.StopTask(task.ID); err != nil {
+		t.Fatalf("StopTask returned error: %v", err)
+	}
+}
+
+func TestScheduler_OtherRetryableSourceCodeIsNotCapped(t *testing.T) {
+	runner := &otherRetryableSourceRunner{eleventh: make(chan struct{})}
+	s := NewScheduler(WithRunner(runner), WithRetryBackoff(time.Millisecond, time.Millisecond))
+
+	task, err := s.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	if err := s.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask returned error: %v", err)
+	}
+
+	select {
+	case <-runner.eleventh:
+	case <-time.After(2 * time.Second):
+		got, _ := s.GetTask(task.ID)
+		t.Fatalf("expected non-SOURCE_UNREACHABLE retries to continue, state=%s", got.State)
 	}
 	if err := s.StopTask(task.ID); err != nil {
 		t.Fatalf("StopTask returned error: %v", err)

--- a/internal/tasks/runner_test.go
+++ b/internal/tasks/runner_test.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task commands/events, retryable/permanent runner callbacks, store/lease/uploader dependencies
-// output: runner invocation, retry, readiness, stop, and permanent-failure assertions
+// output: runner invocation, retry cap/reset, readiness, stop, and permanent-failure assertions
 // pos: public Scheduler seam tests for runner-driven task lifecycle behavior
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -36,6 +36,52 @@ type failOnceRunner struct {
 type permanentFailureRunner struct {
 	mu    sync.Mutex
 	calls int
+}
+
+type unreachableRunner struct {
+	mu    sync.Mutex
+	calls int
+}
+
+type readyResetRunner struct {
+	mu      sync.Mutex
+	calls   int
+	resumed chan struct{}
+}
+
+func (r *readyResetRunner) Run(context.Context, Task) error {
+	return errors.New("RunWithNotify required")
+}
+
+func (r *readyResetRunner) RunWithNotify(ctx context.Context, _ Task, onReady func()) error {
+	r.mu.Lock()
+	r.calls++
+	call := r.calls
+	r.mu.Unlock()
+
+	if call < 10 {
+		return NewRetryableSourceError(CodeSourceUnreachable, "dial tcp: connection refused")
+	}
+	onReady()
+	if call == 10 {
+		return NewRetryableSourceError(CodeSourceUnreachable, "read tcp: connection reset")
+	}
+	close(r.resumed)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (r *unreachableRunner) Run(context.Context, Task) error {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	return NewRetryableSourceError(CodeSourceUnreachable, "dial tcp: connection refused")
+}
+
+func (r *unreachableRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
 }
 
 // Run returns an unrecoverable source error.
@@ -326,6 +372,78 @@ func TestScheduler_PermanentRunnerErrorTransitionsToFailed(t *testing.T) {
 	}
 	if calls := runner.callCount(); calls != 1 {
 		t.Fatalf("expected runner called once, got %d", calls)
+	}
+}
+
+func TestScheduler_UnreachableSourceFailsAfterTenConsecutiveAttempts(t *testing.T) {
+	runner := &unreachableRunner{}
+	s := NewScheduler(WithRunner(runner), WithRetryBackoff(time.Millisecond, time.Millisecond))
+
+	task, err := s.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "203.0.113.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	if err := s.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask returned error: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, err := s.GetTask(task.ID)
+		if err != nil {
+			t.Fatalf("GetTask returned error: %v", err)
+		}
+		if got.State == StateFailed {
+			if got.LastError != "SOURCE_UNREACHABLE: dial tcp: connection refused" {
+				t.Fatalf("expected stable source error detail, got %q", got.LastError)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = s.StopTask(task.ID)
+			t.Fatalf("expected state %s after retry cap, got %s", StateFailed, got.State)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if calls := runner.callCount(); calls != 10 {
+		t.Fatalf("expected 10 runner attempts, got %d", calls)
+	}
+}
+
+func TestScheduler_RunnerReadyResetsConsecutiveSourceFailures(t *testing.T) {
+	runner := &readyResetRunner{resumed: make(chan struct{})}
+	s := NewScheduler(WithRunner(runner), WithRetryBackoff(time.Millisecond, time.Millisecond))
+
+	task, err := s.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "203.0.113.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	if err := s.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask returned error: %v", err)
+	}
+
+	select {
+	case <-runner.resumed:
+	case <-time.After(2 * time.Second):
+		got, _ := s.GetTask(task.ID)
+		t.Fatalf("expected retry budget reset after ready, state=%s", got.State)
+	}
+	got, err := s.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.State != StateRunning || got.LastError != "" {
+		t.Fatalf("expected resumed runner to be RUNNING without error, got state=%s last_error=%q", got.State, got.LastError)
+	}
+	if err := s.StopTask(task.ID); err != nil {
+		t.Fatalf("StopTask returned error: %v", err)
 	}
 }
 

--- a/internal/tasks/scheduler_lifecycle.go
+++ b/internal/tasks/scheduler_lifecycle.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: start/stop commands, metadata source policy, runner callbacks, typed source errors, cancellation signals
-// output: guarded start/stop, bounded source retry, and cancellation orchestration
+// output: guarded start/stop, bounded SOURCE_UNREACHABLE retry, and cancellation orchestration
 // pos: scheduler execution loop delegating state mutations to scheduler_transitions.go
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -301,7 +301,7 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 			s.mu.Unlock()
 			return
 		}
-		if IsRetryableSourceError(err) {
+		if IsSourceUnreachable(err) {
 			consecutiveSourceFailures++
 			if consecutiveSourceFailures >= maxConsecutiveRetryableSourceFailures {
 				logTransitionPersistError(id, StateFailed, s.markFailedLocked(id, errMsg))

--- a/internal/tasks/scheduler_lifecycle.go
+++ b/internal/tasks/scheduler_lifecycle.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: start/stop commands, metadata source policy, runner callbacks, permanent/retryable errors, cancellation signals
-// output: guarded start/stop, runner retry, and cancellation orchestration
+// input: start/stop commands, metadata source policy, runner callbacks, typed source errors, cancellation signals
+// output: guarded start/stop, bounded source retry, and cancellation orchestration
 // pos: scheduler execution loop delegating state mutations to scheduler_transitions.go
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -10,10 +10,13 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 )
+
+const maxConsecutiveRetryableSourceFailures = 10
 
 func (s *Scheduler) StartTask(id string) error {
 	s.mu.Lock()
@@ -267,9 +270,14 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 
 	// Step 1: 调用 runRunner 执行一次会话；错误则进入退避重试。
 	attempt := 0
+	consecutiveSourceFailures := 0
 	for {
 		// runRunner 是一次“会话级”执行：内部会一直拉 binlog，直到 stop 或报错才返回。
-		err := s.runRunner(ctx, id, task)
+		ready, err := s.runRunner(ctx, id, task)
+		if ready {
+			attempt = 0
+			consecutiveSourceFailures = 0
+		}
 		if err == nil || errors.Is(err, context.Canceled) {
 			return
 		}
@@ -292,6 +300,16 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 			logTransitionPersistError(id, StateFailed, s.markFailedLocked(id, errMsg))
 			s.mu.Unlock()
 			return
+		}
+		if IsRetryableSourceError(err) {
+			consecutiveSourceFailures++
+			if consecutiveSourceFailures >= maxConsecutiveRetryableSourceFailures {
+				logTransitionPersistError(id, StateFailed, s.markFailedLocked(id, errMsg))
+				s.mu.Unlock()
+				return
+			}
+		} else {
+			consecutiveSourceFailures = 0
 		}
 
 		logTransitionPersistError(id, StateRetryBackoff, s.markRetryBackoffLocked(current, errMsg))
@@ -328,9 +346,11 @@ func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan
 }
 
 // runRunner 负责把 Scheduler 状态机与 Runner 生命周期对齐。
-func (s *Scheduler) runRunner(ctx context.Context, id string, task Task) error {
+func (s *Scheduler) runRunner(ctx context.Context, id string, task Task) (bool, error) {
+	var ready atomic.Bool
 	// Step 1: 定义 ready 回调，把任务状态收敛到 RUNNING。
 	onReady := func() {
+		ready.Store(true)
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
@@ -339,13 +359,15 @@ func (s *Scheduler) runRunner(ctx context.Context, id string, task Task) error {
 
 	if n, ok := s.runner.(runnerWithNotify); ok {
 		// 类型断言：如果 runner 支持 RunWithNotify，就走精确 ready 语义。
-		return n.RunWithNotify(ctx, task, onReady)
+		err := n.RunWithNotify(ctx, task, onReady)
+		return ready.Load(), err
 	}
 	// Step 2: 兼容旧 runner（无 notify），采用乐观 ready 语义。
 	// 向后兼容旧 runner：没有 notify 能力时，在 Run 前乐观置为 RUNNING。
 	// 该路径可能出现“短暂 RUNNING 后立即失败”；失败会在 runTask 的错误分支回收状态。
 	onReady()
-	return s.runner.Run(ctx, task)
+	// 乐观状态不等于 runner 明确 ready，不重置连续源失败计数。
+	return false, s.runner.Run(ctx, task)
 }
 
 // isClosed 判断 channel 是否已关闭（nil 视为已关闭）。


### PR DESCRIPTION
## Summary
- classify wrapped stream EOF failures as SOURCE_UNREACHABLE
- cap only consecutive SOURCE_UNREACHABLE failures at exactly 10 attempts
- reset the in-process budget after runner-ready and preserve other retryable source errors
- expose stable FAILED/source error state through task, replication, and dashboard APIs
- preserve #33 loopback source identity behavior

Refs #37

## Verification
- go test ./... (314 passed)
- go test -race ./internal/tasks ./internal/api ./internal/replication (199 passed)
- go vet ./...
- go mod tidy -diff
- git diff --check
- three-level documentation validation
- make e2e-quick on isolated ports: smoke and compression passed; owned containers cleaned
- rollback candidate c1624b1 passed equivalent Go and E2E gates
- final independent Standards and Spec reviews: PASS, P0/P1/P2 0

## Integration
Only the two reviewed #37 product commits were cherry-picked; setup commit 76c7021 is excluded. One header-only conflict with #33 tests was merged, and one documentation-list P2 was fixed in fef6d8a.