### PR TITLE
fix: treat LATEST start at source tip as zero lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Maintenance rules:
 
 ## [Unreleased]
 
+### Fixed
+
+- LATEST start at the source tip no longer reports `DELAYED` from a days-old binlog event header. `delay_seconds` is 0 / `NORMAL` as soon as StartSync succeeds; FILE_POS/GTID catch-up that is still behind the tip keeps real lag. `last_event_at` may still show the last event header time.
+
 ## [v0.5.1] - 2026-08-30
 
 ### Changed

--- a/docs/guide/admin/troubleshooting.md
+++ b/docs/guide/admin/troubleshooting.md
@@ -189,7 +189,7 @@ curl http://localhost:8080/api/tasks/{task_id}/replication
 
 关键字段：
 - `status`: `NORMAL / DELAYED / ABNORMAL`
-- `delay_seconds`: 基于 `last_event_at` 计算的延迟秒数
+- `delay_seconds`: lag in seconds. At the source tip (LATEST start after StartSync, or idle dump wait) this is 0 even if `last_event_at` is an old event header. Catch-up that is still behind the source tip uses `now - last_event_at`.
 - `has_progress=false`: 当前没有可用复制进度（需结合任务状态判断）
 
 ### 3.4 任务事件

--- a/docs/guide/reference/api.md
+++ b/docs/guide/reference/api.md
@@ -316,7 +316,7 @@ curl http://localhost:8080/api/tasks/{task_id}/replication
 
 | 值 | 说明 |
 |----|------|
-| NORMAL | 正常，延迟 < 阈值 |
+| NORMAL | 正常，延迟 < 阈值；已在源 tip 时延迟视为 0（即使 `last_event_at` 是旧 event header） |
 | DELAYED | 延迟，延迟 >= 阈值 |
 | ABNORMAL | 异常，无法获取位点 |
 | IDLE | 空闲，长时间无事件 |

--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -47,6 +47,7 @@
   - `/api/tasks/{id}/files/retry-upload`（`limit` 范围 1..1000，默认 100）
   - `/api/tasks/{id}/upload-failures/reasons`（`limit` 范围 1..200，默认 20）
 - task、replication 与 dashboard 响应保留 `FAILED` 状态及稳定的源错误 `last_error`，供管理台直接展示。
+- RUNNING 且 dump 已在源 tip（`ReplicationProgress.AtTip`）时，`delay_seconds` 为 0 / `NORMAL`，即使 `last_event_at` 仍是旧 event header；仍在追位点的 catch-up 继续按 `now - last_event_at` 计算 DELAYED。
 
 ## Update Rule
 - 路由、请求/响应结构、认证/限流配置变化时，更新本文件。

