### PR TITLE
fix: include example configs in goreleaser archives (#60)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,8 @@ archives:
       - README.md
       - README_ZH.md
       - CHANGELOG.md
+      - config.example.yaml
+      - config.production.example.yaml
       - migrations/*.sql
 
 checksum:


### PR DESCRIPTION
Fixes #60

Release tarballs now include `config.example.yaml` and `config.production.example.yaml`. Already-published v0.5.2 archives are unchanged.

**Review:** approved.