### PR TITLE
fix: harden production auth and add scale evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test build build-linux check-linux-compat check-linux-release-archive ui-build release-assets e2e-topology-check e2e-quick e2e-full e2e-observability e2e migrate-up migrate-down migrate-version migrate-force sqlc-generate sqlc-verify
+.PHONY: help test build build-linux check-linux-compat check-linux-release-archive ui-build release-assets e2e-topology-check e2e-quick e2e-full e2e-observability e2e-scale e2e migrate-up migrate-down migrate-version migrate-force sqlc-generate sqlc-verify
 
 VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo devel)
 BUILD_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
@@ -19,6 +19,7 @@ help:
 	@echo "  make e2e-quick                  # run quick e2e (smoke,compression)"
 	@echo "  make e2e-full                   # run full e2e (smoke,compression,orchestrator,semisync)"
 	@echo "  make e2e-observability          # run observability e2e (smoke-observability)"
+	@echo "  make e2e-scale                  # opt-in 1000-control-task / 100-live-stream scale evidence"
 	@echo "  make e2e SCENARIOS=a,b,c        # run custom e2e scenarios"
 	@echo "  make sqlc-generate              # generate typed SQL code from sqlc.yaml"
 	@echo "  make sqlc-verify                # regenerate and check for no git diff"
@@ -82,6 +83,9 @@ e2e-full:
 
 e2e-observability:
 	./scripts/e2e/run-suite.sh --scenarios smoke-observability
+
+e2e-scale:
+	./scripts/e2e/run-suite.sh --scenarios smoke-scale
 
 e2e:
 	@if [ -z "$(SCENARIOS)" ]; then \

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ export BINLOG_SERVER_API_AUTH_PROTECT_API=true
 export BINLOG_SERVER_API_AUTH_PROTECT_METRICS=true
 ```
 
+Start from [`config.production.example.yaml`](config.production.example.yaml); it contains no credential, needs only the protected bearer-token environment variable, and refuses to load until that placeholder is resolved.
+
 If you use the metadata database:
 
 ```bash

--- a/config.production.example.yaml
+++ b/config.production.example.yaml
@@ -1,0 +1,11 @@
+# Production deployment template. Keep secrets outside this file.
+listen_addr: ":8080"
+data_dir: "./data"
+
+api:
+  auth:
+    enabled: true
+    mode: "bearer"
+    bearer_token: "${BINLOG_SERVER_API_AUTH_BEARER_TOKEN}"
+    protect_api: true
+    protect_metrics: true

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -4,7 +4,8 @@
 - `app.go`: 应用主流程与运行时装配。
 - `tracing.go`: tracing provider 初始化与生命周期管理。
 - `tracing_test.go`: OTLP HTTP 默认 traces 路径兼容性回归测试。
-- `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`）。
+- `http_server_test.go`: HTTP 超时和生产环境 auth fail-closed 校验测试。
+- `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`），包括 auth 到真实路由的回归。
 - `restart_recovery_test.go`: standalone 重启后安全的持久化 active task 自动恢复、metadata/source 冲突任务保持停止的回归测试。
 - `source_guard_test.go`: 从 `meta_dsn` 到任务 API 的 metadata/source 隔离装配回归测试。
 
@@ -15,6 +16,7 @@
 - 通过 `config.meta.timeout.*` 注入 tasks/meta 的内部依赖调用超时（读/写/lease/上传）。
 - 对 TCP `meta_dsn` 提取 host/port 并注入 tasks，同端点 source 在 create/update/start 边界被拒绝。
 - API server 支持从 `config.API.Auth` 注入鉴权策略。
