### PR TITLE
docs: pin API worker example to v0.5.1

### DIFF
--- a/docs/guide/reference/api.md
+++ b/docs/guide/reference/api.md
@@ -469,7 +469,7 @@ curl "http://localhost:8080/api/workers?limit=10"
       "session_id": "abc123",
       "role": "worker",
       "host": "10.0.1.1",
-      "version": "v0.4.3",
+      "version": "v0.5.1",
       "status": "ONLINE",
       "expires_at": "2024-01-01T10:10:00Z",
       "updated_at": "2024-01-01T10:00:00Z"


### PR DESCRIPTION
## Summary

- bump the `/api/workers` sample `"version"` from `v0.4.3` to `v0.5.1`
- this is the remaining current-version pin from the v0.4.2/v0.4.3 release surface; it was missed in v0.5.0 and v0.5.1

No runtime change. No new tag.