--- a/internal/api/handlers_tasks.go
+++ b/internal/api/handlers_tasks.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces, shared source endpoint identity
-// output: REST API JSON responses including single/batch task creation, numeric-id-ordered paginated task/dashboard data, loopback-equivalent source lookup, independent STARTING/RUNNING counters, and structured 400 bodies
+// output: REST API JSON responses including single/batch task creation, numeric-id-ordered paginated task/dashboard data, loopback-equivalent source lookup, independent STARTING/RUNNING counters, at-tip delay 0/NORMAL, and structured 400 bodies
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -927,11 +927,16 @@ func buildReplicationResponse(task tasks.Task, progress tasks.ReplicationProgres
 		if !progress.LastEventAt.IsZero() {
 			lastEventAt := progress.LastEventAt
 			resp.LastEventAt = &lastEventAt
-			delay := int64(now.Sub(progress.LastEventAt).Seconds())
-			if delay < 0 {
-				delay = 0
+			if progress.AtTip {
+				// Dump is at the source tip (LATEST start or idle). Header age is not lag.
+				resp.DelaySeconds = 0
+			} else {
+				delay := int64(now.Sub(progress.LastEventAt).Seconds())
+				if delay < 0 {
+					delay = 0
+				}
+				resp.DelaySeconds = delay
 			}
-			resp.DelaySeconds = delay
 		}
 		if !progress.UpdatedAt.IsZero() {
 			updatedAt := progress.UpdatedAt

--- a/internal/api/metrics_prometheus.go
+++ b/internal/api/metrics_prometheus.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: scheduler/task service snapshots and progress used for metric exposition
-// output: Prometheus collector and /metrics handler wiring with stable metric contracts
+// output: Prometheus collector and /metrics handler wiring with stable metric contracts, including at-tip replication lag of 0
 // pos: observability edge for control-plane metrics exposure in API layer
 // note: if this file changes, update this header and module README.md.
 package api
@@ -117,7 +117,7 @@ func (c *apiMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 		lag := now.Sub(progress.LastEventAt).Seconds()
-		if lag < 0 {
+		if progress.AtTip || lag < 0 {
 			lag = 0
 		}
 		ch <- prometheus.MustNewConstMetric(c.replicationLagSeconds, prometheus.GaugeValue, lag, task.ID)

--- a/internal/api/replication_status_test.go
+++ b/internal/api/replication_status_test.go
@@ -1,0 +1,164 @@
+// Package api provides module-level functionality for api.
+// input: replication progress snapshots and task state for delay/status mapping
+// output: regression coverage that at-tip RUNNING lag stays NORMAL while catch-up lag stays DELAYED
+// pos: API-layer test boundary for operator-visible replication delay semantics
+// note: if this file changes, update this header and module README.md.
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"binlog_server/internal/tasks"
+)
+
+// TestBuildReplicationResponse_RunningAtTipWithOldEventTimeIsNormal 验证
+// LATEST 已经跟在源库当前 file/pos 时，即使 last_event_at 是几天前的 event header，
+// 值班看到的也必须是 delay 0 / NORMAL，而不是 DELAYED。
+func TestBuildReplicationResponse_RunningAtTipWithOldEventTimeIsNormal(t *testing.T) {
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	lastEventAt := now.Add(-72 * time.Hour)
+	task := tasks.Task{ID: "1", State: tasks.StateRunning}
+	progress := tasks.ReplicationProgress{
+		TaskID:        "1",
+		LastEventAt:   lastEventAt,
+		LastEventFile: "mysql-bin.000003",
+		LastEventPos:  56456,
+		UpdatedAt:     now,
+		AtTip:         true,
+	}
+
+	resp := buildReplicationResponse(task, progress, true, now, 30)
+	if resp.Status != "NORMAL" {
+		t.Fatalf("operator saw status=%s reason=%s, want NORMAL when dump is already at LATEST tip", resp.Status, resp.Reason)
+	}
+	if resp.DelaySeconds != 0 {
+		t.Fatalf("delay_seconds=%d, want 0 at LATEST tip even if last event header is days old", resp.DelaySeconds)
+	}
+	if resp.LastEventAt == nil || !resp.LastEventAt.Equal(lastEventAt) {
+		t.Fatalf("last_event_at should remain header time for diagnostics, got %v", resp.LastEventAt)
+	}
+	if resp.State != tasks.StateRunning {
+		t.Fatalf("state=%s, want RUNNING", resp.State)
+	}
+}
+
+// TestBuildReplicationResponse_RunningBehindTipKeepsCatchUpDelay 验证
+// FILE_POS/GTID 还在追旧事件时，不能因为 UpdatedAt 新鲜就把 delay 抹成 0。
+func TestBuildReplicationResponse_RunningBehindTipKeepsCatchUpDelay(t *testing.T) {
+	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	lastEventAt := now.Add(-72 * time.Hour)
+	task := tasks.Task{ID: "2", State: tasks.StateRunning}
+	progress := tasks.ReplicationProgress{
+		TaskID:        "2",
+		LastEventAt:   lastEventAt,
+		LastEventFile: "mysql-bin.000001",
+		LastEventPos:  4,
+		UpdatedAt:     now,
+		AtTip:         false,
+	}
+
+	resp := buildReplicationResponse(task, progress, true, now, 30)
+	if resp.Status != "DELAYED" {
+		t.Fatalf("status=%s reason=%s, want DELAYED while catch-up is still behind source tip", resp.Status, resp.Reason)
+	}
+	if resp.DelaySeconds != 72*60*60 {
+		t.Fatalf("delay_seconds=%d, want 259200 for 72h catch-up lag", resp.DelaySeconds)
+	}
+	if resp.Reason != "DELAY_EXCEEDS_THRESHOLD" {
+		t.Fatalf("reason=%s, want DELAY_EXCEEDS_THRESHOLD", resp.Reason)
+	}
+}
+
+func startRunningTask(t *testing.T) (*tasks.Scheduler, http.Handler, tasks.Task) {
+	t.Helper()
+	runner := &apiReadyGateRunner{readyIDs: map[string]bool{}}
+	scheduler := tasks.NewScheduler(tasks.WithRunner(runner))
+	task, err := scheduler.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	runner.readyIDs[task.ID] = true
+	if err := scheduler.ConfigureSource(task.ID, tasks.SourceConfig{
+		Host: "127.0.0.1",
+		Port: 3306,
+		User: "repl",
+	}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	if err := scheduler.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask returned error: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		cur, err := scheduler.GetTask(task.ID)
+		if err != nil {
+			t.Fatalf("GetTask returned error: %v", err)
+		}
+		if cur.State == tasks.StateRunning {
+			t.Cleanup(func() { _ = scheduler.StopTask(task.ID) })
+			return scheduler, NewServer(scheduler), cur
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task did not reach running state in time: %s", cur.State)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func getReplicationJSON(t *testing.T, handler http.Handler, taskID string) map[string]any {
+	t.Helper()
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/"+taskID+"/replication", nil)
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return body
+}
+
+// TestTaskAPI_GetReplication_LatestAtTipWithOldEventTimeIsNormal 验证值班立刻 GET
+// /replication 时，已经在 LATEST tip 的 RUNNING 任务不能显示 DELAYED。
+func TestTaskAPI_GetReplication_LatestAtTipWithOldEventTimeIsNormal(t *testing.T) {
+	scheduler, handler, task := startRunningTask(t)
+	lastEventAt := time.Now().UTC().Add(-72 * time.Hour).Truncate(time.Second)
+	scheduler.ReportReplicationProgress(task.ID, lastEventAt, "mysql-bin.000003", 56456, true)
+
+	body := getReplicationJSON(t, handler, task.ID)
+	if body["state"] != string(tasks.StateRunning) {
+		t.Fatalf("state=%v, want RUNNING", body["state"])
+	}
+	if body["status"] != "NORMAL" {
+		t.Fatalf("operator saw status=%v reason=%v, want NORMAL at LATEST tip", body["status"], body["reason"])
+	}
+	if delay, _ := body["delay_seconds"].(float64); delay != 0 {
+		t.Fatalf("delay_seconds=%v, want 0 at LATEST tip", body["delay_seconds"])
+	}
+	gotAt, _ := body["last_event_at"].(string)
+	parsed, err := time.Parse(time.RFC3339, gotAt)
+	if err != nil || !parsed.Equal(lastEventAt) {
+		t.Fatalf("last_event_at=%v, want header time %s", body["last_event_at"], lastEventAt.Format(time.RFC3339))
+	}
+}
+
+// TestTaskAPI_GetReplication_CatchUpBehindTipIsDelayed 验证 GET JSON 对仍在追位点的任务保留真实 lag。
+func TestTaskAPI_GetReplication_CatchUpBehindTipIsDelayed(t *testing.T) {
+	scheduler, handler, task := startRunningTask(t)
+	lastEventAt := time.Now().UTC().Add(-72 * time.Hour).Truncate(time.Second)
+	scheduler.ReportReplicationProgress(task.ID, lastEventAt, "mysql-bin.000001", 4, false)
+
+	body := getReplicationJSON(t, handler, task.ID)
+	if body["status"] != "DELAYED" {
+		t.Fatalf("status=%v reason=%v, want DELAYED while catch-up is behind tip", body["status"], body["reason"])
+	}
+	if delay, _ := body["delay_seconds"].(float64); delay < 30 {
+		t.Fatalf("delay_seconds=%v, want catch-up lag above threshold", body["delay_seconds"])
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1063,7 +1063,7 @@ func TestAPI_MetricsEndpointContainsCoreMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTask returned error: %v", err)
 	}
-	scheduler.ReportReplicationProgress(task.ID, time.Now().Add(-3*time.Second), "mysql-bin.000001", 123)
+	scheduler.ReportReplicationProgress(task.ID, time.Now().Add(-3*time.Second), "mysql-bin.000001", 123, false)
 	checkpointReader.checkpoints[task.ID] = binlog.Checkpoint{
 		File:      "mysql-bin.000001",
 		Pos:       123,
@@ -2745,7 +2745,7 @@ func TestTaskAPI_GetReplication(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTask returned error: %v", err)
 	}
-	scheduler.ReportReplicationProgress(task.ID, time.Now().Add(-8*time.Second), "mysql-bin.000777", 456)
+	scheduler.ReportReplicationProgress(task.ID, time.Now().Add(-8*time.Second), "mysql-bin.000777", 456, false)
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/tasks/"+task.ID+"/replication", nil)
@@ -2846,7 +2846,7 @@ func TestAPI_Dashboard(t *testing.T) {
 		t.Fatalf("StartTask A returned error: %v", err)
 	}
 
-	scheduler.ReportReplicationProgress(taskA.ID, time.Now().Add(-3*time.Second), "mysql-bin.000001", 123)
+	scheduler.ReportReplicationProgress(taskA.ID, time.Now().Add(-3*time.Second), "mysql-bin.000001", 123, false)
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/dashboard", nil)

--- a/internal/replication/README.md
+++ b/internal/replication/README.md
@@ -1,14 +1,14 @@
 # internal/replication Module
 
 ## Files
-- `mysql_runner.go`: 复制主执行流程（含 open segment 元数据及进度更新、idle lag 上报、heartbeat 跳过落盘）。
+- `mysql_runner.go`: 复制主执行流程（含 open segment 元数据及进度更新、LATEST/idle at-tip lag 上报、heartbeat 跳过落盘）。
 - `source_identity.go`: MySQL/MariaDB 源库身份，以及永久认证/配置错误与可重试网络错误分类。
 - `resolver.go`: 起点解析。
 - 其余 `*_test.go`: 复制、恢复、上传等行为测试。
-  其中 `mysql_runner_run_test.go` 重点覆盖 runner 级起点选择、checkpoint 推进/失败、错误传播与停止清理语义。
+  其中 `mysql_runner_run_test.go` 重点覆盖 runner 级起点选择、LATEST at-tip vs FILE_POS catch-up 进度、checkpoint 推进/失败、错误传播与停止清理语义。
 
 ## Exports
-- Runner 启停与进度上报。
+- Runner 启停与进度上报。fresh LATEST 在 StartSync 成功后立即按 at-tip 上报；idle dump wait 共用同一 at-tip 规则；仍在追源 tip 的 FILE_POS/GTID 保持 event header lag。
 - 源网络超时、拒绝、主机不可达及复制流 EOF/UnexpectedEOF 统一暴露 `SOURCE_UNREACHABLE`，本地文件/metadata/lease 错误保持原分类。
 - MariaDB 身份：`mariadb:<server_id>:<gtid_domain_id>`；MySQL 仍用 `server_uuid`。
 - 文件落盘、checkpoint 对接、随落盘进度更新的 OPEN/SEALED 生命周期元数据、上传触发。

--- a/internal/replication/mysql_runner.go
+++ b/internal/replication/mysql_runner.go
@@ -1,6 +1,6 @@
 // Package replication provides module-level functionality for replication.
 // input: source replication config, flavor-aware identity, checkpoint/file metadata store dependencies
-// output: replication run control, observable OPEN/SEALED artifacts, idle lag progress, and permanent source errors
+// output: replication run control, observable OPEN/SEALED artifacts, at-tip/idle lag progress, and permanent source errors
 // pos: data-plane runtime that consumes MySQL/MariaDB binlog stream and emits durable outputs
 // note: if this file changes, update this header and module README.md.
 package replication
@@ -125,8 +125,8 @@ type FileUploader interface {
 
 // ProgressReporter 定义复制进度上报接口。
 type ProgressReporter interface {
-	// ReportReplicationProgress 上报复制进度。
-	ReportReplicationProgress(taskID string, sourceEventAt time.Time, file string, pos uint32)
+	// ReportReplicationProgress 上报复制进度。atTip 表示 dump 已在源库当前 file/pos。
+	ReportReplicationProgress(taskID string, sourceEventAt time.Time, file string, pos uint32, atTip bool)
 }
 
 // LeaseVerifier 定义 cluster 下 lease ownership 校验接口。
@@ -196,7 +196,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 	// Step 1: 解析源库标识与复制起点（含 checkpoint 接管修正）。
 	// 常见误解：
 	// onReady 只表示“复制连接+writer 已就绪”，不代表已经收到第一条业务事件。
-	// RUNNING 的含义是执行链路 ready，而不是延迟一定为 0。
+	// FILE_POS/GTID 追旧事件时 RUNNING 仍可 DELAYED；fresh LATEST 在 StartSync 成功时已在源 tip。
 	// source_server_uuid 作为 object key 的稳定维度，避免 cluster_key 相同但源实例切换时冲突。
 	sourceServerUUID, err := r.fetcher.FetchServerUUID(ctx, task.Source)
 	if err != nil {
@@ -208,10 +208,12 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 	}
 
 	// 先解析请求的 start strategy（LATEST/FILE_POS/GTID）。
+	requestedLatest := task.Start.Mode == tasks.StartModeLatest || task.Start.Mode == ""
 	start, err := ResolveStart(ctx, task, r.fetcher)
 	if err != nil {
 		return classifySourceError(err)
 	}
+	checkpointExists := false
 	if r.checkpointStore != nil {
 		// 持久化 checkpoint 优先级更高，保证重启后的 resumability。
 		checkpoint, ok, err := r.checkpointStore.LoadCheckpoint(ctx, task.ID)
@@ -219,7 +221,11 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 			return err
 		}
 		start, _ = effectiveStartForTakeover(task, start, checkpoint, ok)
+		checkpointExists = ok
 	}
+	// Fresh LATEST has already resolved to SHOW MASTER STATUS, so StartSync is at tip.
+	// A checkpoint means this run may still be catching up.
+	atTip := requestedLatest && !checkpointExists
 
 	// Step 2: 打开当前 open 文件并构造 writer。
 	currentFile := start.File
@@ -299,7 +305,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 
 		if event.Header.EventType == replication.HEARTBEAT_EVENT || event.Header.EventType == replication.HEARTBEAT_LOG_EVENT_V2 {
 			if r.progressReporter != nil {
-				r.progressReporter.ReportReplicationProgress(task.ID, sourceEventAt, currentFile, currentPos)
+				r.progressReporter.ReportReplicationProgress(task.ID, sourceEventAt, currentFile, currentPos, atTip)
 			}
 			return nil
 		}
@@ -365,7 +371,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 					}
 				}
 				if r.progressReporter != nil {
-					r.progressReporter.ReportReplicationProgress(task.ID, sourceEventAt, currentFile, currentPos)
+					r.progressReporter.ReportReplicationProgress(task.ID, sourceEventAt, currentFile, currentPos, atTip)
 				}
 				return nil
 			}
@@ -383,7 +389,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 			return err
 		}
 		if r.progressReporter != nil {
-			r.progressReporter.ReportReplicationProgress(task.ID, sourceEventAt, currentFile, currentPos)
+			r.progressReporter.ReportReplicationProgress(task.ID, sourceEventAt, currentFile, currentPos, atTip)
 		}
 		return nil
 	}
@@ -422,6 +428,11 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 		return classifySourceError(err)
 	}
 
+	if atTip && r.progressReporter != nil {
+		// LATEST StartSync is already at master file/pos; do not wait for idle or the next event.
+		r.progressReporter.ReportReplicationProgress(task.ID, time.Now().UTC(), currentFile, currentPos, true)
+	}
+
 	if onReady != nil {
 		// 到这里说明“连接 + 起点 + writer”都已 ready，Scheduler 可安全切 RUNNING。
 		onReady()
@@ -431,7 +442,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 		// SynchronousEventHandler 模式下，事件由 syncer 内部 goroutine 推送到 handler。
 		// 这里阻塞等待错误或取消，保持任务生命周期。
 		for {
-			event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos)
+			event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos, &atTip)
 			if err != nil {
 				if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 					return nil
@@ -446,7 +457,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 
 	// Step 5: 异步模式主循环（逐条拉取并处理事件）。
 	for {
-		event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos)
+		event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos, &atTip)
 		if err != nil {
 			if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 				return nil
@@ -464,7 +475,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 
 const idlePollInterval = 2 * time.Second
 
-func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, taskID, file string, pos uint32) (*replication.BinlogEvent, error) {
+func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, taskID, file string, pos uint32, atTip *bool) (*replication.BinlogEvent, error) {
 	eventCtx, cancel := context.WithTimeout(ctx, idlePollInterval)
 	event, err := streamer.GetEvent(eventCtx)
 	cancel()
@@ -477,9 +488,12 @@ func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, ta
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			// No event for idlePollInterval means the dump is at tip.
-			// Use wall clock so last-event age on a silent master is not reported as lag.
+			// Share the LATEST-start at-tip rule: delay must not use event-header age.
+			if atTip != nil {
+				*atTip = true
+			}
 			if r.progressReporter != nil {
-				r.progressReporter.ReportReplicationProgress(taskID, time.Now().UTC(), file, pos)
+				r.progressReporter.ReportReplicationProgress(taskID, time.Now().UTC(), file, pos, true)
 			}
 			return nil, nil
 		}

--- a/internal/replication/mysql_runner_run_test.go
+++ b/internal/replication/mysql_runner_run_test.go
@@ -1,6 +1,6 @@
 // Package replication provides module-level functionality for replication.
 // input: fake source metadata, fake streamer/syncer, and injected writer/checkpoint doubles
-// output: runner-level tests for start selection, checkpoint semantics, error propagation, and stop cleanup
+// output: runner-level tests for start selection, LATEST at-tip vs catch-up progress, checkpoint semantics, error propagation, and stop cleanup
 // pos: replication runtime test boundary around mysql runner orchestration
 // note: if this file changes, update this header and module README.md.
 package replication
@@ -80,14 +80,16 @@ type progressReport struct {
 	at     time.Time
 	file   string
 	pos    uint32
+	atTip  bool
 }
 
-func (f *fakeRunnerProgressReporter) ReportReplicationProgress(taskID string, sourceEventAt time.Time, file string, pos uint32) {
+func (f *fakeRunnerProgressReporter) ReportReplicationProgress(taskID string, sourceEventAt time.Time, file string, pos uint32, atTip bool) {
 	f.reports = append(f.reports, progressReport{
 		taskID: taskID,
 		at:     sourceEventAt,
 		file:   file,
 		pos:    pos,
+		atTip:  atTip,
 	})
 }
 
@@ -128,9 +130,9 @@ type streamResult struct {
 }
 
 type fakeStreamer struct {
-	results         []streamResult
-	calls           int
-	blockUntilCtx   bool
+	results          []streamResult
+	calls            int
+	blockUntilCtx    bool
 	getEventReturned chan struct{}
 }
 
@@ -158,13 +160,13 @@ func (f *fakeStreamer) GetEvent(ctx context.Context) (*goreplication.BinlogEvent
 }
 
 type fakeSyncer struct {
-	streamer      binlogStreamer
-	startPos      gomysql.Position
-	startPosCalls int
-	startGTID     gomysql.GTIDSet
+	streamer       binlogStreamer
+	startPos       gomysql.Position
+	startPosCalls  int
+	startGTID      gomysql.GTIDSet
 	startGTIDCalls int
-	startErr      error
-	closeCalls    int
+	startErr       error
+	closeCalls     int
 }
 
 func (f *fakeSyncer) StartSync(pos gomysql.Position) (binlogStreamer, error) {
@@ -190,11 +192,15 @@ func (f *fakeSyncer) Close() {
 }
 
 func newRunnerEvent(logPos uint32) *goreplication.BinlogEvent {
+	return newRunnerEventAt(logPos, time.Now())
+}
+
+func newRunnerEventAt(logPos uint32, ts time.Time) *goreplication.BinlogEvent {
 	return &goreplication.BinlogEvent{
 		Header: &goreplication.EventHeader{
 			EventType: goreplication.QUERY_EVENT,
 			LogPos:    logPos,
-			Timestamp: uint32(time.Now().Unix()),
+			Timestamp: uint32(ts.Unix()),
 		},
 		RawData: []byte{0x01, 0x02, 0x03},
 	}
@@ -249,6 +255,120 @@ func TestMySQLRunnerRun_LatestResolvesAndStartsFromMasterStatus(t *testing.T) {
 	}
 	if closer.closeCalls != 1 {
 		t.Fatalf("expected writer closer called once, got %d", closer.closeCalls)
+	}
+}
+
+func newTestRunner(t *testing.T, fetcher sourceMetaFetcher, syncer binlogSyncer, reporter *fakeRunnerProgressReporter) *MySQLRunner {
+	t.Helper()
+	return &MySQLRunner{
+		fetcher:          fetcher,
+		progressReporter: reporter,
+		newSyncer: func(_ goreplication.BinlogSyncerConfig) binlogSyncer {
+			return syncer
+		},
+		writerOpener: func(_ tasks.Task, fileName string, initialPos uint32) (io.Closer, *binlog.Writer, string, error) {
+			file := &fakeSyncFile{}
+			return &fakeCloser{}, binlog.NewWriter(file, binlog.Checkpoint{File: fileName, Pos: initialPos}), t.TempDir() + "/" + fileName, nil
+		},
+	}
+}
+
+// TestMySQLRunnerRun_LatestStartReportsAtTipBeforeNextEvent 验证 LATEST 在 StartSync 成功后立刻按 at-tip 上报，
+// 不等 2s idle，也不把 dump 握手事件的旧 header 时间当成落后。
+func TestMySQLRunnerRun_LatestStartReportsAtTipBeforeNextEvent(t *testing.T) {
+	oldEventAt := time.Date(2026, 8, 27, 4, 47, 20, 0, time.UTC)
+	fetcher := &fakeSourceMetaFetcher{
+		status:     MasterStatus{File: "mysql-bin.000003", Pos: 56456},
+		serverUUID: "srv-uuid-1",
+	}
+	streamer := &fakeStreamer{
+		results: []streamResult{
+			{event: newRunnerEventAt(0, oldEventAt)},
+			{err: context.Canceled},
+		},
+	}
+	syncer := &fakeSyncer{streamer: streamer}
+	reporter := &fakeRunnerProgressReporter{}
+	runner := newTestRunner(t, fetcher, syncer, reporter)
+
+	err := runner.Run(context.Background(), newRunnerTask(tasks.StartConfig{Mode: tasks.StartModeLatest}))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(reporter.reports) == 0 {
+		t.Fatal("expected LATEST start to report at-tip progress before the next dump event / idle timeout")
+	}
+	first := reporter.reports[0]
+	if !first.atTip || first.file != "mysql-bin.000003" || first.pos != 56456 {
+		t.Fatalf("first progress report %+v, want at-tip mysql-bin.000003:56456 immediately after StartSync", first)
+	}
+	last := reporter.reports[len(reporter.reports)-1]
+	if !last.atTip {
+		t.Fatalf("handshake event overwrote at-tip: last report %+v", last)
+	}
+	if last.file != "mysql-bin.000003" || last.pos != 56456 {
+		t.Fatalf("last progress report %+v, want tip file/pos preserved", last)
+	}
+}
+
+// TestMySQLRunnerRun_FilePosCatchUpKeepsEventHeaderLag 验证 FILE_POS 追旧事件时不能标成 at-tip。
+func TestMySQLRunnerRun_FilePosCatchUpKeepsEventHeaderLag(t *testing.T) {
+	oldEventAt := time.Date(2026, 8, 27, 4, 47, 20, 0, time.UTC)
+	streamer := &fakeStreamer{
+		results: []streamResult{
+			{event: newRunnerEventAt(120, oldEventAt)},
+			{err: context.Canceled},
+		},
+	}
+	syncer := &fakeSyncer{streamer: streamer}
+	reporter := &fakeRunnerProgressReporter{}
+	runner := newTestRunner(t, &fakeSourceMetaFetcher{serverUUID: "srv-uuid-1"}, syncer, reporter)
+
+	err := runner.Run(context.Background(), newRunnerTask(tasks.StartConfig{
+		Mode: tasks.StartModeFilePos,
+		File: "mysql-bin.000010",
+		Pos:  4,
+	}))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(reporter.reports) != 1 {
+		t.Fatalf("expected 1 catch-up progress report, got %+v", reporter.reports)
+	}
+	got := reporter.reports[0]
+	if got.atTip {
+		t.Fatalf("FILE_POS catch-up reported at-tip: %+v", got)
+	}
+	if got.pos != 120 || !got.at.Equal(oldEventAt) {
+		t.Fatalf("catch-up report %+v, want pos=120 and old event header time", got)
+	}
+}
+
+// TestMySQLRunnerRun_IdlePollReportsAtTip 验证 2s idle 与 LATEST start 共用 at-tip 规则。
+func TestMySQLRunnerRun_IdlePollReportsAtTip(t *testing.T) {
+	streamer := &fakeStreamer{
+		results: []streamResult{
+			{err: context.DeadlineExceeded},
+			{err: context.Canceled},
+		},
+	}
+	syncer := &fakeSyncer{streamer: streamer}
+	reporter := &fakeRunnerProgressReporter{}
+	runner := newTestRunner(t, &fakeSourceMetaFetcher{serverUUID: "srv-uuid-1"}, syncer, reporter)
+
+	err := runner.Run(context.Background(), newRunnerTask(tasks.StartConfig{
+		Mode: tasks.StartModeFilePos,
+		File: "mysql-bin.000010",
+		Pos:  4,
+	}))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(reporter.reports) != 1 || !reporter.reports[0].atTip {
+		t.Fatalf("idle poll should report at-tip, got %+v", reporter.reports)
+	}
+	if reporter.reports[0].file != "mysql-bin.000010" || reporter.reports[0].pos != 4 {
+		t.Fatalf("idle at-tip report %+v, want start file/pos", reporter.reports[0])
 	}
 }
 
@@ -336,8 +456,8 @@ func TestMySQLRunnerRun_AdvancesCheckpointOnlyAfterFlush(t *testing.T) {
 	syncer := &fakeSyncer{streamer: streamer}
 	reporter := &fakeRunnerProgressReporter{}
 	runner := &MySQLRunner{
-		fetcher:         &fakeSourceMetaFetcher{serverUUID: "srv-uuid-1"},
-		checkpointStore: store,
+		fetcher:          &fakeSourceMetaFetcher{serverUUID: "srv-uuid-1"},
+		checkpointStore:  store,
 		progressReporter: reporter,
 		newSyncer: func(_ goreplication.BinlogSyncerConfig) binlogSyncer {
 			return syncer
@@ -469,7 +589,7 @@ func TestMySQLRunnerRun_ContextCancelStopsAndReleasesResources(t *testing.T) {
 	defer cancel()
 
 	streamer := &fakeStreamer{
-		blockUntilCtx:   true,
+		blockUntilCtx:    true,
 		getEventReturned: make(chan struct{}),
 	}
 	syncer := &fakeSyncer{streamer: streamer}

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -7,9 +7,9 @@
 - `scheduler_transitions.go`: 私有生命周期转换规则（状态、事件、错误、ownership 与持久化）。
 - `errors.go`: 稳定操作员错误类型（永久的 1045 / log_bin off / 身份不可用，以及可重试的 `SOURCE_UNREACHABLE`）。
 - `scheduler_cluster_lease.go`: cluster lease 续租与降级/失租处理。
-- `scheduler_observability.go`: 复制进度、checkpoint、事件/文件/运行历史查询。
+- `scheduler_observability.go`: 复制进度（含 at-tip）、checkpoint、事件/文件/运行历史查询。
 - `scheduler_retry_upload.go`: 上传失败补偿重试与失败原因聚合。
-- `model.go`: 任务领域模型与状态定义。
+- `model.go`: 任务领域模型与状态定义（含复制进度 `AtTip`）。
 - 各 `*_test.go`: 状态机、租约、上传重试、事件等测试。
 - `source_guard_test.go`: metadata/source 同端点拒绝策略的公开任务接口回归测试，覆盖 localhost、127/8、::1 与 IPv6 括号表示。
 - `event_store_test.go` 中 fake store 为并发安全实现，用于 `-race` 校验稳定性。

--- a/internal/tasks/lease_test.go
+++ b/internal/tasks/lease_test.go
@@ -369,7 +369,7 @@ func TestScheduler_OwnershipLossSuppressesProgressAfterRenewLoss(t *testing.T) {
 		t.Fatal("runner was not invoked")
 	}
 
-	s.ReportReplicationProgress(task.ID, time.Unix(100, 0), "mysql-bin.000001", 123)
+	s.ReportReplicationProgress(task.ID, time.Unix(100, 0), "mysql-bin.000001", 123, false)
 	before, ok, err := s.GetReplicationProgress(task.ID)
 	if err != nil {
 		t.Fatalf("GetReplicationProgress returned error: %v", err)
@@ -380,7 +380,7 @@ func TestScheduler_OwnershipLossSuppressesProgressAfterRenewLoss(t *testing.T) {
 
 	waitTaskState(t, s, task.ID, 2*time.Second, StateStopping)
 
-	s.ReportReplicationProgress(task.ID, time.Unix(200, 0), "mysql-bin.000002", 456)
+	s.ReportReplicationProgress(task.ID, time.Unix(200, 0), "mysql-bin.000002", 456, false)
 	after, ok, err := s.GetReplicationProgress(task.ID)
 	if err != nil {
 		t.Fatalf("GetReplicationProgress returned error: %v", err)
@@ -586,7 +586,7 @@ func TestScheduler_FailSafeStopSuppressesReplicationProgress(t *testing.T) {
 		t.Fatal("runner was not invoked")
 	}
 
-	s.ReportReplicationProgress(task.ID, time.Unix(100, 0), "mysql-bin.000001", 123)
+	s.ReportReplicationProgress(task.ID, time.Unix(100, 0), "mysql-bin.000001", 123, false)
 	before, ok, err := s.GetReplicationProgress(task.ID)
 	if err != nil {
 		t.Fatalf("GetReplicationProgress returned error: %v", err)
@@ -601,7 +601,7 @@ func TestScheduler_FailSafeStopSuppressesReplicationProgress(t *testing.T) {
 
 	waitTaskState(t, s, task.ID, 2*time.Second, StateStopping)
 
-	s.ReportReplicationProgress(task.ID, time.Unix(200, 0), "mysql-bin.000002", 456)
+	s.ReportReplicationProgress(task.ID, time.Unix(200, 0), "mysql-bin.000002", 456, false)
 	after, ok, err := s.GetReplicationProgress(task.ID)
 	if err != nil {
 		t.Fatalf("GetReplicationProgress returned error: %v", err)

--- a/internal/tasks/model.go
+++ b/internal/tasks/model.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task JSON payloads, runner callbacks, file lifecycle state, store/lease/uploader dependencies
-// output: task/start/source/file models including gtid alias decoding and OPEN/SEALED observability
+// output: task/start/source/file models including gtid alias decoding, OPEN/SEALED observability, and at-tip replication progress
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -199,4 +199,7 @@ type ReplicationProgress struct {
 	LastEventFile string    `json:"last_event_file"`
 	LastEventPos  uint32    `json:"last_event_pos"`
 	UpdatedAt     time.Time `json:"updated_at"`
+	// AtTip is true when the dump is at the source's current file/pos.
+	// Delay/status must not treat last-event header age as lag in that case.
+	AtTip bool `json:"-"`
 }

--- a/internal/tasks/scheduler_observability.go
+++ b/internal/tasks/scheduler_observability.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: replication/checkpoint/event/file/history read requests and store snapshots
-// output: observability-facing task progress, events, files, runs, and worker heartbeat views
+// output: observability-facing task progress including at-tip lag, events, files, runs, and worker heartbeat views
 // pos: scheduler read/query layer for API and metrics consumption
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -13,7 +13,7 @@ import (
 	"binlog_server/internal/binlog"
 )
 
-func (s *Scheduler) ReportReplicationProgress(taskID string, sourceEventAt time.Time, file string, pos uint32) {
+func (s *Scheduler) ReportReplicationProgress(taskID string, sourceEventAt time.Time, file string, pos uint32, atTip bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -36,6 +36,7 @@ func (s *Scheduler) ReportReplicationProgress(taskID string, sourceEventAt time.
 	if pos > 0 {
 		progress.LastEventPos = pos
 	}
+	progress.AtTip = atTip
 	progress.UpdatedAt = time.Now()
 	s.replica[taskID] = progress
 }


### PR DESCRIPTION
Fixes #49

## Problem

Immediately after a LATEST start against a silent MySQL, `GET /api/tasks/{id}/replication` reported `RUNNING` + `DELAYED` with `delay_seconds` in the hundreds of thousands. File/pos was already the source tip; `last_event_at` was the old binlog header. Idle later corrected this after the 2s dump wait. FILE_POS/GTID catch-up must keep real lag.

## Change

- Delay/status do not use `now - last_event_at` when the dump is at the source tip.
- Fresh LATEST reports at-tip as soon as StartSync succeeds (no wait for the 2s idle poll).
- Idle dump wait shares the same at-tip rule.
- `last_event_at` may still show the last event header time.
- Catch-up that is still behind the source tip stays `DELAYED`.

## Tests

- `buildReplicationResponse` / GET `/replication`: RUNNING at tip with a days-old header is `NORMAL` / delay 0; behind-tip catch-up stays `DELAYED`.
- MySQLRunner: LATEST start reports at-tip immediately; FILE_POS catch-up keeps event-header lag; idle poll reports at-tip.

## Notes

Rebased onto `origin/main` after #50 (`c8bbb04`). `handlers_tasks.go` overlap is only the L3 header (numeric-id pagination + at-tip delay). Not merging from this PR.