### PR TITLE
fix: sort task list pages by numeric id

### DIFF
--- a/frontend/src/mocks/README.md
+++ b/frontend/src/mocks/README.md
@@ -14,7 +14,7 @@
 - 共享 mock 场景数据（含 `pagination`）
 - 共享 mock request handler / session factory
 - `/api/tasks/batch` mock：校验 1..100 envelope，返回有序 `{index,cluster_key,task|error}`，并脱敏成功任务密码。
-- Dashboard summary/source response 中按任务状态分别生成 `starting` 与 `running`，并按全量过滤结果返回 `total/limit/offset`；pagination 场景覆盖后页当前页匹配，limit 超过 500 返回 400。
+- Dashboard summary/source response 中按任务状态分别生成 `starting` 与 `running`，并按全量过滤结果返回 `total/limit/offset`；任务页按数字 id 升序（非数字 id 排在数字之后），pagination 场景覆盖后页当前页匹配，limit 超过 500 返回 400。
 
 ## Dependencies
 

--- a/frontend/src/mocks/mock-handler.js
+++ b/frontend/src/mocks/mock-handler.js
@@ -1,5 +1,5 @@
 // input: mock scenario name plus normalized API request method/path/query/body tuples
-// output: deterministic mock API responses including batch task results, server pagination/filter validation, independent STARTING counters for frontend dev mode and Playwright route interception
+// output: deterministic mock API responses including batch task results, numeric-id-ordered server pagination/filter validation, independent STARTING counters for frontend dev mode and Playwright route interception
 // pos: shared frontend mock request handler between api.js and test route adapters
 // note: if this file changes, update this header and frontend/src/mocks/README.md.
 
@@ -25,6 +25,22 @@ function parseInteger(value) {
   if (!/^-?\d+$/.test(raw)) return null;
   const number = Number(raw);
   return Number.isSafeInteger(number) ? number : null;
+}
+
+function compareNumericTaskID(a, b) {
+  const left = String(a ?? "");
+  const right = String(b ?? "");
+  const leftNum = /^[0-9]+$/.test(left) ? Number(left) : null;
+  const rightNum = /^[0-9]+$/.test(right) ? Number(right) : null;
+  const leftOK = leftNum !== null && Number.isSafeInteger(leftNum);
+  const rightOK = rightNum !== null && Number.isSafeInteger(rightNum);
+  if (leftOK && rightOK) {
+    if (leftNum !== rightNum) return leftNum - rightNum;
+    return left.localeCompare(right);
+  }
+  if (leftOK) return -1;
+  if (rightOK) return 1;
+  return left.localeCompare(right);
 }
 
 function deepClone(value) {
@@ -289,7 +305,7 @@ function filteredTaskRows(state, taskQuery) {
         (!taskQuery.state || row.task?.state === taskQuery.state)
       );
     })
