### PR TITLE
docs: prepare v0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@ Maintenance rules:
 
 ## [Unreleased]
 
+## [v0.5.2] - 2026-08-30
+
+### Changed
+
+- Operator download examples in README, the landing page, and the deployment guide now pin `v0.5.2`.
+
 ### Fixed
 
 - LATEST start at the source tip no longer reports `DELAYED` from a days-old binlog event header. `delay_seconds` is 0 / `NORMAL` as soon as StartSync succeeds; FILE_POS/GTID catch-up that is still behind the tip keeps real lag. `last_event_at` may still show the last event header time.
+- Task list and dashboard pages sort numeric string ids as integers, so page 1 is `1,2,3` rather than `1,10,100`.
 
 ## [v0.5.1] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ For tagged public releases, download the archive that matches your platform from
 - `binlog-server_<version>_linux_amd64.tar.gz`
 - `binlog-server_<version>_linux_arm64.tar.gz`
 
-The real asset name is `binlog-server_<ver>_<os>_<arch>.tar.gz` (for example `binlog-server_0.5.1_linux_amd64.tar.gz`). The release page also provides `checksums.txt`; verify it before extracting. The tarball contains a versioned subdirectory:
+The real asset name is `binlog-server_<ver>_<os>_<arch>.tar.gz` (for example `binlog-server_0.5.2_linux_amd64.tar.gz`). The release page also provides `checksums.txt`; verify it before extracting. The tarball contains a versioned subdirectory:
 
 ```text
-binlog-server_0.5.1_linux_amd64/
+binlog-server_0.5.2_linux_amd64/
   binlog-server
   migrate
   migrations/
@@ -95,7 +95,7 @@ This is the shortest path for release operators. You do not need Go installed.
 ### 1. Download, verify, extract, run
 
 ```bash
-VER=0.5.1
+VER=0.5.2
 OS=linux          # linux | darwin
 ARCH=amd64        # amd64 | arm64
 
@@ -327,7 +327,7 @@ go run ./cmd/binlog-server
 BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
 
 # Prepare a local set of release assets
-make release-assets VERSION=v0.5.1
+make release-assets VERSION=v0.5.2
 ```
 
 ## Development Validation

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -65,10 +65,10 @@ Binlog Server 是一个面向 MySQL binlog 备份与拉流场景的服务：负�
 - `binlog-server_<version>_linux_amd64.tar.gz`
 - `binlog-server_<version>_linux_arm64.tar.gz`
 
-真实资产名是 `binlog-server_<ver>_<os>_<arch>.tar.gz`（例如 `binlog-server_0.5.1_linux_amd64.tar.gz`）。同一页提供 `checksums.txt`，先校验再解压。压缩包里有一层版本子目录：
+真实资产名是 `binlog-server_<ver>_<os>_<arch>.tar.gz`（例如 `binlog-server_0.5.2_linux_amd64.tar.gz`）。同一页提供 `checksums.txt`，先校验再解压。压缩包里有一层版本子目录：
 
 ```text
-binlog-server_0.5.1_linux_amd64/
+binlog-server_0.5.2_linux_amd64/
   binlog-server
   migrate
   migrations/
@@ -94,7 +94,7 @@ binlog-server_0.5.1_linux_amd64/
 ### 1. 下载、校验、解压、运行
 
 ```bash
-VER=0.5.1
+VER=0.5.2
 OS=linux          # linux | darwin
 ARCH=amd64        # amd64 | arm64
 
@@ -324,7 +324,7 @@ go run ./cmd/binlog-server
 BINLOG_SERVER_LISTEN_ADDR=127.0.0.1:18080 go run ./cmd/binlog-server
 
 # 本地准备一组 release 产物
-make release-assets VERSION=v0.5.1
+make release-assets VERSION=v0.5.2
 ```
 
 ## 开发验证入口

