### PR TITLE
docs: prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Maintenance rules:
 
 ## [Unreleased]
 
+## [v0.5.0] - 2026-08-30
+
+### Added
+
+- `POST /api/tasks/batch` accepts 1..100 task-create requests and returns ordered per-item success or structured error results, so a valid batch can report partial success without stopping later items.
+- Task and dashboard queries support bounded `limit`/`offset` paging and `state` filtering. Dashboard summary and source aggregates cover the complete filtered result, while task details are paged; the frontend uses server paging.
+- Production deployments can start from `config.production.example.yaml`, which enables bearer authentication and protects both `/api/*` and `/metrics`; unresolved credential placeholders are rejected. An opt-in `make e2e-scale` harness writes a JSON evidence report for its isolated 1000-control-task / 100-live-stream scenario.
+
+### Changed
+
+- **API contract change:** `GET /api/tasks` now returns `{items,total,limit,offset}` instead of a raw JSON array `[...]`. Upgrade API clients to read `items` and use the returned page metadata before deploying `v0.5.0`.
+- Summaries report `STARTING` separately from `RUNNING`.
+
+### Fixed
+
+- Unreachable replication sources now fail after bounded retries instead of retrying indefinitely; disconnected source streams follow the bounded retry path.
+
 ## [v0.4.3] - 2026-08-30
 
 ### Fixed

--- a/docs/releases/release-notes-v0.5.0.md
+++ b/docs/releases/release-notes-v0.5.0.md
@@ -1,0 +1,26 @@
+# Binlog Server v0.5.0
+
+Release date: 2026-08-30
+
+Binlog Server `v0.5.0` improves control-plane scale handling, batch task creation, source-failure handling, and production authentication defaults.
+
+## Highlights
+
+- Unreachable replication sources and disconnected source streams now use bounded retries and enter failure instead of retrying forever.
+- `STARTING` is reported separately from `RUNNING` in summary and dashboard views.
+- `GET /api/tasks` and `GET /api/dashboard` support `state` filtering and bounded `limit`/`offset` paging. Dashboard summary and source aggregation cover all filtered tasks; only task details are paged. The frontend follows the server paging contract.
+- `POST /api/tasks/batch` accepts 1..100 create requests. A malformed envelope fails as HTTP 400 without creating tasks; a valid envelope returns ordered per-item results, allowing later items to succeed when another item fails.
+- `config.production.example.yaml` provides an authenticated control-plane starting point. In `PRODUCTION=true`, control-plane API and metrics protection are required and unresolved auth-secret placeholders are rejected.
+- `make e2e-scale` is an opt-in isolated evidence harness for 1000 control-plane tasks and 100 live streams. It produces a JSON report; it has not been run or used to claim production-capacity validation for this release.
+
+## Upgrade Notes
+
+- **Breaking API response change:** `GET /api/tasks` now returns `{ "items": [...], "total": N, "limit": N, "offset": N }` instead of a raw JSON array `[...]`. Update clients to read `items`, honor the returned page metadata, and request additional pages as needed.
+- No schema migration is required for `v0.5.0`.
+- For production control-plane deployments, begin with `config.production.example.yaml`, set `BINLOG_SERVER_API_AUTH_BEARER_TOKEN`, and keep API and metrics protection enabled. The scale harness is opt-in and requires its generated JSON report as evidence; do not infer scale or production-capacity results from its presence.
+
+## Chinese Release Notes
+
+Chinese version:
+
+https://github.com/Fanduzi/BinlogServer/blob/main/docs/releases/v0.5.0.zh-CN.md

--- a/docs/releases/v0.5.0.zh-CN.md
+++ b/docs/releases/v0.5.0.zh-CN.md
@@ -1,0 +1,22 @@
+# Binlog Server v0.5.0 中文发布说明
+
+> 对应版本：`v0.5.0`
+
+发布日期：2026-08-30
+
+`v0.5.0` 改进了控制面规模处理、批量创建任务、source 失败处理以及生产环境认证默认配置。
+
+## 核心变化
+
+- 不可达的复制 source 和已断开的 source stream 现在采用有上限的重试，达到上限后进入失败状态，不再无限重试。
+- 汇总和 dashboard 将 `STARTING` 与 `RUNNING` 分开统计。
+- `GET /api/tasks` 与 `GET /api/dashboard` 支持 `state` 过滤以及受限的 `limit`/`offset` 分页。dashboard 的 summary 和 source 聚合覆盖全部过滤结果，只有任务明细按页返回；前端已使用服务端分页契约。
+- `POST /api/tasks/batch` 可接收 1..100 个创建请求。envelope 格式错误时返回 HTTP 400 且不创建任务；合法 envelope 返回有序的逐项结果，一项失败不会阻止后续项成功。
+- `config.production.example.yaml` 提供了带认证的控制面起点。`PRODUCTION=true` 时，控制面 API 与 metrics 必须启用保护，未解析的认证密钥占位符会被拒绝。
+- `make e2e-scale` 是隔离环境中的可选规模证据 harness，面向 1000 个控制面任务和 100 条实时流，并生成 JSON 报告。本版本未运行该 harness，也未据此宣称通过生产容量验证。
+
+## 升级影响
+
+- **API 响应契约变更：**`GET /api/tasks` 已从原始 JSON 数组 `[...]` 改为 `{ "items": [...], "total": N, "limit": N, "offset": N }`。升级前请将客户端读取字段改为 `items`，使用返回的分页元数据，并按需请求后续页面。
+- `v0.5.0` 不需要 schema migration。
+- 生产控制面部署请从 `config.production.example.yaml` 开始，设置 `BINLOG_SERVER_API_AUTH_BEARER_TOKEN`，并保持 API 与 metrics 保护开启。scale harness 仅为 opt-in；必须生成并审阅 JSON 报告后，才能将其作为规模证据，不能因其存在而推断规模或生产容量结果。


### PR DESCRIPTION
## Summary

- add v0.5.0 changelog entries
- add English and Chinese release notes
- document the raw-array to paginated /api/tasks response migration
- disclose that e2e-scale remains opt-in and no production-capacity result is claimed without its JSON report

## Verification

- go test ./... -count=1
- go vet ./...
- goreleaser check
- four-platform release asset build at exact candidate SHA
- checksum verification
- Linux archive compatibility validation
- independent exact-SHA release-note review: P0/P1/P2 = 0