-    .sort((a, b) => String(a.task?.id || "").localeCompare(String(b.task?.id || "")));
+    .sort((a, b) => compareNumericTaskID(a.task?.id, b.task?.id));
 }
 
 function currentDashboard(state, query) {

--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -19,7 +19,7 @@
 - `WithRateLimit(RateLimiterConfig) ServerOption` - 注入限流配置
 - `GET /api/summary` - 返回兼容既有字段的任务计数；`starting` 单独统计 STARTING，`running` 仅统计 runner ready 后的 RUNNING。
 - `GET /api/dashboard` - 返回同口径 summary、任务明细与 source 聚合；source 状态计数同时暴露 `starting` 与 `running`。
-- `GET /api/tasks` - 返回 `{items,total,limit,offset}` 任务页；支持 host/port/state 过滤，默认 limit=100，limit 必须为 1..500，超过 500 返回 400 `invalid limit`。
+- `GET /api/tasks` - 返回 `{items,total,limit,offset}` 任务页；页序为数字 id 升序；支持 host/port/state 过滤，默认 limit=100，limit 必须为 1..500，超过 500 返回 400 `invalid limit`。
 - `GET /api/dashboard` - 支持同一组过滤/分页参数；`summary`/`sources` 按全量过滤结果聚合，仅 `tasks` 明细切页，并返回 `total/limit/offset`。
 - `POST /api/tasks/batch` - 接收 `items` 数组（1..100 个现有创建请求），整包 envelope 错误返回 400 且不创建；合法 envelope 按顺序逐项调用 `CreateTaskFromSpec`，返回 200 的 `{index,cluster_key,task|error}` 结果数组。
 
@@ -37,7 +37,7 @@
 - 文件观测：`GET /api/tasks/{id}/files` 返回当前 `OPEN` segment 与历史 `SEALED` 文件。
 - 状态汇总：summary/dashboard 保留既有计数键，并新增 `starting`；STARTING 不混入 `running`。
 - Source 聚合：dashboard source 项保留 `running`，并新增独立 `starting` 状态计数。
-- 服务端分页：任务与 dashboard 使用稳定 task ID 顺序在全量快照上过滤、计数和切片；非法 state/limit/offset/port 返回 400，limit 超过 500 返回 `invalid limit`。
+- 服务端分页：任务与 dashboard 在全量快照上过滤、计数和切片，页序按数字 task ID 升序（非数字 ID 排在数字之后、按字符串稳定排序）；非法 state/limit/offset/port 返回 400，limit 超过 500 返回 `invalid limit`。
 - 限流：基于 IP 的令牌桶限流，默认 100 req/s，burst 200
 - Tracing：OTel HTTP span（可选）
 

--- a/internal/api/handlers_tasks.go
+++ b/internal/api/handlers_tasks.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces, shared source endpoint identity
-// output: REST API JSON responses including single/batch task creation, paginated task/dashboard data, loopback-equivalent source lookup, independent STARTING/RUNNING counters, and structured 400 bodies
+// output: REST API JSON responses including single/batch task creation, numeric-id-ordered paginated task/dashboard data, loopback-equivalent source lookup, independent STARTING/RUNNING counters, and structured 400 bodies
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -810,11 +810,39 @@ func filterTasksByQuery(items []tasks.Task, query taskListQuery) []tasks.Task {
 	return out
 }
 
-// sortTasksByID keeps API pages aligned with the metadata store's ORDER BY id convention.
+// sortTasksByID keeps API pages aligned with the metadata store's
+// ORDER BY CAST(id AS UNSIGNED), id convention: numeric ids ascending,
+// then non-numeric ids by string.
 func sortTasksByID(items []tasks.Task) {
 	sort.SliceStable(items, func(i, j int) bool {
-		return items[i].ID < items[j].ID
+		return lessTaskID(items[i].ID, items[j].ID)
 	})
+}
+
+func lessTaskID(a, b string) bool {
+	ai, aOK := parseNumericTaskID(a)
+	bi, bOK := parseNumericTaskID(b)
+	switch {
+	case aOK && bOK:
+		if ai != bi {
+			return ai < bi
+		}
+		return a < b
+	case aOK:
+		return true
+	case bOK:
+		return false
+	default:
+		return a < b
+	}
+}
+
+func parseNumericTaskID(id string) (uint64, bool) {
+	n, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 func taskPageBounds(total, offset, limit int) (int, int) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces, task/error states, and shared source endpoint identity
-// output: REST/dashboard responses, task pagination/filter validation regression coverage, batch task creation contracts, operator error visibility, independent STARTING/RUNNING status counters, task/cluster status codes, and source lookup regression coverage
+// output: REST/dashboard responses, task pagination/filter validation and numeric task-id page order coverage, batch task creation contracts, operator error visibility, independent STARTING/RUNNING status counters, task/cluster status codes, and source lookup regression coverage
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -2454,6 +2454,127 @@ func TestTaskAPI_TaskPaginationAndDashboardAggregation(t *testing.T) {
 	if len(dashboard.Tasks) != 1 || dashboard.Tasks[0].Task.Source.Password != "" || len(dashboard.Sources) != 1 || dashboard.Sources[0].TaskCount != combinedTasks || dashboard.Sources[0].Abnormal != combinedTasks {
 		t.Fatalf("unexpected dashboard page/source response: %+v", dashboard)
 	}
+}
+
+// TestTaskAPI_ListTasksNumericIDPageOrder 验证任务列表按数字 id 升序分页，非数字 id 排在数字之后。
+func TestTaskAPI_ListTasksNumericIDPageOrder(t *testing.T) {
+	store := newFakeAPIRunHistoryStore()
+	for _, id := range []string{"100", "10", "2", "1", "task-b", "task-a"} {
+		store.tasks[id] = tasks.Task{
+			ID:         id,
+			Name:       "task-" + id,
+			ClusterKey: "cluster-" + id,
+			State:      tasks.StateCreated,
+			Source: tasks.SourceConfig{
+				Host:     "db-a",
+				Port:     3306,
+				User:     "repl",
+				Password: "secret",
+			},
+		}
+	}
+	scheduler := tasks.NewScheduler(tasks.WithStore(store))
+	if err := scheduler.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	handler := NewServer(scheduler)
+
+	type taskPage struct {
+		Items  []tasks.Task `json:"items"`
+		Total  int          `json:"total"`
+		Limit  int          `json:"limit"`
+		Offset int          `json:"offset"`
+	}
+	getIDs := func(path string) []string {
+		t.Helper()
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, path, nil))
+		if resp.Code != http.StatusOK {
+			t.Fatalf("%s returned %d body=%s", path, resp.Code, resp.Body.String())
+		}
+		var page taskPage
+		if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+			t.Fatalf("decode %s: %v body=%s", path, err, resp.Body.String())
+		}
+		ids := make([]string, len(page.Items))
+		for i, item := range page.Items {
+			ids[i] = item.ID
+		}
+		return ids
+	}
+
+	if got, want := getIDs("/api/tasks?limit=10&offset=0"), []string{"1", "2", "10", "100", "task-a", "task-b"}; !equalStrings(got, want) {
+		t.Fatalf("first page ids = %v, want %v", got, want)
+	}
+	if got, want := getIDs("/api/tasks?limit=2&offset=0"), []string{"1", "2"}; !equalStrings(got, want) {
+		t.Fatalf("offset=0 limit=2 ids = %v, want %v", got, want)
+	}
+	if got, want := getIDs("/api/tasks?limit=2&offset=2"), []string{"10", "100"}; !equalStrings(got, want) {
+		t.Fatalf("offset=2 limit=2 ids = %v, want %v", got, want)
+	}
+
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/api/dashboard?limit=10&offset=0", nil))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("dashboard returned %d body=%s", resp.Code, resp.Body.String())
+	}
+	var dashboard struct {
+		Tasks []struct {
+			Task tasks.Task `json:"task"`
+		} `json:"tasks"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &dashboard); err != nil {
+		t.Fatalf("decode dashboard: %v", err)
+	}
+	got := make([]string, len(dashboard.Tasks))
+	for i, item := range dashboard.Tasks {
+		got[i] = item.Task.ID
+	}
+	want := []string{"1", "2", "10", "100", "task-a", "task-b"}
+	if !equalStrings(got, want) {
+		t.Fatalf("dashboard page ids = %v, want %v", got, want)
+	}
+}
+
+// TestSortTasksByID_NumericPageOrder 验证 sortTasksByID+paginateTasks 按数字 id 切页。
+func TestSortTasksByID_NumericPageOrder(t *testing.T) {
+	items := []tasks.Task{
+		{ID: "100"},
+		{ID: "task-b"},
+		{ID: "2"},
+		{ID: "10"},
+		{ID: "task-a"},
+		{ID: "1"},
+	}
+	sortTasksByID(items)
+	got := taskIDs(paginateTasks(items, 0, 10))
+	want := []string{"1", "2", "10", "100", "task-a", "task-b"}
+	if !equalStrings(got, want) {
+		t.Fatalf("sorted page ids = %v, want %v", got, want)
+	}
+	if got, want := taskIDs(paginateTasks(items, 0, 4)), []string{"1", "2", "10", "100"}; !equalStrings(got, want) {
+		t.Fatalf("offset=0 limit=4 ids = %v, want %v", got, want)
+	}
+}
+
+func taskIDs(items []tasks.Task) []string {
+	ids := make([]string, len(items))
+	for i, item := range items {
+		ids[i] = item.ID
+	}
+	return ids
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestAPI_SourceLookup 验证相关行为。

--- a/internal/meta/README.md
+++ b/internal/meta/README.md
@@ -1,7 +1,7 @@
 # internal/meta Module
 
 ## Files
-- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）。
+- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）；`ListTasks` 使用 `ORDER BY CAST(id AS UNSIGNED), id`，不改变 `id` 列类型。
 - `lease_store.go`: lease 读写逻辑。
 - `retry.go`: 重试策略适配层与执行器封装（基于 backoff v4，屏蔽第三方类型）。
 - `tracing.go`: metadata store tracing 开关与 span helper（默认关闭）。

--- a/internal/meta/mysql_store.go
+++ b/internal/meta/mysql_store.go
@@ -1,6 +1,6 @@
 // Package meta provides module-level functionality for meta.
 // input: MySQL connections, SQL schema/contracts including file lifecycle state, retry/lease timing policies
-// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints
+// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints, with ListTasks ordered by numeric id
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
@@ -141,7 +141,7 @@ ON DUPLICATE KEY UPDATE
 const listTaskSQL = `
 SELECT id, name, cluster_key, state, last_error, owner_worker_id, epoch, run_id, source_json, start_json, storage_json, updated_at
 FROM backup_tasks
-ORDER BY id;
+ORDER BY CAST(id AS UNSIGNED), id;
 `
 
 const deleteTaskSQL = `

--- a/internal/meta/mysql_store_test.go
+++ b/internal/meta/mysql_store_test.go
@@ -1,6 +1,6 @@
 // Package meta provides module-level functionality for meta.
 // input: mocked MySQL contracts including OPEN/SEALED file state, retry and lease timing policies
-// output: persistence contract coverage for tasks, files, leases, runs, and checkpoints
+// output: persistence contract coverage for tasks, files, leases, runs, checkpoints, and numeric ListTasks order
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
@@ -166,6 +166,13 @@ func TestMySQLTaskStore_ListTasks(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestListTaskSQL_OrdersByNumericID 验证 ListTasks 按数字 id 排序，避免 VARCHAR 字典序。
+func TestListTaskSQL_OrdersByNumericID(t *testing.T) {
+	if !strings.Contains(listTaskSQL, "ORDER BY CAST(id AS UNSIGNED), id") {
+		t.Fatalf("listTaskSQL must order by CAST(id AS UNSIGNED), id, got %q", listTaskSQL)
 	}
 }
 

--- a/internal/meta/tracing_test.go
+++ b/internal/meta/tracing_test.go
@@ -7,6 +7,7 @@ package meta
 
 import (
 	"context"
+	"regexp"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ func TestMySQLTaskStore_ListTasks_TracingEnabled(t *testing.T) {
 	defer db.Close()
 
 	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
-	mock.ExpectQuery(listTaskSQL).WillReturnRows(sqlmock.NewRows([]string{
+	mock.ExpectQuery(regexp.QuoteMeta(listTaskSQL)).WillReturnRows(sqlmock.NewRows([]string{
 		"id", "name", "cluster_key", "state", "last_error", "owner_worker_id", "epoch", "run_id", "source_json", "start_json", "storage_json", "updated_at",
 	}))
 


### PR DESCRIPTION
## Summary
- `GET /api/tasks` and `GET /api/dashboard` pages now order by numeric task id ascending (`1,2,10,100` instead of `1,10,100,101`).
- Metadata `ListTasks` uses `ORDER BY CAST(id AS UNSIGNED), id` with no column-type migration.
- Non-numeric ids (fixtures/tests) sort after numeric ones by string. Frontend mock handler matches the API order.

Fixes #50

## Test plan
- [x] `go test ./...`
- [x] `go test -race ./internal/api ./internal/tasks`
- [x] `go vet ./...`
- [x] three-level-doc check on changed files
- [ ] CI green on this PR

Operator check after merge:
```bash
curl -sS 'http://127.0.0.1:18080/api/tasks?limit=10&offset=0'
```
First page should be ids `1..10` when those tasks exist.