+- 非空 `PRODUCTION` 用标准布尔值解析；control-plane 在 true 时强制 auth 已启用、同时保护 `/api/*` 和 `/metrics`，并复用 `config.ValidateAPIAuthConfig` 校验模式/已解析凭证；worker-only 不暴露该 API 且不套用此约束。
 - tracing：默认关闭；启用时装配 HTTP 入站 span 与元数据存储调用 span；无路径的 OTLP HTTP endpoint 沿用 `/v1/traces` 默认路径。
 - standalone/cluster worker 启动时自动恢复 metadata 中遗留的 active task，并从 checkpoint 续传。
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
-// input: runtime config including metadata DSN, persisted task state, scheduler/runner/meta store dependencies, process context
-// output: application lifecycle control with metadata/source isolation, active-task restart recovery, role wiring, and shutdown
+// input: runtime config, PRODUCTION environment flag, persisted task state, scheduler/runner/meta store dependencies, process context
+// output: role-aware application lifecycle control with production control-plane auth checks, metadata/source isolation, restart recovery, and shutdown
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -98,12 +98,18 @@ func New(cfg config.Config) *App {
 // Run 启动应用运行时：按 mode/role 组装 scheduler 与 runner，
 // 在 cluster 场景维护 worker 注册、心跳与任务认领，并在 control-plane 模式对外提供 HTTP API。
 func (a *App) Run(ctx context.Context) error {
-	// 安全检查：生产环境强制要求认证。
-	if !a.cfg.API.Auth.Enabled {
-		if os.Getenv("PRODUCTION") == "true" {
-			return errors.New("api.auth.enabled must be true in PRODUCTION mode (set PRODUCTION=false for development)")
+	// 先解析角色，worker-only 不暴露 control-plane API，不能套用 API 鉴权启动约束。
+	controlPlaneEnabled, workerEnabled := resolveRoleMode(a.cfg)
+	production, err := productionMode(os.Getenv("PRODUCTION"))
+	if err != nil {
+		return err
+	}
+	if controlPlaneEnabled {
+		if err := validateProductionAuth(a.cfg.API.Auth, production); err != nil {
+			return err
 		}
-		// 开发环境显示警告。
+	}
+	if controlPlaneEnabled && !a.cfg.API.Auth.Enabled {
 		log.Printf("\x1b[33m\x1b[1m⚠️  SECURITY WARNING: API authentication is DISABLED\x1b[0m")
 		log.Printf("\x1b[33m   For production, set api.auth.enabled=true and configure your auth method.\x1b[0m")
 		log.Printf("\x1b[33m   See docs/security.md for details.\x1b[0m")
@@ -123,9 +129,6 @@ func (a *App) Run(ctx context.Context) error {
 	}()
 	meta.ConfigureTracing(a.cfg.Tracing.Enabled && a.cfg.Tracing.Exporter != "disabled", tracerProvider)
 	defer meta.ConfigureTracing(false, nil)
-
-	// 解析运行角色：是否对外提供 API（control-plane）以及是否执行任务（worker）。
-	controlPlaneEnabled, workerEnabled := resolveRoleMode(a.cfg)
 
 	// opts 供 scheduler 使用；runnerOpts 供数据面 runner 使用。
 	opts := []tasks.Option{}
@@ -373,6 +376,31 @@ func (a *App) Run(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func productionMode(raw string) (bool, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return false, nil
+	}
+	production, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid PRODUCTION value %q: %w", value, err)
+	}
+	return production, nil
+}
+
+func validateProductionAuth(auth config.APIAuthConfig, production bool) error {
+	if !production {
+		return nil
+	}
+	if !auth.Enabled {
+		return errors.New("api.auth.enabled must be true in PRODUCTION mode (set PRODUCTION=false for development)")
+	}
+	if !auth.ProtectAPI || !auth.ProtectMetrics {
+		return errors.New("api.auth.protect_api and api.auth.protect_metrics must be true in PRODUCTION mode")
+	}
+	return config.ValidateAPIAuthConfig(auth)
 }
 
 func metadataSourceEndpoint(dsn string) (string, uint16, bool) {

--- a/internal/app/http_server_test.go
+++ b/internal/app/http_server_test.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
-// input: runtime config, scheduler/runner/meta store dependencies, process context
-// output: application lifecycle control including startup, role wiring, and shutdown
+// input: HTTP timeout config and PRODUCTION environment values
+// output: HTTP timeout plus production auth/boolean parsing regression coverage
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -35,5 +35,47 @@ func TestBuildHTTPServerAppliesTimeouts(t *testing.T) {
 	}
 	if server.IdleTimeout != 37*time.Second {
 		t.Fatalf("expected IdleTimeout=37s, got %s", server.IdleTimeout)
+	}
+}
+
+// TestValidateProductionAuthFailsClosed verifies production cannot accidentally expose either protected surface.
+func TestValidateProductionAuthFailsClosed(t *testing.T) {
+	for _, auth := range []config.APIAuthConfig{
+		{},
+		{Enabled: true, ProtectAPI: true},
+		{Enabled: true, ProtectMetrics: true},
+		{Enabled: true, Mode: "bearer", BearerToken: "test-token", ProtectAPI: true, ProtectMetrics: true},
+	} {
+		err := validateProductionAuth(auth, true)
+		if auth.Enabled && auth.ProtectAPI && auth.ProtectMetrics && auth.BearerToken != "" {
+			if err != nil {
+				t.Fatalf("expected protected production config to pass: %v", err)
+			}
+			continue
+		}
+		if err == nil {
+			t.Fatalf("expected production config %+v to fail closed", auth)
+		}
+	}
+	if err := validateProductionAuth(config.APIAuthConfig{}, false); err != nil {
+		t.Fatalf("development defaults must remain unchanged: %v", err)
+	}
+}
+
+func TestProductionMode(t *testing.T) {
+	for _, raw := range []string{"true", " TRUE ", "1"} {
+		production, err := productionMode(raw)
+		if err != nil || !production {
+			t.Fatalf("expected %q to enable production, got production=%t err=%v", raw, production, err)
+		}
+	}
+	for _, raw := range []string{"", " false ", "0"} {
+		production, err := productionMode(raw)
+		if err != nil || production {
+			t.Fatalf("expected %q to disable production, got production=%t err=%v", raw, production, err)
+		}
+	}
+	if _, err := productionMode("production"); err == nil {
+		t.Fatal("expected malformed PRODUCTION value to fail")
 	}
 }

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
-// input: runtime config, persisted active tasks, scheduler/runner/meta store dependencies, process context
-// output: application lifecycle coverage for startup recovery, role wiring, and shutdown
+// input: runtime config/template, persisted active tasks, scheduler/runner/meta store dependencies, process context
+// output: application lifecycle plus real-route production auth and worker-only regression coverage
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -192,6 +192,97 @@ func TestApp_StartAndServeHealth(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("app did not shut down in time")
+	}
+}
+
+// TestApp_ProductionAuthProtectsRealRoutes verifies config reaches the live app router without closing health checks.
+func TestApp_ProductionAuthProtectsRealRoutes(t *testing.T) {
+	t.Setenv("PRODUCTION", "TRUE")
+	t.Setenv("BINLOG_SERVER_API_AUTH_BEARER_TOKEN", "test-token")
+	t.Setenv("BINLOG_SERVER_LISTEN_ADDR", "127.0.0.1:0")
+	cfg, err := config.LoadConfig(filepath.Join("..", "..", "config.production.example.yaml"))
+	if err != nil {
+		t.Fatalf("load production template: %v", err)
+	}
+	if cfg.MetaDSN != "" {
+		t.Fatalf("production template must not require metadata credentials, got %q", cfg.MetaDSN)
+	}
+	a := New(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- a.Run(ctx) }()
+	defer func() {
+		cancel()
+		waitRunExit(t, errCh)
+	}()
+
+	waitReady(t, a)
+	base := "http://" + a.Addr()
+	assertHTTPStatus(t, base+"/healthz", http.StatusOK)
+	for _, path := range []string{"/api/tasks", "/metrics"} {
+		resp, err := http.Get(base + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("expected %s without auth to return 401, got %d", path, resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+
+		req, err := http.NewRequest(http.MethodGet, base+path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Authorization", "Bearer test-token")
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("authorized GET %s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected %s with bearer auth to return 200, got %d", path, resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+	}
+}
+
+// TestApp_ProductionWorkerOnlySkipsControlPlaneAuth verifies a worker-only process has no API surface to protect.
+func TestApp_ProductionWorkerOnlySkipsControlPlaneAuth(t *testing.T) {
+	t.Setenv("PRODUCTION", "1")
+	a := New(config.Config{
+		DataDir: t.TempDir(), Mode: "cluster", ListenAddr: "127.0.0.1:0",
+		Cluster: config.ClusterConfig{Role: "worker", WorkerID: "production-worker", WorkerHealthListenAddr: "127.0.0.1:0"},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- a.Run(ctx) }()
+	defer func() {
+		cancel()
+		waitRunExit(t, errCh)
+	}()
+
+	waitReady(t, a)
+	if a.Addr() != "" {
+		t.Fatalf("worker-only process must not expose control-plane API, got %q", a.Addr())
+	}
+	assertHTTPStatus(t, "http://"+a.WorkerHealthAddr()+"/healthz", http.StatusOK)
+}
+
+// TestApp_ProductionRejectsProgrammaticAuthSecrets verifies App.Run cannot bypass config validation before binding a listener.
+func TestApp_ProductionRejectsProgrammaticAuthSecrets(t *testing.T) {
+	t.Setenv("PRODUCTION", "true")
+	for _, auth := range []config.APIAuthConfig{
+		{Enabled: true, Mode: "bearer", ProtectAPI: true, ProtectMetrics: true},
+		{Enabled: true, Mode: "bearer", BearerToken: "${TOKEN}", ProtectAPI: true, ProtectMetrics: true},
+		{Enabled: true, Mode: "api_key", APIKeyHeader: "X-API-Key", ProtectAPI: true, ProtectMetrics: true},
+		{Enabled: true, Mode: "api_key", APIKey: "${TOKEN}", APIKeyHeader: "X-API-Key", ProtectAPI: true, ProtectMetrics: true},
+	} {
+		a := New(config.Config{ListenAddr: "127.0.0.1:0", API: config.APIConfig{Auth: auth}})
+		if err := a.Run(context.Background()); err == nil {
+			t.Fatalf("expected auth config %+v to fail before serving", auth)
+		}
+		if a.Addr() != "" {
+			t.Fatalf("invalid auth config bound a listener: %q", a.Addr())
+		}
 	}
 }
 

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -3,18 +3,20 @@
 ## Files
 | File | Responsibility |
 |------|---------------|
-| `config.go` | 配置模型、加载与默认值、校验（`meta_dsn` 为空时 standalone 控制面仅内存） |
-| `config_test.go` | 配置加载与覆盖规则测试 |
+| `config.go` | 配置模型、加载与默认值、校验（`meta_dsn` 为空时 standalone 控制面仅内存；受保护 auth 不接受未解析 `${ENV}` 密钥） |
+| `config_test.go` | 配置加载、覆盖规则和受保护 auth 未解析密钥测试 |
 | `encryption.go` | AES-256-GCM 配置值解密工具 |
 
 ## Exports
 - `LoadConfig(path)` - 加载配置（无加密）
 - `LoadConfigWithEncryption(path, key)` - 加载配置（支持解密）
+- `ValidateAPIAuthConfig(auth)` - 校验鉴权模式、路由保护与已解析凭证
 - `NewDecryptor(key)` - 创建解密器（32 字节 AES-256 密钥）
 - `Decryptor.DecryptIfEncrypted(value)` - 解密带 `enc:aes256:` 前缀的值
 
 ## Configuration Sections
 - `api.auth.*` - API 鉴权开关、模式（`bearer`/`api_key`）与凭证配置
+- `config.production.example.yaml`（仓库根目录）- 无密钥且可直接加载的生产模板；仅需环境变量注入 bearer token，并同时保护 `/api/*` 与 `/metrics`
 - `api.rate_limit.*` - API 限流配置（enabled/requests_per_second/burst），默认 100 req/s、burst 200
 - `http.control_plane.*` / `http.worker_health.*` - HTTP 超时配置
 - `meta.timeout.*` - 内部依赖调用超时配置

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 // Package config provides module-level functionality for config.
 // input: YAML files, environment variables, default config constants
-// output: validated runtime configuration structs for downstream modules
+// output: validated runtime configuration structs that reject unresolved protected-auth secrets
 // pos: configuration boundary translating external settings into internal options
 // note: if this file changes, update this header and module README.md.
 package config
@@ -86,9 +86,9 @@ type APIConfig struct {
 
 // RateLimitConfig 定义 API 速率限制配置。
 type RateLimitConfig struct {
-	Enabled            bool
-	RequestsPerSecond  float64
-	Burst              int
+	Enabled           bool
+	RequestsPerSecond float64
+	Burst             int
 }
 
 // APIAuthConfig 定义 /metrics 与 /api/* 鉴权策略。
@@ -452,7 +452,7 @@ func validateConfig(cfg Config) error {
 	if err := validateHTTPTimeoutConfig("http.worker_health", cfg.HTTP.WorkerHealth); err != nil {
 		return err
 	}
-	if err := validateAPIAuthConfig(cfg.API.Auth); err != nil {
+	if err := ValidateAPIAuthConfig(cfg.API.Auth); err != nil {
 		return err
 	}
 	if err := validateMetaTimeoutConfig("meta.timeout", cfg.Meta.Timeout); err != nil {
@@ -480,7 +480,8 @@ func validateHTTPTimeoutConfig(scope string, cfg HTTPServerTimeoutConfig) error 
 	return nil
 }
 
-func validateAPIAuthConfig(cfg APIAuthConfig) error {
+// ValidateAPIAuthConfig validates route protection, auth mode, and required resolved credentials.
+func ValidateAPIAuthConfig(cfg APIAuthConfig) error {
 	if !cfg.Enabled {
 		if cfg.ProtectAPI || cfg.ProtectMetrics {
 			return errors.New("api.auth.enabled=false cannot protect api or metrics routes")
@@ -490,11 +491,11 @@ func validateAPIAuthConfig(cfg APIAuthConfig) error {
 	mode := strings.ToLower(strings.TrimSpace(cfg.Mode))
 	switch mode {
 	case "bearer":
-		if strings.TrimSpace(cfg.BearerToken) == "" && (cfg.ProtectAPI || cfg.ProtectMetrics) {
+		if unresolvedSecret(cfg.BearerToken) && (cfg.ProtectAPI || cfg.ProtectMetrics) {
 			return errors.New("api.auth.bearer_token is required when protection is enabled")
 		}
 	case "api_key":
-		if strings.TrimSpace(cfg.APIKey) == "" && (cfg.ProtectAPI || cfg.ProtectMetrics) {
+		if unresolvedSecret(cfg.APIKey) && (cfg.ProtectAPI || cfg.ProtectMetrics) {
 			return errors.New("api.auth.api_key is required when protection is enabled")
 		}
 		if strings.TrimSpace(cfg.APIKeyHeader) == "" {
@@ -504,6 +505,10 @@ func validateAPIAuthConfig(cfg APIAuthConfig) error {
 		return fmt.Errorf("api.auth.mode must be bearer or api_key, got %q", cfg.Mode)
 	}
 	return nil
+}
+
+func unresolvedSecret(value string) bool {
+	return strings.TrimSpace(value) == "" || envPlaceholderPattern.MatchString(value)
 }
 
 func validateMetaTimeoutConfig(scope string, cfg MetaTimeoutConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,6 @@
 // Package config provides module-level functionality for config.
 // input: YAML files, environment variables, default config constants
-// output: validated runtime configuration structs for downstream modules
+// output: config loading regression coverage including unresolved protected-auth secret rejection
 // pos: configuration boundary translating external settings into internal options
 // note: if this file changes, update this header and module README.md.
 package config
@@ -546,5 +546,29 @@ func TestLoadConfig_InvalidAPIAuthValidation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "api.auth.bearer_token is required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestLoadConfig_RejectsUnresolvedProtectedAuthSecret verifies deployment templates cannot start protected routes with a missing environment secret.
+func TestLoadConfig_RejectsUnresolvedProtectedAuthSecret(t *testing.T) {
+	t.Setenv("BINLOG_SERVER_API_AUTH_ENABLED", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_MODE", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_BEARER_TOKEN", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_API", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_METRICS", "")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`api:
+  auth:
+    enabled: true
+    mode: bearer
+    bearer_token: "${BINLOG_SERVER_API_AUTH_BEARER_TOKEN}"
+    protect_api: true
+    protect_metrics: true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadConfig(path); err == nil || !strings.Contains(err.Error(), "api.auth.bearer_token is required") {
+		t.Fatalf("expected unresolved bearer token error, got %v", err)
 	}
 }

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -48,6 +48,7 @@
 ./scripts/e2e/run-suite.sh --scenarios smoke-worker-crash-recovery
 ./scripts/e2e/run-suite.sh --scenarios smoke-invalid-inputs
 ./scripts/e2e/run-suite.sh --scenarios smoke-retry-upload
+./scripts/e2e/run-suite.sh --scenarios smoke-scale
 ```
 
 也可用 `Makefile`：
@@ -56,6 +57,7 @@
 make e2e-quick
 make e2e-full
 make e2e-observability
+make e2e-scale
 make e2e SCENARIOS=smoke,compression
 make e2e-topology-check
 ```
@@ -80,6 +82,7 @@ make e2e-topology-check
 - `smoke-worker-crash-recovery.sh`: 模拟 worker 在 OPEN 期间崩溃，验证新 worker 接管后一致性（checkpoint 推进、stale OPEN 清理、sealed 文件与 md5 校验）。
 - `smoke-invalid-inputs.sh`: 验证任务 API 对非法输入返回 `400`（cluster_key/source/start/storage）。
 - `smoke-retry-upload.sh`: 验证上传失败后可通过 `/api/tasks/{id}/files/retry-upload` 人工触发补传，且不影响 checkpoint 推进。
+- `smoke-scale.sh`: 可选的 1000 控制面任务/100 实时流规模证据；复用单个 MySQL fixture（不把它当作数百个独立集群），按 100 条 batch 创建、校验分页/聚合、受控启动流，先写 priming marker 再快照每条 checkpoint，第二个 marker 后验证每条流推进及其 checkpoint 精确文件，并写入 JSON 报告。
 - `run-suite.sh`: 统一编排入口（自动 `up -> 启动服务 -> 跑场景 -> down`）。
 
 说明：当前所有场景创建任务时均显式传入 `cluster_key`（创建/更新必填且全局唯一）。
@@ -99,6 +102,10 @@ make e2e-topology-check
 - `E2E_WORKER_ID`: `smoke-cluster-roles.sh` 中 worker 进程上报的 worker_id（默认 `e2e-worker-1`）。
 - `E2E_WORKER_OFFLINE_WAIT_SEC`: `smoke-cluster-roles.sh` 停 worker 后等待离线判定的秒数（默认 `20`）。
 - `E2E_WORKER_HEALTH_ADDR`: `smoke-cluster-roles.sh` 中 worker health probe 地址（默认 `127.0.0.1:18081`）。
+- `E2E_SCALE_CONTROL_TASKS` / `E2E_SCALE_LIVE_STREAMS`: scale 场景的控制任务/实时流数，默认 `1000` / `100`；实时流最多显式提高到 `300`。
+- `E2E_SCALE_START_RATE`: 每秒启动实时流数（默认 `10`，最多 `25`，低于默认 API 限流）；`E2E_SCALE_REQUEST_DELAY_SEC` 控制 checkpoint 抓取节流；`E2E_SCALE_REPORT` 指定 JSON 证据输出路径。
+
+`smoke-scale` 要求 `E2E_SERVER_PID` 指向存活的 suite server。它会在 disposable `mysql57` 与 `meta-primary` 上执行 `SET GLOBAL max_connections = LIVE_STREAMS + 20`，重新读取并在数据库未接受该容量时失败；因此只适合此隔离 E2E Compose 环境。
 
 所有正式 E2E 入口都会加载 `lib-topology.sh`，必填值不能为空，端口必须处于 `1-65535`。Compose 保留同值兜底，仅用于直接执行 `docker compose ... ps/logs` 等排障命令；`make e2e-topology-check` 会阻止两处默认值漂移。
 

--- a/scripts/e2e/run-suite.sh
+++ b/scripts/e2e/run-suite.sh
@@ -44,6 +44,7 @@ Scenarios:
   smoke-worker-crash-recovery
   smoke-invalid-inputs
   smoke-retry-upload
+  smoke-scale
 EOF
 }
 
@@ -183,6 +184,9 @@ run_scenario() {
       ;;
     smoke-retry-upload)
       E2E_DATA_DIR="$DATA_DIR" "$ROOT_DIR/scripts/e2e/smoke-retry-upload.sh"
+      ;;
+    smoke-scale)
+      E2E_DATA_DIR="$DATA_DIR" E2E_SERVER_PID="$SERVER_PID" E2E_SERVER_LOG="$SERVER_LOG" "$ROOT_DIR/scripts/e2e/smoke-scale.sh"
       ;;
     *)
       echo "unsupported scenario: $name" >&2

--- a/scripts/e2e/smoke-scale.sh
+++ b/scripts/e2e/smoke-scale.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# input: canonical E2E topology, batch/pagination APIs, local capacity, and the suite server process
+# output: opt-in full-live-stream progress assertions and a machine-readable capacity/performance report
+# pos: E2E scale evidence for control-plane pagination and bounded live replication streams
+# note: if this file changes, update this header and module README.md.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/deploy/e2e/docker-compose.yml"
+source "$ROOT_DIR/scripts/e2e/lib-topology.sh"
+
+API="${E2E_API:-http://127.0.0.1:18080}"
+CONTROL_TASKS="${E2E_SCALE_CONTROL_TASKS:-1000}"
+LIVE_STREAMS="${E2E_SCALE_LIVE_STREAMS:-100}"
+START_RATE="${E2E_SCALE_START_RATE:-10}"
+REQUEST_DELAY="${E2E_SCALE_REQUEST_DELAY_SEC:-0.03}"
+DATA_DIR="${E2E_DATA_DIR:-$ROOT_DIR/tmp/e2e/data-scale-$(date +%s)}"
+SERVER_PID="${E2E_SERVER_PID:-}"
+SERVER_LOG="${E2E_SERVER_LOG:-/tmp/binlog-server-e2e-suite.log}"
+RUN_TAG="$(date +%s)"
+REPORT="${E2E_SCALE_REPORT:-$ROOT_DIR/tmp/e2e/scale-report-${RUN_TAG}.json}"
+TASK_IDS="$DATA_DIR/scale-task-ids.txt"
+CHECKPOINTS="$DATA_DIR/scale-checkpoints.tsv"
+PROGRESS_MISSING="$DATA_DIR/scale-progress-missing.txt"
+DATA_PATHS="$DATA_DIR/scale-data-paths.txt"
+
+fail() { echo "[scale] $*" >&2; exit 1; }
+need_cmd() { command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"; }
+is_uint() { [[ "$1" =~ ^[0-9]+$ ]]; }
+
+for cmd in curl jq docker awk sort df ps; do need_cmd "$cmd"; done
+is_uint "$CONTROL_TASKS" && (( CONTROL_TASKS >= 1000 && CONTROL_TASKS % 100 == 0 )) || fail "E2E_SCALE_CONTROL_TASKS must be a multiple of 100 and at least 1000"
+is_uint "$LIVE_STREAMS" && (( LIVE_STREAMS >= 1 && LIVE_STREAMS <= 300 )) || fail "E2E_SCALE_LIVE_STREAMS must be 1..300"
+is_uint "$START_RATE" && (( START_RATE >= 1 && START_RATE <= 25 )) || fail "E2E_SCALE_START_RATE must be 1..25"
+(( LIVE_STREAMS <= CONTROL_TASKS )) || fail "live streams cannot exceed control tasks"
+
+mkdir -p "$DATA_DIR" "$(dirname "$REPORT")"
+touch "$TASK_IDS"
+LOG_BYTES_BEFORE="$(wc -c <"$SERVER_LOG" 2>/dev/null || echo 0)"
+
+preflight() {
+  local fd min_fd disk_kb
+  [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1 || fail "E2E_SERVER_PID must name a live suite server before scale evidence runs"
+  fd="$(ulimit -n)"
+  min_fd=$((LIVE_STREAMS * 4 + 256))
+  is_uint "$fd" && (( fd >= min_fd )) || fail "fd capacity too low: have=$fd need=$min_fd (raise ulimit -n)"
+  disk_kb="$(df -Pk "$DATA_DIR" | awk 'NR==2 {print $4}')"
+  is_uint "$disk_kb" && (( disk_kb >= ${E2E_SCALE_MIN_DISK_MB:-1024} * 1024 )) || fail "disk capacity too low: have=${disk_kb:-unknown}KB need=${E2E_SCALE_MIN_DISK_MB:-1024}MB"
+  ensure_max_connections mysql57
+  SOURCE_MAX_CONNECTIONS="$MAX_CONNECTIONS"
+  ensure_max_connections meta-primary
+  META_MAX_CONNECTIONS="$MAX_CONNECTIONS"
+  PREFLIGHT_FD="$fd" PREFLIGHT_DISK_KB="$disk_kb"
+}
+
+ensure_max_connections() {
+  local service="$1" desired=$((LIVE_STREAMS + 20))
+  docker compose -f "$COMPOSE_FILE" exec -T "$service" mysql -uroot -proot -e "SET GLOBAL max_connections = $desired" >/dev/null
+  MAX_CONNECTIONS="$(docker compose -f "$COMPOSE_FILE" exec -T "$service" mysql -N -uroot -proot -e "SHOW VARIABLES LIKE 'max_connections'" | awk '{print $2}')"
+  [[ "$MAX_CONNECTIONS" == "$desired" ]] || fail "$service max_connections not honored: have=${MAX_CONNECTIONS:-unknown} need=$desired"
+}
+
+api() {
+  local method="$1" path="$2" data="${3:-}" raw
+  if [[ -n "$data" ]]; then
+    raw="$(curl -sS -w $'\n%{http_code}' -X "$method" "$API$path" -H 'Content-Type: application/json' --data "$data")" || fail "request failed: $method $path"
+  else
+    raw="$(curl -sS -w $'\n%{http_code}' -X "$method" "$API$path")" || fail "request failed: $method $path"
+  fi
+  API_STATUS="${raw##*$'\n'}"
+  API_BODY="${raw%$'\n'*}"
+  [[ "$API_STATUS" != "429" && "$API_STATUS" != 5* ]] || fail "unexpected HTTP $API_STATUS: $method $path body=$API_BODY"
+}
+
+create_batch() {
+  local first="$1" count="$2" payload
+  payload="$(jq -n --arg tag "$RUN_TAG" --arg host "$E2E_SOURCE_HOST" --arg user "$E2E_SOURCE_USER" --arg pass "$E2E_SOURCE_PASS" --argjson port "$E2E_MYSQL57_PORT" --argjson first "$first" --argjson count "$count" '
+    {items: [range($first; $first + $count) | {
+      name: ("e2e-scale-" + $tag + "-" + tostring),
+      cluster_key: ("e2e-scale-" + $tag + "-" + tostring),
+      source: {host:$host, port:$port, user:$user, password:$pass, flavor:"mysql", server_id:(610000 + .)},
+      start: {mode:"LATEST"}, storage:{retention_days:7}
+    }]}')"
+  api POST /api/tasks/batch "$payload"
+  [[ "$API_STATUS" == "200" ]] || fail "batch create returned $API_STATUS: $API_BODY"
+  printf '%s' "$API_BODY" | jq -e --argjson expected "$count" '[.[] | select(.task != null)] | length == $expected and ([.[] | select(.error != null)] | length == 0)' >/dev/null || fail "batch did not fully succeed"
+  printf '%s' "$API_BODY" | jq -r '.[].task.id' >>"$TASK_IDS"
+}
+
+verify_pagination() {
+  local offset body
+  : >"$DATA_DIR/reassembled-ids.txt"
+  for ((offset=0; offset<CONTROL_TASKS; offset+=100)); do
+    api GET "/api/tasks?limit=100&offset=$offset"
+    [[ "$API_STATUS" == "200" ]] || fail "task pagination returned $API_STATUS"
+    printf '%s' "$API_BODY" | jq -e --argjson total "$CONTROL_TASKS" '.total == $total and .limit == 100 and (.items | length) <= 100' >/dev/null || fail "bad task page metadata at offset=$offset"
+    printf '%s' "$API_BODY" | jq -r '.items[].id' >>"$DATA_DIR/reassembled-ids.txt"
+  done
+  [[ "$(sort "$TASK_IDS" | uniq | wc -l | tr -d ' ')" == "$CONTROL_TASKS" ]] || fail "created task ids are not unique"
+  [[ "$(sort "$DATA_DIR/reassembled-ids.txt" | uniq | wc -l | tr -d ' ')" == "$CONTROL_TASKS" ]] || fail "pagination has gaps or duplicates"
+  cmp <(sort "$TASK_IDS") <(sort "$DATA_DIR/reassembled-ids.txt") || fail "pagination did not reassemble all task ids"
+
+  api GET "/api/dashboard?limit=100&offset=0"
+  [[ "$API_STATUS" == "200" ]] || fail "dashboard returned $API_STATUS"
+  printf '%s' "$API_BODY" | jq -e --argjson total "$CONTROL_TASKS" '
+    .total == $total and .summary.total == $total and (.tasks | length) == 100 and
+    ([.sources[].task_count] | add) == $total' >/dev/null || fail "dashboard aggregation or detail pagination is incomplete"
+}
+
+write_source_marker() {
+  local marker="$1"
+  docker compose -f "$COMPOSE_FILE" exec -T mysql57 mysql -uroot -proot -e "INSERT INTO binlog_e2e_57.t1(v) VALUES('${marker}');"
+}
+
+start_live_streams() {
+  local i id state
+  LIVE_IDS=()
+  while IFS= read -r id; do LIVE_IDS+=("$id"); done < <(head -n "$LIVE_STREAMS" "$TASK_IDS")
+  for ((i=0; i<LIVE_STREAMS; i++)); do
+    id="${LIVE_IDS[$i]}"
+    api POST "/api/tasks/$id/start"
+    [[ "$API_STATUS" == "204" ]] || fail "start failed for $id: $API_STATUS $API_BODY"
+    sleep "$(awk -v rate="$START_RATE" 'BEGIN { printf "%.3f", 1/rate }')"
+  done
+  for _ in {1..180}; do
+    api GET /api/summary
+    if printf '%s' "$API_BODY" | jq -e --argjson live "$LIVE_STREAMS" '.running == $live and .failed == 0 and .retry_backoff == 0' >/dev/null; then return; fi
+    sleep 1
+  done
+  fail "live streams did not converge: $API_BODY"
+}
+
+snapshot_checkpoints() {
+  local id file pos
+  : >"$CHECKPOINTS"
+  for id in "${LIVE_IDS[@]}"; do
+    for _ in {1..120}; do
+      api GET "/api/tasks/$id/checkpoint"
+      file="$(printf '%s' "$API_BODY" | jq -r '.file // ""')"; pos="$(printf '%s' "$API_BODY" | jq -r '.pos // 0')"
+      [[ "$API_STATUS" == "200" && -n "$file" && "$pos" =~ ^[0-9]+$ ]] && break
+      sleep 1
+    done
+    [[ "$API_STATUS" == "200" && -n "$file" && "$pos" =~ ^[0-9]+$ ]] || fail "checkpoint not ready for $id: $API_BODY"
+    printf '%s\t%s\t%s\n' "$id" "$file" "$pos" >>"$CHECKPOINTS"
+    sleep "$REQUEST_DELAY"
+  done
+}
+
+verify_all_progress() {
+  local id before_file before_pos file pos advanced=0
+  : >"$PROGRESS_MISSING"; : >"$DATA_PATHS"
+  write_source_marker "scale-progress-${RUN_TAG}"
+  while IFS=$'\t' read -r id before_file before_pos; do
+    for _ in {1..180}; do
+      api GET "/api/tasks/$id/checkpoint"
+      file="$(printf '%s' "$API_BODY" | jq -r '.file // ""')"; pos="$(printf '%s' "$API_BODY" | jq -r '.pos // 0')"
+      if [[ "$file" != "$before_file" || ( "$pos" =~ ^[0-9]+$ && "$pos" -gt "$before_pos" ) ]]; then break; fi
+      sleep "$REQUEST_DELAY"
+    done
+    if [[ "$file" == "$before_file" && ( ! "$pos" =~ ^[0-9]+$ || "$pos" -le "$before_pos" ) ]]; then
+      printf '%s\n' "$id" >>"$PROGRESS_MISSING"
+      continue
+    fi
+    [[ -s "$DATA_DIR/$id/$file" ]] || { printf '%s\n' "$id" >>"$PROGRESS_MISSING"; continue; }
+    printf '%s\t%s\n' "$id" "$DATA_DIR/$id/$file" >>"$DATA_PATHS"
+    advanced=$((advanced + 1))
+    sleep "$REQUEST_DELAY"
+  done <"$CHECKPOINTS"
+  PROGRESS_ADVANCED="$advanced"
+  PROGRESS_MISSING_COUNT="$(wc -l <"$PROGRESS_MISSING" | tr -d ' ')"
+  [[ "$PROGRESS_MISSING_COUNT" == "0" ]] || fail "not every live stream advanced or wrote an open file: $(tr '\n' ' ' <"$PROGRESS_MISSING")"
+  [[ "$(cut -f1 "$DATA_PATHS" | sort -u | wc -l | tr -d ' ')" == "$LIVE_STREAMS" ]] || fail "live task IDs are not uniquely evidenced"
+  [[ "$(cut -f2 "$DATA_PATHS" | sort -u | wc -l | tr -d ' ')" == "$LIVE_STREAMS" ]] || fail "live task data paths are not unique"
+}
+
+verify_unreachable() {
+  local bad_payload bad_id state err
+  bad_payload="$(jq -n --arg tag "$RUN_TAG" '{name:("e2e-scale-unreachable-"+$tag),cluster_key:("e2e-scale-unreachable-"+$tag),source:{host:"127.0.0.1",port:1,user:"repl",password:"replpass",flavor:"mysql",server_id:999999},start:{mode:"LATEST"},storage:{retention_days:7}}')"
+  api POST /api/tasks "$bad_payload"; [[ "$API_STATUS" == "201" ]] || fail "unreachable task create failed"
+  bad_id="$(printf '%s' "$API_BODY" | jq -r '.id')"
+  api POST "/api/tasks/$bad_id/start"; [[ "$API_STATUS" == "204" ]] || fail "unreachable task start failed"
+  for _ in {1..300}; do
+    api GET "/api/tasks/$bad_id"
+    state="$(printf '%s' "$API_BODY" | jq -r '.state // empty')"
+    err="$(printf '%s' "$API_BODY" | jq -r '.last_error // empty')"
+    [[ "$state" == "FAILED" && "$err" == *SOURCE_UNREACHABLE* ]] && return
+    sleep 1
+  done
+  fail "unreachable source did not converge to FAILED/SOURCE_UNREACHABLE (state=$state error=$err)"
+}
+
+percentiles() {
+  local path="$1" samples="$DATA_DIR/latency-$(echo "$path" | tr '/?&=' '_').txt" sample status latency n p50 p95
+  : >"$samples"
+  for _ in {1..20}; do
+    sample="$(curl -sS -o /dev/null -w '%{http_code} %{time_total}' "$API$path")" || fail "latency sample failed: $path"
+    status="${sample%% *}"; latency="${sample#* }"
+    [[ "$status" != "429" && "$status" != 5* && "$status" == 2* ]] || fail "unexpected HTTP $status while sampling $path"
+    printf '%s\n' "$latency" >>"$samples"
+  done
+  sort -n "$samples" -o "$samples"; n="$(wc -l <"$samples" | tr -d ' ')"
+  p50="$(awk -v n="$n" 'NR == int((n+1)*.50) {print; exit}' "$samples")"
+  p95="$(awk -v n="$n" 'NR == int((n+1)*.95) {print; exit}' "$samples")"
+  printf '%s %s' "$p50" "$p95"
+}
+
+preflight
+echo "[scale] create $CONTROL_TASKS control tasks in batches of 100"
+for ((start=0; start<CONTROL_TASKS; start+=100)); do create_batch "$start" 100; done
+verify_pagination
+start_live_streams
+write_source_marker "scale-prime-${RUN_TAG}"
+snapshot_checkpoints
+verify_all_progress
+verify_unreachable
+
+read -r API_P50 API_P95 <<<"$(percentiles '/api/tasks?limit=100&offset=0')"
+read -r DASHBOARD_P50 DASHBOARD_P95 <<<"$(percentiles '/api/dashboard?limit=100&offset=0')"
+read -r METRICS_P50 METRICS_P95 <<<"$(percentiles '/metrics')"
+RSS_KB="$(ps -o rss= -p "$SERVER_PID" 2>/dev/null | tr -d ' ' || true)"
+LOG_BYTES_AFTER="$(wc -c <"$SERVER_LOG" 2>/dev/null || echo "$LOG_BYTES_BEFORE")"
+SOURCE_THREADS="$(docker compose -f "$COMPOSE_FILE" exec -T mysql57 mysql -N -uroot -proot -e "SHOW STATUS LIKE 'Threads_connected'" | awk '{print $2}')"
+META_THREADS="$(docker compose -f "$COMPOSE_FILE" exec -T meta-primary mysql -N -uroot -proot -e "SHOW STATUS LIKE 'Threads_connected'" | awk '{print $2}')"
+
+jq -n \
+  --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg api "$API" \
+  --argjson control_tasks "$CONTROL_TASKS" --argjson live_streams "$LIVE_STREAMS" --argjson start_rate "$START_RATE" \
+  --argjson fd_limit "$PREFLIGHT_FD" --argjson disk_available_kb "$PREFLIGHT_DISK_KB" --argjson source_max_connections "$SOURCE_MAX_CONNECTIONS" --argjson meta_max_connections "$META_MAX_CONNECTIONS" \
+  --argjson source_threads_connected "${SOURCE_THREADS:-0}" --argjson meta_threads_connected "${META_THREADS:-0}" --argjson process_rss_kb "${RSS_KB:-0}" \
+  --argjson log_delta_bytes "$((LOG_BYTES_AFTER - LOG_BYTES_BEFORE))" \
+  --argjson api_p50 "$API_P50" --argjson api_p95 "$API_P95" --argjson dashboard_p50 "$DASHBOARD_P50" --argjson dashboard_p95 "$DASHBOARD_P95" --argjson metrics_p50 "$METRICS_P50" --argjson metrics_p95 "$METRICS_P95" --argjson progress_expected "$LIVE_STREAMS" --argjson progress_advanced "$PROGRESS_ADVANCED" --argjson progress_missing "$PROGRESS_MISSING_COUNT" --argjson unique_ids "$(cut -f1 "$DATA_PATHS" | sort -u | wc -l | tr -d ' ')" --argjson unique_data_paths "$(cut -f2 "$DATA_PATHS" | sort -u | wc -l | tr -d ' ')" --rawfile data_path_evidence "$DATA_PATHS" \
+  '{generated_at:$generated_at,api:$api,control_tasks:$control_tasks,live_streams:$live_streams,start_rate_per_second:$start_rate,preflight:{fd_limit:$fd_limit,disk_available_kb:$disk_available_kb,source_max_connections:$source_max_connections,meta_max_connections:$meta_max_connections},capacity:{source_threads_connected:$source_threads_connected,meta_threads_connected:$meta_threads_connected,process_rss_kb:$process_rss_kb,server_log_delta_bytes:$log_delta_bytes},progress:{expected:$progress_expected,advanced:$progress_advanced,missing:$progress_missing,unique_task_ids:$unique_ids,unique_data_paths:$unique_data_paths,evidence:($data_path_evidence | split("\n") | map(select(length > 0) | split("\t") | {task_id:.[0],data_path:.[1]}))},latency_seconds:{api:{p50:$api_p50,p95:$api_p95},dashboard:{p50:$dashboard_p50,p95:$dashboard_p95},metrics:{p50:$metrics_p50,p95:$metrics_p95}},notes:["One MySQL fixture supplies many clients; this does not model independent source clusters.","No performance SLA is asserted."]}' >"$REPORT"
+echo "[scale] PASS report=$REPORT"


### PR DESCRIPTION
## Summary

- fail closed for production control-plane auth, including strict PRODUCTION parsing and programmatic config validation
- add a secret-free production config template verified through real API, metrics, and health routes
- add opt-in make e2e-scale coverage for 1000 control tasks and 100–300 live streams
- batch creation, pagination/aggregate completeness, per-stream checkpoint/file progress, unreachable-source convergence, capacity preflight, and JSON evidence are covered by the scenario

## Verification

- go test ./...
- affected race tests
- go vet ./...
- make e2e-topology-check
- Bash syntax and report-JQ validation
- three independent exact-SHA final reviews: P0/P1/P2 = 0

The scale scenario is intentionally opt-in and was not run locally because the Docker engine remains blocked by an unrelated InnoDB No space left on device condition. No unrelated Docker data was deleted, and this PR does not claim a scale pass without a generated report.

Refs #38