### PR TITLE
fix: resume only this worker's tasks on cluster start (#56)

### DIFF
--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -5,7 +5,7 @@
 - `tracing.go`: tracing provider 初始化与生命周期管理。
 - `tracing_test.go`: OTLP HTTP 默认 traces 路径兼容性回归测试。
 - `http_server_test.go`: HTTP 超时和生产环境 auth fail-closed 校验测试。
-- `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`），包括 auth 到真实路由的回归。
+- `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`），包括 auth 到真实路由、以及 cluster 启动只恢复本 worker 任务的回归。
 - `restart_recovery_test.go`: standalone 重启后安全的持久化 active task 自动恢复、metadata/source 冲突任务保持停止的回归测试。
 - `source_guard_test.go`: 从 `meta_dsn` 到任务 API 的 metadata/source 隔离装配回归测试。
 
@@ -18,7 +18,8 @@
 - API server 支持从 `config.API.Auth` 注入鉴权策略。
 - 非空 `PRODUCTION` 用标准布尔值解析；control-plane 在 true 时强制 auth 已启用、同时保护 `/api/*` 和 `/metrics`，并复用 `config.ValidateAPIAuthConfig` 校验模式/已解析凭证；worker-only 不暴露该 API 且不套用此约束。
 - tracing：默认关闭；启用时装配 HTTP 入站 span 与元数据存储调用 span；无路径的 OTLP HTTP endpoint 沿用 `/v1/traces` 默认路径。