--- a/docs/guide/admin/deployment.md
+++ b/docs/guide/admin/deployment.md
@@ -49,7 +49,7 @@ FLUSH PRIVILEGES;
 
 ```bash
 # 推荐：下载 GitHub Release tarball（不需要 Go）
-VER=0.5.1
+VER=0.5.2
 OS=linux          # linux | darwin
 ARCH=amd64        # amd64 | arm64
 curl -fsSL -O "https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz"

--- a/docs/guide/reference/api.md
+++ b/docs/guide/reference/api.md
@@ -469,7 +469,7 @@ curl "http://localhost:8080/api/workers?limit=10"
       "session_id": "abc123",
       "role": "worker",
       "host": "10.0.1.1",
-      "version": "v0.5.1",
+      "version": "v0.5.2",
       "status": "ONLINE",
       "expires_at": "2024-01-01T10:10:00Z",
       "updated_at": "2024-01-01T10:00:00Z"

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -514,7 +514,7 @@
   <section class="hero">
     <div class="container" style="position:relative;">
       <div class="hero-badge animate-fade-up" style="animation-delay:0.05s;">
-        <span class="tag tag-new" data-i18n="heroBadge">v0.5.1 — latest release</span>
+        <span class="tag tag-new" data-i18n="heroBadge">v0.5.2 — latest release</span>
       </div>
       <h1 class="animate-fade-up" style="animation-delay:0.12s;" data-i18n="heroTitle">MySQL binlog backup control plane
 for real operations</h1>
@@ -547,7 +547,7 @@ Signals        Checkpoint / Lag / Events / Workers / Metrics</code>
 verify, extract, run</h2>
       <p class="section-sub" data-i18n="deploySub">Operators do not need Go. Real assets are named <code>binlog-server_&lt;ver&gt;_&lt;os&gt;_&lt;arch&gt;.tar.gz</code> and extract into a versioned subdirectory. Full write-up: <a href="https://github.com/Fanduzi/BinlogServer/blob/main/docs/guide/admin/deployment.md">docs/guide/admin/deployment.md</a>.</p>
       <div class="hero-code">
-        <code data-i18n="deployCode">VER=0.5.1 OS=linux ARCH=amd64
+        <code data-i18n="deployCode">VER=0.5.2 OS=linux ARCH=amd64
 curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz
 curl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
@@ -785,18 +785,18 @@ better UI, better ops, better reliability</h2>
           <div class="timeline">
             <div class="timeline-item">
               <div class="timeline-date">2026-08-30</div>
+              <div class="timeline-version">v0.5.2</div>
+              <p data-i18n="release1">LATEST start on a quiet source no longer flashes DELAYED from an old event header, and task pages sort numeric ids as 1,2,3 not 1,10,100.</p>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-date">2026-08-30</div>
               <div class="timeline-version">v0.5.1</div>
-              <p data-i18n="release1">Download examples now match the published tarball, and isolated 1000/100 scale plus production-template auth evidence were recorded.</p>
+              <p data-i18n="release2">Download examples now match the published tarball, and isolated 1000/100 scale plus production-template auth evidence were recorded.</p>
             </div>
             <div class="timeline-item">
               <div class="timeline-date">2026-08-30</div>
               <div class="timeline-version">v0.5.0</div>
-              <p data-i18n="release2">Batch create, server paging, bounded source retries, and a production auth template landed; GET /api/tasks is now a paged object.</p>
-            </div>
-            <div class="timeline-item">
-              <div class="timeline-date">2026-08-30</div>
-              <div class="timeline-version">v0.4.3</div>
-              <p data-i18n="release3">Loopback aliases can no longer bypass metadata/source isolation, and source lookup uses the same endpoint identity.</p>
+              <p data-i18n="release3">Batch create, server paging, bounded source retries, and a production auth template landed; GET /api/tasks is now a paged object.</p>
             </div>
           </div>
         </div>
@@ -908,8 +908,8 @@ and into a real product surface</h2>
         deployLabel: 'Quick Start',
         deployTitle: 'Download the release tarball,\nverify, extract, run',
         deploySub: 'Operators do not need Go. Real assets are named binlog-server_<ver>_<os>_<arch>.tar.gz and extract into a versioned subdirectory.',
-        deployCode: 'VER=0.5.1 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
-        heroBadge: 'v0.5.1 — latest release',
+        deployCode: 'VER=0.5.2 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
+        heroBadge: 'v0.5.2 — latest release',
         heroTitle: 'MySQL binlog backup control plane\nfor real operations',
         heroSub: 'BinlogServer centralizes MySQL binlog backup behind one service. Run local-first durable capture, inspect state through API and embedded UI, scale into cluster roles, export metrics, and archive sealed files with optional S3-compatible upload.',
         heroPrimary: 'Open Deployment Guide',
@@ -1000,9 +1000,9 @@ and into a real product surface</h2>
         changelogTitle: 'Recent work trends toward\nbetter UI, better ops, better reliability',
         changelogSub: 'The recent story is not random feature sprawl. It is clearer operator workflows, stronger frontend validation, and more production-minded behavior.',
         releaseLeftTitle: 'Release timeline',
-        release1: 'Download examples now match the published tarball, and isolated 1000/100 scale plus production-template auth evidence were recorded.',
-        release2: 'Batch create, server paging, bounded source retries, and a production auth template landed; GET /api/tasks is now a paged object.',
-        release3: 'Loopback aliases can no longer bypass metadata/source isolation, and source lookup uses the same endpoint identity.',
+        release1: 'LATEST start on a quiet source no longer flashes DELAYED from an old event header, and task pages sort numeric ids as 1,2,3 not 1,10,100.',
+        release2: 'Download examples now match the published tarball, and isolated 1000/100 scale plus production-template auth evidence were recorded.',
+        release3: 'Batch create, server paging, bounded source retries, and a production auth template landed; GET /api/tasks is now a paged object.',
         releaseRightTitle: 'What the homepage should emphasize',
         releaseFocus1Date: 'Current direction',
         releaseFocus1Title: 'Control plane maturity',
@@ -1049,8 +1049,8 @@ and into a real product surface</h2>
         deployLabel: '快速开始',
         deployTitle: '下载 release tarball，\n校验、解压、运行',
         deploySub: '值班不需要安装 Go。真实资产名是 binlog-server_<ver>_<os>_<arch>.tar.gz，解压后在一层版本子目录里。',
-        deployCode: 'VER=0.5.1 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
-        heroBadge: 'v0.5.1 — 最新发布',
+        deployCode: 'VER=0.5.2 OS=linux ARCH=amd64\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncurl -fsSL -O https://github.com/Fanduzi/BinlogServer/releases/download/v${VER}/checksums.txt\nsha256sum -c checksums.txt --ignore-missing\ntar -xzf binlog-server_${VER}_${OS}_${ARCH}.tar.gz\ncd binlog-server_${VER}_${OS}_${ARCH}\nexport BINLOG_SERVER_DATA_DIR=./data\n./binlog-server',
+        heroBadge: 'v0.5.2 — 最新发布',
         heroTitle: '面向真实运维的\nMySQL binlog 备份控制平面',
         heroSub: 'BinlogServer 把 MySQL binlog 备份集中到一个服务里：本地优先的可靠采集、通过 API 与内置 UI 可见的运行状态、可扩展到集群角色的执行模型、Prometheus 指标，以及可选的兼容 S3 的归档上传。',
         heroPrimary: '打开部署指南',
@@ -1141,9 +1141,9 @@ and into a real product surface</h2>
         changelogTitle: '近期工作明显朝着\n更好的 UI、更好的运维、更好的可靠性前进',
         changelogSub: '最近的变化不是零散功能堆砌，而是更清晰的运维流程、更强的前端验证，以及更偏生产的行为。',
         releaseLeftTitle: '版本时间线',
-        release1: '下载示例已对齐当前发布包，并记录了隔离环境 1000/100 规模与生产模板鉴权证据。',
-        release2: '批量创建、服务端分页、有上限的源重试和生产鉴权模板落地；GET /api/tasks 改为分页对象。',
-        release3: 'loopback 别名不再能够绕过 metadata/source 隔离检查，source lookup 也使用同一套端点身份规则。',
+        release1: '安静源上的 LATEST start 不再用旧 event header 闪 DELAYED，任务分页按数字 id 排成 1,2,3 而不是 1,10,100。',
+        release2: '下载示例已对齐当前发布包，并记录了隔离环境 1000/100 规模与生产模板鉴权证据。',
+        release3: '批量创建、服务端分页、有上限的源重试和生产鉴权模板落地；GET /api/tasks 改为分页对象。',
         releaseRightTitle: '首页应该强调什么',
         releaseFocus1Date: '当前方向',
         releaseFocus1Title: '控制平面成熟度',

--- a/docs/releases/release-notes-v0.5.2.md
+++ b/docs/releases/release-notes-v0.5.2.md
@@ -1,0 +1,23 @@
+# Binlog Server v0.5.2
+
+Release date: 2026-08-30
+
+Binlog Server `v0.5.2` is an operator-facing bugfix patch on `v0.5.1`.
+
+## Highlights
+
+- Starting a `LATEST` task against a quiet source no longer flashes `DELAYED` from a days-old binlog event header. Once the dump is at the source file/pos, `delay_seconds` is 0 / `NORMAL`. Catch-up from `FILE_POS`/`GTID` that is still behind the tip still reports real lag.
+- Task list and dashboard pages sort numeric string ids as integers. With hundreds of tasks, page 1 is `1,2,3,…` instead of `1,10,100,…`.
+- Quick Start, landing-page, and deployment download examples now point at `v0.5.2`.
+
+## Upgrade Notes
+
+- No schema migration is required for `v0.5.2`.
+- No API contract change versus `v0.5.1`. The `GET /api/tasks` paging object from `v0.5.0` still applies if you are upgrading from `v0.4.x`.
+- List order of existing tasks changes from lexicographic id to numeric id.
+
+## Chinese Release Notes
+
+Chinese version:
+
+https://github.com/Fanduzi/BinlogServer/blob/main/docs/releases/v0.5.2.zh-CN.md

--- a/docs/releases/v0.5.2.zh-CN.md
+++ b/docs/releases/v0.5.2.zh-CN.md
@@ -1,0 +1,19 @@
+# Binlog Server v0.5.2 中文发布说明
+
+> 对应版本：`v0.5.2`
+
+发布日期：2026-08-30
+
+`v0.5.2` 是 `v0.5.1` 的值班可见 bugfix 补丁。
+
+## 核心变化
+
+- 对着一段时间没写入的源库做 `LATEST` start，不再用几天前的 event header 时间报 `DELAYED`。dump 已在源库当前 file/pos 时，`delay_seconds` 为 0 / `NORMAL`。仍在追位点的 `FILE_POS`/`GTID` 继续报真延迟。
+- 任务列表和 dashboard 分页按数字 id 排序。几百条任务时第 1 页是 `1,2,3,…`，不是 `1,10,100,…`。
+- Quick Start、落地页和部署文档里的下载示例改为 `v0.5.2`。
+
+## 升级影响
+
+- `v0.5.2` 不需要 schema migration。
+- 相对 `v0.5.1` 没有 API 契约变化。如果是从 `v0.4.x` 升上来，`v0.5.0` 的 `GET /api/tasks` 分页对象仍然有效。
+- 已有任务的列表顺序从 id 字典序改为数字序。


### PR DESCRIPTION
## Summary

- add v0.5.2 changelog entries for #49 and #50
- add English and Chinese release notes
- pin README, landing, deployment, and API worker example to `v0.5.2`

## Verification

- `go test ./...`
- `go vet ./...`
- `goreleaser check`
- three-level-doc OK