-- standalone/cluster worker 启动时自动恢复 metadata 中遗留的 active task，并从 checkpoint 续传。
+- standalone worker 启动时 Stop+Start 全部 persisted active task，并从 checkpoint 续传。
+- cluster worker 启动时只 Stop+Start 本 worker 拥有的任务以及无主 STARTING（owner 为空且 epoch 为 0），不会对其他 worker 的 RUNNING 调用 StopTask。
 
 ### Minimal Tracing Config Example
 ```yaml

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
-// input: runtime config, PRODUCTION environment flag, persisted task state, scheduler/runner/meta store dependencies, process context
-// output: role-aware application lifecycle control with production control-plane auth checks, metadata/source isolation, restart recovery, and shutdown
+// input: runtime config, PRODUCTION environment flag, persisted task state, resolved cluster worker id, scheduler/runner/meta store dependencies, process context
+// output: role-aware application lifecycle control with production control-plane auth checks, metadata/source isolation, worker-scoped restart recovery, and shutdown
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -275,7 +275,8 @@ func (a *App) Run(ctx context.Context) error {
 	}
 	if workerEnabled {
 		// worker 重启后把可恢复任务重新拉起，清理遗留的中间态。
-		stats := resumePersistedActiveTasks(scheduler)
+		// cluster 传入本实例 worker id，避免 StopTask 把其他 worker 仍在跑的任务写成 STOPPED。
+		stats := resumePersistedActiveTasks(scheduler, resolvedWorkerID)
 		if stats.StopErrors > 0 || stats.StartErrors > 0 {
 			log.Printf(
 				"task resume completed with errors considered=%d resumed=%d stop_errors=%d start_errors=%d",
@@ -989,25 +990,48 @@ type taskResumer interface {
 }
 
 // resumePersistedActiveTasks 在 worker 启动时重置并恢复持久化的 active 任务。
-func resumePersistedActiveTasks(scheduler taskResumer) resumeStats {
+// clusterWorkerID 为空时按 standalone 恢复全部 active 任务；非空时只 Stop+Start 本 worker 拥有的任务和无主 STARTING。
+func resumePersistedActiveTasks(scheduler taskResumer, clusterWorkerID string) resumeStats {
 	var stats resumeStats
 	for _, task := range scheduler.ListTasks() {
-		switch task.State {
-		case tasks.StateRunning, tasks.StateStarting, tasks.StateRetryBackoff, tasks.StateLeaseDegraded:
-			// 这些状态都需要 worker 继续推进；通过 stop->start 让其在当前实例重新走 lease 获取流程。
-			stats.Considered++
-			if err := scheduler.StopTask(task.ID); err != nil {
-				stats.StopErrors++
-				log.Printf("task resume stop failed task=%s err=%v", task.ID, err)
-				continue
-			}
-			if err := scheduler.StartTask(task.ID); err != nil {
-				stats.StartErrors++
-				log.Printf("task resume start failed task=%s err=%v", task.ID, err)
-				continue
-			}
-			stats.Resumed++
+		if !shouldResumePersistedTask(task, clusterWorkerID) {
+			continue
 		}
+		// 这些状态都需要本 worker 继续推进；通过 stop->start 让其在当前实例重新走 lease 获取流程。
+		stats.Considered++
+		if err := scheduler.StopTask(task.ID); err != nil {
+			stats.StopErrors++
+			log.Printf("task resume stop failed task=%s err=%v", task.ID, err)
+			continue
+		}
+		if err := scheduler.StartTask(task.ID); err != nil {
+			stats.StartErrors++
+			log.Printf("task resume start failed task=%s err=%v", task.ID, err)
+			continue
+		}
+		stats.Resumed++
 	}
 	return stats
+}
+
+// shouldResumePersistedTask 判断启动恢复是否应对该任务执行 Stop+Start。
+// standalone（worker id 为空）恢复全部 active 任务；cluster 只恢复本 worker 拥有的任务，以及 owner 为空且 epoch 为 0 的 STARTING。
+func shouldResumePersistedTask(task tasks.Task, clusterWorkerID string) bool {
+	switch task.State {
+	case tasks.StateRunning, tasks.StateStarting, tasks.StateRetryBackoff, tasks.StateLeaseDegraded:
+	default:
+		return false
+	}
+	workerID := strings.TrimSpace(clusterWorkerID)
+	if workerID == "" {
+		return true
+	}
+	owner := strings.TrimSpace(task.OwnerWorkerID)
+	if owner == workerID {
+		return true
+	}
+	if owner != "" {
+		return false
+	}
+	return task.State == tasks.StateStarting && task.Epoch <= 0
 }

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
-// input: runtime config/template, persisted active tasks, scheduler/runner/meta store dependencies, process context
-// output: application lifecycle plus real-route production auth and worker-only regression coverage
+// input: runtime config/template, persisted active tasks, resolved cluster worker id, scheduler/runner/meta store dependencies, process context
+// output: application lifecycle plus real-route production auth, worker-only, and cluster resume ownership-filter regression coverage
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -625,7 +625,7 @@ func TestApp_ResumePersistedActiveTasksStartsRecoveredTasks(t *testing.T) {
 		t.Fatalf("Restore returned error: %v", err)
 	}
 
-	stats := resumePersistedActiveTasks(s)
+	stats := resumePersistedActiveTasks(s, "")
 	if stats.Considered != 1 || stats.Resumed != 1 || stats.StopErrors != 0 || stats.StartErrors != 0 {
 		t.Fatalf("unexpected resume stats: %+v", stats)
 	}
@@ -1088,8 +1088,9 @@ func (f *fakeResumeScheduler) StartTask(id string) error {
 func TestApp_ResumeClusterWorkerTasksLogsAndCountsErrors(t *testing.T) {
 	resumer := &fakeResumeScheduler{
 		items: []tasks.Task{
-			{ID: "1", State: tasks.StateRunning},
-			{ID: "2", State: tasks.StateLeaseDegraded},
+			{ID: "1", State: tasks.StateRunning, OwnerWorkerID: "W1", Epoch: 3},
+			{ID: "2", State: tasks.StateLeaseDegraded, OwnerWorkerID: "W1", Epoch: 4},
+			{ID: "foreign", State: tasks.StateRunning, OwnerWorkerID: "W2", Epoch: 8},
 		},
 		stopErr: map[string]error{
 			"1": errors.New("stop failed"),
@@ -1104,13 +1105,159 @@ func TestApp_ResumeClusterWorkerTasksLogsAndCountsErrors(t *testing.T) {
 	log.SetOutput(&buf)
 	defer log.SetOutput(origWriter)
 
-	stats := resumePersistedActiveTasks(resumer)
+	stats := resumePersistedActiveTasks(resumer, "W1")
 	if stats.Considered != 2 || stats.Resumed != 0 || stats.StopErrors != 1 || stats.StartErrors != 1 {
 		t.Fatalf("unexpected resume stats: %+v", stats)
+	}
+	if containsString(resumer.stopCalls, "foreign") || containsString(resumer.startCalls, "foreign") {
+		t.Fatalf("foreign running task was resumed, stop=%v start=%v", resumer.stopCalls, resumer.startCalls)
 	}
 	if !strings.Contains(buf.String(), "task=1") || !strings.Contains(buf.String(), "task=2") {
 		t.Fatalf("expected error logs contain task ids, got logs=%q", buf.String())
 	}
+}
+
+// TestApp_ResumeClusterWorkerSkipsForeignRunning 验证 cluster 启动不会 Stop+Start 其他 worker 的 RUNNING。
+func TestApp_ResumeClusterWorkerSkipsForeignRunning(t *testing.T) {
+	resumer := &fakeResumeScheduler{
+		items: []tasks.Task{
+			{ID: "foreign", State: tasks.StateRunning, OwnerWorkerID: "W2", Epoch: 4},
+			{ID: "own", State: tasks.StateRunning, OwnerWorkerID: "W1", Epoch: 2},
+			{ID: "starting", State: tasks.StateStarting},
+			{ID: "foreign-starting", State: tasks.StateStarting, OwnerWorkerID: "W2", Epoch: 1},
+		},
+	}
+
+	stats := resumePersistedActiveTasks(resumer, "W1")
+	if stats.Considered != 2 || stats.Resumed != 2 || stats.StopErrors != 0 || stats.StartErrors != 0 {
+		t.Fatalf("unexpected resume stats: %+v", stats)
+	}
+	if containsString(resumer.stopCalls, "foreign") || containsString(resumer.startCalls, "foreign") {
+		t.Fatalf("foreign RUNNING was Stop/Start, stop=%v start=%v", resumer.stopCalls, resumer.startCalls)
+	}
+	if containsString(resumer.stopCalls, "foreign-starting") || containsString(resumer.startCalls, "foreign-starting") {
+		t.Fatalf("foreign STARTING was Stop/Start, stop=%v start=%v", resumer.stopCalls, resumer.startCalls)
+	}
+	if !containsString(resumer.stopCalls, "own") || !containsString(resumer.startCalls, "own") {
+		t.Fatalf("expected own RUNNING to be Stop+Start, stop=%v start=%v", resumer.stopCalls, resumer.startCalls)
+	}
+	if !containsString(resumer.stopCalls, "starting") || !containsString(resumer.startCalls, "starting") {
+		t.Fatalf("expected unowned STARTING to be resumed, stop=%v start=%v", resumer.stopCalls, resumer.startCalls)
+	}
+}
+
+// TestApp_ResumeStandaloneStillResumesForeignOwnedRunning 验证 standalone（无 worker 过滤）仍恢复全部 RUNNING。
+func TestApp_ResumeStandaloneStillResumesForeignOwnedRunning(t *testing.T) {
+	resumer := &fakeResumeScheduler{
+		items: []tasks.Task{
+			{ID: "running", State: tasks.StateRunning, OwnerWorkerID: "W2", Epoch: 4},
+		},
+	}
+
+	stats := resumePersistedActiveTasks(resumer, "")
+	if stats.Considered != 1 || stats.Resumed != 1 || stats.StopErrors != 0 || stats.StartErrors != 0 {
+		t.Fatalf("unexpected resume stats: %+v", stats)
+	}
+	if len(resumer.stopCalls) != 1 || resumer.stopCalls[0] != "running" {
+		t.Fatalf("expected standalone resume to StopTask running, got %v", resumer.stopCalls)
+	}
+	if len(resumer.startCalls) != 1 || resumer.startCalls[0] != "running" {
+		t.Fatalf("expected standalone resume to StartTask running, got %v", resumer.startCalls)
+	}
+}
+
+// TestApp_ResumeClusterWorkerDoesNotPersistForeignRunningStopped 验证不会把别人的 RUNNING 持久化为 STOPPED。
+func TestApp_ResumeClusterWorkerDoesNotPersistForeignRunningStopped(t *testing.T) {
+	store := newAppFakeStore()
+	source := tasks.SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"}
+	start := tasks.StartConfig{Mode: tasks.StartModeLatest}
+	store.tasks["foreign"] = tasks.Task{
+		ID:            "foreign",
+		Name:          "foreign",
+		State:         tasks.StateRunning,
+		OwnerWorkerID: "W2",
+		Epoch:         7,
+		Source:        source,
+		Start:         start,
+	}
+	store.tasks["own"] = tasks.Task{
+		ID:            "own",
+		Name:          "own",
+		State:         tasks.StateRunning,
+		OwnerWorkerID: "W1",
+		Epoch:         3,
+		Source:        source,
+		Start:         start,
+	}
+	store.tasks["starting"] = tasks.Task{
+		ID:     "starting",
+		Name:   "starting",
+		State:  tasks.StateStarting,
+		Source: source,
+		Start:  start,
+	}
+
+	runner := &appFakeRunner{started: make(chan tasks.Task, 4)}
+	s := tasks.NewScheduler(
+		tasks.WithStore(store),
+		tasks.WithRunner(runner),
+		tasks.WithClusterLeaseManager(&appLeaseManager{acquireOK: true, acquireEpoch: 11}),
+		tasks.WithClusterWorkerID("W1"),
+	)
+	if err := s.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+
+	stats := resumePersistedActiveTasks(s, "W1")
+	if stats.Considered != 2 || stats.Resumed != 2 || stats.StopErrors != 0 || stats.StartErrors != 0 {
+		t.Fatalf("unexpected resume stats: %+v", stats)
+	}
+
+	foreign, err := s.GetTask("foreign")
+	if err != nil {
+		t.Fatalf("GetTask foreign: %v", err)
+	}
+	if foreign.State != tasks.StateRunning {
+		t.Fatalf("expected foreign task to stay RUNNING, got %s", foreign.State)
+	}
+	persisted, err := store.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	for _, task := range persisted {
+		if task.ID == "foreign" && task.State != tasks.StateRunning {
+			t.Fatalf("foreign RUNNING persisted as %s", task.State)
+		}
+	}
+
+	started := map[string]struct{}{}
+	deadline := time.After(2 * time.Second)
+	for len(started) < 2 {
+		select {
+		case task := <-runner.started:
+			if task.ID == "foreign" {
+				t.Fatal("foreign RUNNING task was started on this worker")
+			}
+			started[task.ID] = struct{}{}
+		case <-deadline:
+			t.Fatalf("expected own and unowned starting to start, got %v", started)
+		}
+	}
+	if _, ok := started["own"]; !ok {
+		t.Fatal("expected own RUNNING to be started")
+	}
+	if _, ok := started["starting"]; !ok {
+		t.Fatal("expected unowned STARTING to be started")
+	}
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 // waitReady 实现对应功能逻辑。


### PR DESCRIPTION
Fixes #56

Cluster worker start only Stop+Starts tasks owned by this worker, or unowned `STARTING`. Another worker's `RUNNING` is no longer persisted as `STOPPED`. Standalone resume-all is unchanged.

**Review:** approved. Merge this before #55 (`app.go` overlap).