### PR TITLE
fix: require auth on non-loopback listen and encrypt source passwords (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Maintenance rules:
 
 ## [Unreleased]
 
+### Changed
+
+- Control-plane `listen_addr` that is not loopback (`:8080`, `0.0.0.0:8080`, and any non-`127.0.0.1`/`localhost`/`::1` bind) now requires `api.auth.enabled`, `protect_api`, and `protect_metrics` at `App.Run`. Loopback binds may stay unauthenticated for local demo. `PRODUCTION=true` still fail-closes independently and is not weakened.
+- When `api.auth.enabled=true`, unset `protect_api` / `protect_metrics` now default to true. Explicit `false` is still honored at config load, but non-loopback listen and `PRODUCTION=true` still reject that combination. `listen_addr` default remains `:8080`.
+
 ## [v0.5.2] - 2026-08-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Maintenance rules:
 - Control-plane `listen_addr` that is not loopback (`:8080`, `0.0.0.0:8080`, and any non-`127.0.0.1`/`localhost`/`::1` bind) now requires `api.auth.enabled`, `protect_api`, and `protect_metrics` at `App.Run`. Loopback binds may stay unauthenticated for local demo. `PRODUCTION=true` still fail-closes independently and is not weakened.
 - When `api.auth.enabled=true`, unset `protect_api` / `protect_metrics` now default to true. Explicit `false` is still honored at config load, but non-loopback listen and `PRODUCTION=true` still reject that combination. `listen_addr` default remains `:8080`.
 
+### Security
+
+- Source passwords in `backup_tasks.source_json` are encrypted with AES-256-GCM (`enc:aes256:`) when `--encryption-key` is provided. Other source fields stay plaintext JSON. Without a key, plaintext persist is unchanged so existing deploys keep starting.
+
 ## [v0.5.2] - 2026-08-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -182,12 +182,13 @@ For more operational and usage guidance, continue from [docs/guide/README.md](do
 
 > ⚠️ **Security Warning**
 >
-> By default, API authentication is **DISABLED** for development convenience.
+> By default, API authentication is **DISABLED** only for loopback demo binds (`127.0.0.1`/`localhost`/`::1`).
+> Non-loopback `listen_addr` (including the default `:8080` and `0.0.0.0:8080`) fail-closes at startup unless `api.auth.enabled`, `protect_api`, and `protect_metrics` are all true. `PRODUCTION=true` still requires the same independently.
 >
 > **For production deployments, you MUST:**
 > 1. Set `api.auth.enabled: true` (or `BINLOG_SERVER_API_AUTH_ENABLED=true`)
 > 2. Configure your authentication method (Bearer Token or API Key)
-> 3. Protect `/api/*` and `/metrics`
+> 3. Protect `/api/*` and `/metrics` (these default true when auth is enabled and the flags are unset)
 >
 > See [SECURITY.md](SECURITY.md) and [docs/security.md](docs/security.md) for security guidance.
 
@@ -195,7 +196,7 @@ For more operational and usage guidance, continue from [docs/guide/README.md](do
 
 Development defaults are intentionally permissive. Do not carry them unchanged into production.
 
-- Auth: disabled by default; production should protect at least `/api/*` and `/metrics`
+- Auth: disabled by default only on loopback; non-loopback listen and `PRODUCTION=true` require enabled auth plus protected `/api/*` and `/metrics`
 - Meta DB: if `meta_dsn` is configured, use an independent MySQL instance that is never a replication source, and run migrations first; the service does not auto-create or auto-upgrade schema
 - Standalone without `meta_dsn` keeps task metadata, checkpoints, and file records in memory only. `kill -9` / process restart drops the control plane. Binlog bytes already written under `{data_dir}/{task_id}/` remain as orphan files. With `meta_dsn`, persisted active tasks resume automatically from their checkpoint after restart, and `GET /files` includes the current `OPEN` segment. `storage.dir` is ignored; files always go to `{data_dir}/{task_id}/`.
 - Upload: S3-compatible upload is optional, but required fields must be complete when enabled

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ If you enable upload, provide at least:
 ### Auth was left disabled in production
 
 - This is the most important development default to override.
-- Development keeps auth off for convenience; production should not.
+- Loopback binds (127.0.0.1/localhost/::1) may stay unauthenticated; non-loopback listen and PRODUCTION=true require auth.
 - See [SECURITY.md](SECURITY.md) and [docs/security.md](docs/security.md) for concrete guidance.
 
 ### Upload is configured but files do not upload

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -243,7 +243,7 @@ export BINLOG_SERVER_META_DSN="$META_DSN"
 ### 生产环境忘了开 auth
 
 - 这是当前最需要显式覆盖的开发默认值。
-- 开发环境默认关闭 auth，生产环境不应该这样部署。
+- 本机 loopback（127.0.0.1/localhost/::1）可以保持关闭鉴权；非 loopback 监听和 PRODUCTION=true 必须开鉴权。
 - 具体安全配置建议见 [SECURITY.md](SECURITY.md) 和 [docs/security.md](docs/security.md)。
 
 ### upload 配置了但上传不工作

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -181,12 +181,13 @@ curl -fsS http://127.0.0.1:8080/api/tasks
 
 > ⚠️ **Security Warning**
 >
-> 默认关闭 API authentication，是为了降低开发环境启动门槛。
+> 默认关闭 API authentication 仅适用于 loopback 演示绑定（`127.0.0.1`/`localhost`/`::1`）。
+> 非 loopback 的 `listen_addr`（含默认 `:8080` 和 `0.0.0.0:8080`）启动时 fail-close，必须同时开启 `api.auth.enabled`、`protect_api` 和 `protect_metrics`。`PRODUCTION=true` 仍会独立强制同一组约束。
 >
 > **生产环境必须：**
 > 1. 设置 `api.auth.enabled: true`（或 `BINLOG_SERVER_API_AUTH_ENABLED=true`）
 > 2. 配置认证方式（Bearer Token 或 API Key）
-> 3. 保护 `/api/*` 与 `/metrics`
+> 3. 保护 `/api/*` 与 `/metrics`（`enabled=true` 且未显式设置时，这两个标志默认为 true）
 >
 > 具体安全建议见 [SECURITY.md](SECURITY.md) 与 [docs/security.md](docs/security.md)。
 
@@ -194,7 +195,7 @@ curl -fsS http://127.0.0.1:8080/api/tasks
 
 开发环境默认值偏宽松，生产环境不要直接照搬。
 
-- Auth：默认关闭，生产环境至少应保护 `/api/*` 与 `/metrics`
+- Auth：仅 loopback 默认可关闭；非 loopback listen 与 `PRODUCTION=true` 都要求开启鉴权并保护 `/api/*` 与 `/metrics`
 - Meta DB：如果配置了 `meta_dsn`，必须使用绝不作为复制源的独立 MySQL 实例，并先执行 migration；服务不会自动建表或自动升级 schema
 - 未配置 `meta_dsn` 的 standalone：任务元数据、checkpoint、文件记录只在内存。进程 `kill -9` / 重启后控制面清空。已经写到 `{data_dir}/{task_id}/` 的 binlog 会变成孤儿文件。配置 `meta_dsn` 后，持久化的 active task 会在重启时自动从 checkpoint 续传，运行中 `GET /files` 也会列出当前 `OPEN` segment。`storage.dir` 会被忽略，真实路径固定为 `{data_dir}/{task_id}/`。
 - Upload：S3-compatible upload 是可选能力，但一旦启用，必填项必须完整

--- a/cmd/binlog-server/README.md
+++ b/cmd/binlog-server/README.md
@@ -5,7 +5,7 @@
 - `cmd/root.go`: Cobra root command，负责配置加载与应用启动。
 
 ## Exports
-- CLI 接口：`binlog-server --config <path>`。
+- CLI 接口：`binlog-server --config <path>`；`--encryption-key` 同时解密 `enc:aes256:` 配置值并加密 meta 中的源库密码。
 - 运行入口：执行 app 运行时。
 
 ## Dependencies

--- a/cmd/binlog-server/cmd/README.md
+++ b/cmd/binlog-server/cmd/README.md
@@ -6,7 +6,7 @@ binlog-server CLI 子命令定义目录。
 
 | File | Responsibility |
 |------|---------------|
-| root.go | Cobra root command，负责参数绑定、根命令参数校验与应用启动调用；bind 失败不刷 Usage |
+| root.go | Cobra root command，负责参数绑定、根命令参数校验与应用启动调用；`--encryption-key` 同时用于配置值解密和 meta 源库密码加密；bind 失败不刷 Usage |
 | version.go | `version` 子命令、`--version` 输出与 ASCII banner 版本信息渲染 |
 | root_test.go | CLI 回归测试，覆盖 `version`、`--version` 与位置参数校验 |
 

--- a/cmd/binlog-server/cmd/root.go
+++ b/cmd/binlog-server/cmd/root.go
@@ -1,5 +1,5 @@
 // Package cmd provides module-level functionality for cmd.
-// input: config loader, signal context, logging setup, app runtime dependencies
+// input: config loader, optional --encryption-key, signal context, logging setup, app runtime dependencies
 // output: root cobra command that starts binlog-server without dumping Usage on bind errors
 // pos: CLI orchestration entry between process bootstrap and app lifecycle
 // note: if this file changes, update this header and module README.md.
@@ -35,7 +35,7 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	root.Flags().StringVarP(&configPath, "config", "c", "", "YAML config file path (default: ./config.yaml if exists)")
-	root.Flags().StringVar(&encryptionKey, "encryption-key", "", "Encryption key for encrypted config values (32 bytes for AES-256)")
+	root.Flags().StringVar(&encryptionKey, "encryption-key", "", "AES-256 key (32 bytes) for enc:aes256: config values and source passwords in meta")
 	root.Flags().BoolVar(&versionOnly, "version", false, "Print version and exit")
 	root.AddCommand(newVersionCommand())
 	return root

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,6 @@
+# Loopback may stay unauthenticated for local demo.
 # Non-loopback binds (:8080, 0.0.0.0:8080) require api.auth.enabled + protect_api + protect_metrics.
-# Loopback (127.0.0.1/localhost/::1) may stay unauthenticated for local demo.
-listen_addr: ":8080"
+listen_addr: "127.0.0.1:8080"
 data_dir: "./data"
 meta_dsn: "${BINLOG_SERVER_META_DSN}" # 推荐用环境变量注入，避免明文口令
 mode: "standalone" # standalone | cluster
@@ -30,8 +30,7 @@ api:
     bearer_token: "${BINLOG_SERVER_API_AUTH_BEARER_TOKEN}" # 推荐用环境变量注入
     api_key: ""
     api_key_header: "X-API-Key"
-    protect_api: false # enabled=true 且未设置时默认为 true；显式 false 仅 loopback 可启动
-    protect_metrics: false
+    # Omit protect_api / protect_metrics: when enabled=true they default to true.
 
 http:
   control_plane:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,5 @@
+# Non-loopback binds (:8080, 0.0.0.0:8080) require api.auth.enabled + protect_api + protect_metrics.
+# Loopback (127.0.0.1/localhost/::1) may stay unauthenticated for local demo.
 listen_addr: ":8080"
 data_dir: "./data"
 meta_dsn: "${BINLOG_SERVER_META_DSN}" # 推荐用环境变量注入，避免明文口令
@@ -23,12 +25,12 @@ upload:
 
 api:
   auth:
-    enabled: false # 生产环境建议改为 true 并配置凭证
+    enabled: false # 非 loopback listen 与 PRODUCTION=true 时必须为 true
     mode: "bearer" # bearer | api_key
     bearer_token: "${BINLOG_SERVER_API_AUTH_BEARER_TOKEN}" # 推荐用环境变量注入
     api_key: ""
     api_key_header: "X-API-Key"
-    protect_api: false
+    protect_api: false # enabled=true 且未设置时默认为 true；显式 false 仅 loopback 可启动
     protect_metrics: false
 
 http:

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,7 +17,7 @@ api:
     mode: bearer
     bearer_token: "your-secret-token"
     protect_api: true
-    protect_metrics: true  # Optional: also protect /metrics endpoint
+    protect_metrics: true  # defaults to true when api.auth.enabled=true and unset
 ```
 
 Or via environment variables:
@@ -99,6 +99,8 @@ For enhanced security, you can encrypt sensitive values in your configuration fi
    ```bash
    ./binlog-server --config config.yaml --encryption-key "your-32-byte-encryption-key"
    ```
+   The same key encrypts task source passwords in `backup_tasks.source_json`. Without a key, those passwords remain plaintext JSON.
+
 ### Encrypted Value Format
 
 Encrypted values use the format: `enc:aes256:<base64-encoded-ciphertext>`
@@ -160,3 +162,5 @@ When authentication is disabled, Binlog Server will display a warning at startup
 The control-plane also fail-closes when `listen_addr` is not loopback (`:8080` and `0.0.0.0:8080` count as non-loopback). Local demo on `127.0.0.1`/`localhost`/`::1` may keep auth disabled.
 
 In production mode (when `PRODUCTION=true` environment variable is set), the server will refuse to start without authentication enabled. This check is independent of listen_addr and is not weakened.
+
+When `--encryption-key` is set, task source passwords are stored in `backup_tasks.source_json` as `enc:aes256:` ciphertext and decrypted only for internal use. API responses still redact `source.password`. Without a key, existing plaintext rows continue to load.

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,7 +99,6 @@ For enhanced security, you can encrypt sensitive values in your configuration fi
    ```bash
    ./binlog-server --config config.yaml --encryption-key "your-32-byte-encryption-key"
    ```
-
 ### Encrypted Value Format
 
 Encrypted values use the format: `enc:aes256:<base64-encoded-ciphertext>`
@@ -158,4 +157,6 @@ When authentication is disabled, Binlog Server will display a warning at startup
    See docs/security.md for details.
 ```
 
-In production mode (when `PRODUCTION=true` environment variable is set), the server will refuse to start without authentication enabled.
+The control-plane also fail-closes when `listen_addr` is not loopback (`:8080` and `0.0.0.0:8080` count as non-loopback). Local demo on `127.0.0.1`/`localhost`/`::1` may keep auth disabled.
+
+In production mode (when `PRODUCTION=true` environment variable is set), the server will refuse to start without authentication enabled. This check is independent of listen_addr and is not weakened.

--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -30,7 +30,7 @@
 - Tracing: `go.opentelemetry.io/otel`
 
 ## Features
-- 认证：支持 Bearer Token 或 API Key；`/healthz` 默认匿名，`/metrics` 与 `/api/*` 可配置保护
+- 认证：支持 Bearer Token 或 API Key；`/healthz` 默认匿名，`/metrics` 与 `/api/*` 可配置保护。`sanitizeTask` 在响应中清空 `source.password`（解密仅供内部使用）。`/ui` 与 `/swagger` 仍不走 API auth。
 - 创建任务：`CreateTaskFromSpec` 整包校验通过后才落库；400 返回 JSON `{"error","code"}`。批量创建复用同一入口，单项错误不阻塞后续项，成功任务脱敏返回。
 - source lookup：`GET /api/sources/lookup` 使用 tasks 共享 loopback 分类归并 localhost 与显式 loopback literal，端口仍严格匹配；非 loopback host 保持修剪后的原文精确匹配且不做 DNS 解析。
 - 健康检查：`GET /healthz` 文本 `ok`；`GET /api/health` JSON `{"status":"ok"}`

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -263,6 +263,16 @@ func TestTaskAPI_CreateWithSourceAndStart(t *testing.T) {
 	}
 }
 
+func TestSanitizeTaskClearsPassword(t *testing.T) {
+	got := sanitizeTask(tasks.Task{Source: tasks.SourceConfig{Host: "127.0.0.1", Password: "secret"}})
+	if got.Source.Password != "" {
+		t.Fatalf("expected sanitizeTask to redact password after internal decrypt, got %q", got.Source.Password)
+	}
+	if got.Source.Host != "127.0.0.1" {
+		t.Fatalf("expected other source fields to remain, got %+v", got.Source)
+	}
+}
+
 // TestTaskAPI_CreateTaskRequiresClusterKey 验证相关行为。
 func TestTaskAPI_CreateTaskRequiresClusterKey(t *testing.T) {
 	scheduler := tasks.NewScheduler()

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -18,6 +18,7 @@
 - API server 支持从 `config.API.Auth` 注入鉴权策略。
 - 非空 `PRODUCTION` 用标准布尔值解析；control-plane 在 true 时强制 auth 已启用、同时保护 `/api/*` 和 `/metrics`，并复用 `config.ValidateAPIAuthConfig` 校验模式/已解析凭证；worker-only 不暴露该 API 且不套用此约束。
 - control-plane `listen_addr` 非 loopback（含 `:8080`、`0.0.0.0:8080`）时同样强制 `api.auth.enabled` + `protect_api` + `protect_metrics`；`127.0.0.1`/`localhost`/`::1` 可保持未鉴权本地演示。`/healthz` 仍匿名。
+- 创建 meta store 时把 `config.EncryptionKey` 注入，用于 `source_json` 源库密码加解密。
 - tracing：默认关闭；启用时装配 HTTP 入站 span 与元数据存储调用 span；无路径的 OTLP HTTP endpoint 沿用 `/v1/traces` 默认路径。
 - standalone/cluster worker 启动时自动恢复 metadata 中遗留的 active task，并从 checkpoint 续传。
 

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -4,7 +4,7 @@
 - `app.go`: 应用主流程与运行时装配。
 - `tracing.go`: tracing provider 初始化与生命周期管理。
 - `tracing_test.go`: OTLP HTTP 默认 traces 路径兼容性回归测试。
-- `http_server_test.go`: HTTP 超时和生产环境 auth fail-closed 校验测试。
+- `http_server_test.go`: HTTP 超时、PRODUCTION 以及非 loopback listen 的 auth fail-closed 校验测试。
 - `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`），包括 auth 到真实路由的回归。
 - `restart_recovery_test.go`: standalone 重启后安全的持久化 active task 自动恢复、metadata/source 冲突任务保持停止的回归测试。
 - `source_guard_test.go`: 从 `meta_dsn` 到任务 API 的 metadata/source 隔离装配回归测试。
@@ -17,6 +17,7 @@
 - 对 TCP `meta_dsn` 提取 host/port 并注入 tasks，同端点 source 在 create/update/start 边界被拒绝。
 - API server 支持从 `config.API.Auth` 注入鉴权策略。
 - 非空 `PRODUCTION` 用标准布尔值解析；control-plane 在 true 时强制 auth 已启用、同时保护 `/api/*` 和 `/metrics`，并复用 `config.ValidateAPIAuthConfig` 校验模式/已解析凭证；worker-only 不暴露该 API 且不套用此约束。
+- control-plane `listen_addr` 非 loopback（含 `:8080`、`0.0.0.0:8080`）时同样强制 `api.auth.enabled` + `protect_api` + `protect_metrics`；`127.0.0.1`/`localhost`/`::1` 可保持未鉴权本地演示。`/healthz` 仍匿名。
 - tracing：默认关闭；启用时装配 HTTP 入站 span 与元数据存储调用 span；无路径的 OTLP HTTP endpoint 沿用 `/v1/traces` 默认路径。
 - standalone/cluster worker 启动时自动恢复 metadata 中遗留的 active task，并从 checkpoint 续传。
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -61,6 +61,7 @@ var newAppMetaStoreForRun = func(cfg config.Config) (appMetaStore, error) {
 	return meta.NewMySQLTaskStoreWithSchemaTimeout(
 		cfg.MetaDSN,
 		time.Duration(cfg.Meta.Timeout.WriteSec)*time.Second,
+		cfg.EncryptionKey,
 	)
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
-// input: runtime config, PRODUCTION environment flag, persisted task state, scheduler/runner/meta store dependencies, process context
-// output: role-aware application lifecycle control with production control-plane auth checks, metadata/source isolation, restart recovery, and shutdown
+// input: runtime config, PRODUCTION environment flag, control-plane listen_addr, persisted task state, scheduler/runner/meta store dependencies, process context
+// output: role-aware application lifecycle control with production and non-loopback control-plane auth checks, metadata/source isolation, restart recovery, and shutdown
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -105,7 +105,7 @@ func (a *App) Run(ctx context.Context) error {
 		return err
 	}
 	if controlPlaneEnabled {
-		if err := validateProductionAuth(a.cfg.API.Auth, production); err != nil {
+		if err := validateControlPlaneAuth(a.cfg.ListenAddr, a.cfg.API.Auth, production); err != nil {
 			return err
 		}
 	}
@@ -390,6 +390,16 @@ func productionMode(raw string) (bool, error) {
 	return production, nil
 }
 
+func validateControlPlaneAuth(listenAddr string, auth config.APIAuthConfig, production bool) error {
+	if err := validateProductionAuth(auth, production); err != nil {
+		return err
+	}
+	if isLoopbackListenAddr(listenAddr) {
+		return nil
+	}
+	return validateNonLoopbackAuth(auth)
+}
+
 func validateProductionAuth(auth config.APIAuthConfig, production bool) error {
 	if !production {
 		return nil
@@ -401,6 +411,31 @@ func validateProductionAuth(auth config.APIAuthConfig, production bool) error {
 		return errors.New("api.auth.protect_api and api.auth.protect_metrics must be true in PRODUCTION mode")
 	}
 	return config.ValidateAPIAuthConfig(auth)
+}
+
+func validateNonLoopbackAuth(auth config.APIAuthConfig) error {
+	if !auth.Enabled {
+		return errors.New("api.auth.enabled must be true when listen_addr is not loopback")
+	}
+	if !auth.ProtectAPI || !auth.ProtectMetrics {
+		return errors.New("api.auth.protect_api and api.auth.protect_metrics must be true when listen_addr is not loopback")
+	}
+	return config.ValidateAPIAuthConfig(auth)
+}
+
+func isLoopbackListenAddr(addr string) bool {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return false
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "" {
+		return false
+	}
+	return tasks.IsLoopbackHost(host)
 }
 
 func metadataSourceEndpoint(dsn string) (string, uint16, bool) {

--- a/internal/app/http_server_test.go
+++ b/internal/app/http_server_test.go
@@ -1,12 +1,14 @@
 // Package app provides module-level functionality for app.
-// input: HTTP timeout config and PRODUCTION environment values
-// output: HTTP timeout plus production auth/boolean parsing regression coverage
+// input: HTTP timeout config, PRODUCTION environment values, and control-plane listen_addr
+// output: HTTP timeout plus production/non-loopback auth fail-closed regression coverage
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
 
 import (
+	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +61,80 @@ func TestValidateProductionAuthFailsClosed(t *testing.T) {
 	}
 	if err := validateProductionAuth(config.APIAuthConfig{}, false); err != nil {
 		t.Fatalf("development defaults must remain unchanged: %v", err)
+	}
+}
+
+func TestIsLoopbackListenAddr(t *testing.T) {
+	loopback := []string{"127.0.0.1:8080", "localhost:18080", "[::1]:8080", "127.0.0.1:0"}
+	for _, addr := range loopback {
+		if !isLoopbackListenAddr(addr) {
+			t.Fatalf("expected loopback listen %q", addr)
+		}
+	}
+	nonLoopback := []string{":8080", "0.0.0.0:8080", "[::]:8080", "192.168.1.10:8080", ""}
+	for _, addr := range nonLoopback {
+		if isLoopbackListenAddr(addr) {
+			t.Fatalf("expected non-loopback listen %q", addr)
+		}
+	}
+}
+
+func TestApp_NonLoopbackListenRejectsDisabledAuth(t *testing.T) {
+	for _, addr := range []string{":8080", "0.0.0.0:8080"} {
+		a := New(config.Config{ListenAddr: addr})
+		err := a.Run(context.Background())
+		if err == nil {
+			t.Fatalf("expected App.Run to reject non-loopback listen %q with auth disabled", addr)
+		}
+		if !strings.Contains(err.Error(), "listen_addr is not loopback") {
+			t.Fatalf("unexpected error for %q: %v", addr, err)
+		}
+		if a.Addr() != "" {
+			t.Fatalf("non-loopback listen %q bound a listener without auth: %q", addr, a.Addr())
+		}
+	}
+}
+
+func TestApp_LoopbackListenAllowsDisabledAuth(t *testing.T) {
+	for _, addr := range []string{"127.0.0.1:0", "localhost:18080", "[::1]:0"} {
+		if err := validateControlPlaneAuth(addr, config.APIAuthConfig{}, false); err != nil {
+			t.Fatalf("loopback listen %q should allow disabled auth: %v", addr, err)
+		}
+	}
+
+	a := New(config.Config{ListenAddr: "127.0.0.1:0"})
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- a.Run(ctx) }()
+	defer func() {
+		cancel()
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("app did not exit after cancel")
+		}
+	}()
+
+	select {
+	case <-a.Ready():
+	case err := <-errCh:
+		t.Fatalf("loopback listen with auth disabled failed: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("app did not become ready in time")
+	}
+}
+
+func TestValidateControlPlaneAuth_NonLoopbackRequiresProtectFlags(t *testing.T) {
+	auth := config.APIAuthConfig{
+		Enabled: true, Mode: "bearer", BearerToken: "test-token",
+	}
+	if err := validateControlPlaneAuth(":8080", auth, false); err == nil {
+		t.Fatal("expected non-loopback listen to require protect_api and protect_metrics")
+	}
+	auth.ProtectAPI = true
+	auth.ProtectMetrics = true
+	if err := validateControlPlaneAuth(":8080", auth, false); err != nil {
+		t.Fatalf("expected fully protected non-loopback auth to pass: %v", err)
 	}
 }
 

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -3,16 +3,17 @@
 ## Files
 | File | Responsibility |
 |------|---------------|
-| `config.go` | 配置模型、加载与默认值、校验（`meta_dsn` 为空时 standalone 控制面仅内存；受保护 auth 不接受未解析 `${ENV}` 密钥；`enabled=true` 时未设置的 protect 标志视为 true） |
+| `config.go` | 配置模型、加载与默认值、校验（`meta_dsn` 为空时 standalone 控制面仅内存；受保护 auth 不接受未解析 `${ENV}` 密钥；`enabled=true` 时未设置的 protect 标志视为 true；`EncryptionKey` 仅来自 `--encryption-key`） |
 | `config_test.go` | 配置加载、覆盖规则、protect 默认值和受保护 auth 未解析密钥测试 |
-| `encryption.go` | AES-256-GCM 配置值解密工具 |
+| `encryption.go` | AES-256-GCM `enc:aes256:` 加解密工具（配置值与 meta 源库密码共用） |
+| `encryption_test.go` | 加解密往返测试 |
 
 ## Exports
 - `LoadConfig(path)` - 加载配置（无加密）
-- `LoadConfigWithEncryption(path, key)` - 加载配置（支持解密）
+- `LoadConfigWithEncryption(path, key)` - 加载配置（支持解密，并把 key 保留到 `Config.EncryptionKey`）
 - `ValidateAPIAuthConfig(auth)` - 校验鉴权模式、路由保护与已解析凭证
-- `NewDecryptor(key)` - 创建解密器（32 字节 AES-256 密钥）
-- `Decryptor.DecryptIfEncrypted(value)` - 解密带 `enc:aes256:` 前缀的值
+- `NewDecryptor(key)` - 创建加解密器（32 字节 AES-256 密钥）
+- `Decryptor.Encrypt(value)` / `Decryptor.DecryptIfEncrypted(value)` - 生成或解密 `enc:aes256:` 值
 
 ## Configuration Sections
 - `api.auth.*` - API 鉴权开关、模式（`bearer`/`api_key`）与凭证配置；`enabled=true` 且未显式设置时 `protect_api`/`protect_metrics` 为 true
@@ -24,7 +25,7 @@
 - 加密值格式：`enc:aes256:<base64-encoded-ciphertext>`
 
 ## Dependencies
-- Upstream: `cmd/binlog-server`, `internal/app`
+- Upstream: `cmd/binlog-server`, `internal/app`, `internal/meta`
 - Downstream: `viper`, process env, `crypto/aes`, `crypto/cipher`
 
 ## Update Rule

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -3,8 +3,8 @@
 ## Files
 | File | Responsibility |
 |------|---------------|
-| `config.go` | 配置模型、加载与默认值、校验（`meta_dsn` 为空时 standalone 控制面仅内存；受保护 auth 不接受未解析 `${ENV}` 密钥） |
-| `config_test.go` | 配置加载、覆盖规则和受保护 auth 未解析密钥测试 |
+| `config.go` | 配置模型、加载与默认值、校验（`meta_dsn` 为空时 standalone 控制面仅内存；受保护 auth 不接受未解析 `${ENV}` 密钥；`enabled=true` 时未设置的 protect 标志视为 true） |
+| `config_test.go` | 配置加载、覆盖规则、protect 默认值和受保护 auth 未解析密钥测试 |
 | `encryption.go` | AES-256-GCM 配置值解密工具 |
 
 ## Exports
@@ -15,7 +15,7 @@
 - `Decryptor.DecryptIfEncrypted(value)` - 解密带 `enc:aes256:` 前缀的值
 
 ## Configuration Sections
-- `api.auth.*` - API 鉴权开关、模式（`bearer`/`api_key`）与凭证配置
+- `api.auth.*` - API 鉴权开关、模式（`bearer`/`api_key`）与凭证配置；`enabled=true` 且未显式设置时 `protect_api`/`protect_metrics` 为 true
 - `config.production.example.yaml`（仓库根目录）- 无密钥且可直接加载的生产模板；仅需环境变量注入 bearer token，并同时保护 `/api/*` 与 `/metrics`
 - `api.rate_limit.*` - API 限流配置（enabled/requests_per_second/burst），默认 100 req/s、burst 200
 - `http.control_plane.*` / `http.worker_health.*` - HTTP 超时配置

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 // Package config provides module-level functionality for config.
-// input: YAML files, environment variables, default config constants
-// output: validated runtime configuration structs that reject unresolved protected-auth secrets
+// input: YAML files, environment variables, default config constants, optional --encryption-key
+// output: validated runtime configuration structs that reject unresolved protected-auth secrets and default protect flags to true when auth is enabled and unset
 // pos: configuration boundary translating external settings into internal options
 // note: if this file changes, update this header and module README.md.
 package config
@@ -352,6 +352,7 @@ func LoadConfigWithEncryption(path string, encryptionKey string) (Config, error)
 			ServiceName: getString(v, decryptor, "tracing.service_name", "tracing_service_name"),
 		},
 	}
+	applyEnabledAuthProtectDefaults(v, &cfg.API.Auth)
 	if err := validateConfig(cfg); err != nil {
 		return Config{}, err
 	}
@@ -384,6 +385,33 @@ func getBool(v *viper.Viper, keys ...string) bool {
 	for _, key := range keys {
 		if v.IsSet(key) {
 			return v.GetBool(key)
+		}
+	}
+	return false
+}
+
+// applyEnabledAuthProtectDefaults treats unset protect flags as true when auth is enabled.
+// Do not SetDefault(protect_*, true): that would fail enabled=false validation.
+func applyEnabledAuthProtectDefaults(v *viper.Viper, auth *APIAuthConfig) {
+	if auth == nil || !auth.Enabled {
+		return
+	}
+	if !isBoolConfigured(v, "api.auth.protect_api", "api_auth_protect_api") {
+		auth.ProtectAPI = true
+	}
+	if !isBoolConfigured(v, "api.auth.protect_metrics", "api_auth_protect_metrics") {
+		auth.ProtectMetrics = true
+	}
+}
+
+func isBoolConfigured(v *viper.Viper, keys ...string) bool {
+	for _, key := range keys {
+		if v.InConfig(key) {
+			return true
+		}
+		envKey := "BINLOG_SERVER_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+		if val, ok := os.LookupEnv(envKey); ok && strings.TrimSpace(val) != "" {
+			return true
 		}
 	}
 	return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 // Package config provides module-level functionality for config.
 // input: YAML files, environment variables, default config constants, optional --encryption-key
-// output: validated runtime configuration structs that reject unresolved protected-auth secrets and default protect flags to true when auth is enabled and unset
+// output: validated runtime configuration structs that reject unresolved protected-auth secrets, default protect flags to true when auth is enabled and unset, and retain EncryptionKey for meta source-password encryption
 // pos: configuration boundary translating external settings into internal options
 // note: if this file changes, update this header and module README.md.
 package config
@@ -53,6 +53,10 @@ type Config struct {
 	Meta MetaConfig
 	// Tracing 是 OpenTelemetry tracing 配置（默认关闭）。
 	Tracing TracingConfig
+
+	// EncryptionKey 来自 --encryption-key / LoadConfigWithEncryption，不从 YAML 读取。
+	// 空值表示不加密 backup_tasks.source_json 中的源库密码。
+	EncryptionKey string
 }
 
 // ClusterConfig 定义 cluster 角色和 lease 参数。
@@ -351,6 +355,7 @@ func LoadConfigWithEncryption(path string, encryptionKey string) (Config, error)
 			SampleRatio: getFloat64(v, "tracing.sample_ratio", "tracing_sample_ratio"),
 			ServiceName: getString(v, decryptor, "tracing.service_name", "tracing_service_name"),
 		},
+		EncryptionKey: encryptionKey,
 	}
 	applyEnabledAuthProtectDefaults(v, &cfg.API.Auth)
 	if err := validateConfig(cfg); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,6 @@
 // Package config provides module-level functionality for config.
 // input: YAML files, environment variables, default config constants, optional encryption key
-// output: config loading regression coverage including unresolved protected-auth secret rejection and enabled-auth protect-flag defaults
+// output: config loading regression coverage including unresolved protected-auth secret rejection, enabled-auth protect-flag defaults, and EncryptionKey passthrough
 // pos: configuration boundary translating external settings into internal options
 // note: if this file changes, update this header and module README.md.
 package config
@@ -635,5 +635,24 @@ api:
 	}
 	if cfg.API.Auth.ProtectAPI || cfg.API.Auth.ProtectMetrics {
 		t.Fatalf("expected explicit protect false to be preserved, got %+v", cfg.API.Auth)
+	}
+}
+
+func TestLoadConfigWithEncryption_RetainsKey(t *testing.T) {
+	t.Setenv("BINLOG_SERVER_API_AUTH_ENABLED", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_API", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_METRICS", "")
+
+	key := "01234567890123456789012345678901"
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("listen_addr: \"127.0.0.1:18080\"\n"), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	cfg, err := LoadConfigWithEncryption(path, key)
+	if err != nil {
+		t.Fatalf("LoadConfigWithEncryption returned error: %v", err)
+	}
+	if cfg.EncryptionKey != key {
+		t.Fatalf("expected encryption key to be retained for meta wiring, got %q", cfg.EncryptionKey)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,6 @@
 // Package config provides module-level functionality for config.
-// input: YAML files, environment variables, default config constants
-// output: config loading regression coverage including unresolved protected-auth secret rejection
+// input: YAML files, environment variables, default config constants, optional encryption key
+// output: config loading regression coverage including unresolved protected-auth secret rejection and enabled-auth protect-flag defaults
 // pos: configuration boundary translating external settings into internal options
 // note: if this file changes, update this header and module README.md.
 package config
@@ -570,5 +570,70 @@ func TestLoadConfig_RejectsUnresolvedProtectedAuthSecret(t *testing.T) {
 	}
 	if _, err := LoadConfig(path); err == nil || !strings.Contains(err.Error(), "api.auth.bearer_token is required") {
 		t.Fatalf("expected unresolved bearer token error, got %v", err)
+	}
+}
+
+func TestLoadConfig_AuthEnabledUnsetProtectDefaultsTrue(t *testing.T) {
+	t.Setenv("BINLOG_SERVER_API_AUTH_ENABLED", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_MODE", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_BEARER_TOKEN", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_API_KEY", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_API_KEY_HEADER", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_API", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_METRICS", "")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+listen_addr: "127.0.0.1:18080"
+api:
+  auth:
+    enabled: true
+    mode: bearer
+    bearer_token: test-token
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if !cfg.API.Auth.Enabled {
+		t.Fatalf("expected auth enabled, got %+v", cfg.API.Auth)
+	}
+	if !cfg.API.Auth.ProtectAPI || !cfg.API.Auth.ProtectMetrics {
+		t.Fatalf("expected protect flags to default true when auth enabled and unset, got %+v", cfg.API.Auth)
+	}
+}
+
+func TestLoadConfig_AuthEnabledExplicitProtectFalse(t *testing.T) {
+	t.Setenv("BINLOG_SERVER_API_AUTH_ENABLED", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_MODE", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_BEARER_TOKEN", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_API", "")
+	t.Setenv("BINLOG_SERVER_API_AUTH_PROTECT_METRICS", "")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+listen_addr: "127.0.0.1:18080"
+api:
+  auth:
+    enabled: true
+    mode: bearer
+    bearer_token: test-token
+    protect_api: false
+    protect_metrics: false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if cfg.API.Auth.ProtectAPI || cfg.API.Auth.ProtectMetrics {
+		t.Fatalf("expected explicit protect false to be preserved, got %+v", cfg.API.Auth)
 	}
 }

--- a/internal/config/encryption.go
+++ b/internal/config/encryption.go
@@ -1,7 +1,7 @@
 // Package config provides module-level functionality for config.
-// input: encrypted config values with enc:aes256: prefix
-// output: decrypted plaintext values for internal use
-// pos: security boundary for protecting sensitive configuration values
+// input: plaintext or enc:aes256: values and a 32-byte AES-256 key
+// output: AES-256-GCM encrypt/decrypt helpers sharing the enc:aes256: prefix
+// pos: security boundary for protecting sensitive configuration and source-password values
 // note: if this file changes, update this header and module README.md.
 package config
 

--- a/internal/config/encryption_test.go
+++ b/internal/config/encryption_test.go
@@ -1,0 +1,39 @@
+// Package config provides module-level functionality for config.
+// input: AES-256 keys and plaintext/ciphertext fixture values
+// output: enc:aes256: encrypt/decrypt round-trip coverage
+// pos: configuration boundary translating external settings into internal options
+// note: if this file changes, update this header and module README.md.
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecryptor_EncryptDecryptRoundTrip(t *testing.T) {
+	d, err := NewDecryptor("01234567890123456789012345678901")
+	if err != nil {
+		t.Fatalf("NewDecryptor: %v", err)
+	}
+	encrypted, err := d.Encrypt("secret-password")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if !strings.HasPrefix(encrypted, EncryptionPrefix) {
+		t.Fatalf("expected %s prefix, got %q", EncryptionPrefix, encrypted)
+	}
+	plain, err := d.Decrypt(encrypted)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if plain != "secret-password" {
+		t.Fatalf("expected plaintext password, got %q", plain)
+	}
+	passthrough, err := d.DecryptIfEncrypted("plain")
+	if err != nil {
+		t.Fatalf("DecryptIfEncrypted plaintext: %v", err)
+	}
+	if passthrough != "plain" {
+		t.Fatalf("expected plaintext passthrough, got %q", passthrough)
+	}
+}

--- a/internal/meta/README.md
+++ b/internal/meta/README.md
@@ -1,7 +1,7 @@
 # internal/meta Module
 
 ## Files
-- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）；`ListTasks` 使用 `ORDER BY CAST(id AS UNSIGNED), id`，不改变 `id` 列类型。
+- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）；`ListTasks` 使用 `ORDER BY CAST(id AS UNSIGNED), id`，不改变 `id` 列类型。配置了 encryption key 时只加密 `source_json` 的 `password` 字段（`enc:aes256:`），无 key 时保持明文以兼容现有部署。
 - `lease_store.go`: lease 读写逻辑。
 - `retry.go`: 重试策略适配层与执行器封装（基于 backoff v4，屏蔽第三方类型）。
 - `tracing.go`: metadata store tracing 开关与 span helper（默认关闭）。
@@ -10,11 +10,12 @@
 
 ## Exports
 - Task/Checkpoint/Event/File（含 OPEN/SEALED）/Lease/Run/Worker metadata 存储接口。
+- `NewMySQLTaskStoreWithSchemaTimeout(dsn, timeout, encryptionKey)`：可选 AES-256 key，用于 source 密码加解密。
 - 启动期 schema 版本与结构校验（支持 schema 校验超时配置）。
 
 ## Dependencies
 - Upstream: `internal/tasks`, `internal/app`, `internal/replication`。
-- Downstream: MySQL (`database/sql`)。
+- Downstream: MySQL (`database/sql`)；源库密码加解密复用 `internal/config` 的 AES-256-GCM helpers。
 - Retry adaptor: `github.com/cenkalti/backoff/v4`（仅 `retry.go` 内部使用）。
 - Tracing: `go.opentelemetry.io/otel`（仅在 app 启用 tracing 时生效）。
 - SQL codegen: `github.com/sqlc-dev/sqlc`（通过 Makefile 统一生成/校验）。

--- a/internal/meta/mysql_store.go
+++ b/internal/meta/mysql_store.go
@@ -1,6 +1,6 @@
 // Package meta provides module-level functionality for meta.
-// input: MySQL connections, SQL schema/contracts including file lifecycle state, retry/lease timing policies
-// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints, with ListTasks ordered by numeric id
+// input: MySQL connections, optional AES-256 encryption key from config.EncryptionKey, SQL schema/contracts including file lifecycle state, retry/lease timing policies
+// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints, with ListTasks ordered by numeric id and Source.Password encrypted in source_json when a key is configured
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"binlog_server/internal/binlog"
+	"binlog_server/internal/config"
 	"binlog_server/internal/meta/sqlcgen"
 	"binlog_server/internal/tasks"
 
@@ -329,21 +330,27 @@ WHERE worker_id = ?;
 type MySQLTaskStore struct {
 	db            *sql.DB
 	schemaTimeout time.Duration
+	sourceCrypto  *config.Decryptor
 }
 
 // NewMySQLTaskStore 创建 MySQL 元数据存储并校验 schema 就绪。
 func NewMySQLTaskStore(dsn string) (*MySQLTaskStore, error) {
-	return NewMySQLTaskStoreWithSchemaTimeout(dsn, 5*time.Second)
+	return NewMySQLTaskStoreWithSchemaTimeout(dsn, 5*time.Second, "")
 }
 
 // NewMySQLTaskStoreWithSchemaTimeout 创建 MySQL 元数据存储并设置 schema 校验超时。
-func NewMySQLTaskStoreWithSchemaTimeout(dsn string, schemaTimeout time.Duration) (*MySQLTaskStore, error) {
+// encryptionKey 为空时 source_json 密码保持明文；非空时使用 AES-256-GCM（enc:aes256:）。
+func NewMySQLTaskStoreWithSchemaTimeout(dsn string, schemaTimeout time.Duration, encryptionKey string) (*MySQLTaskStore, error) {
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, err
 	}
 
 	store := newMySQLTaskStoreFromDB(db, schemaTimeout)
+	if err := store.setSourcePasswordKey(encryptionKey); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), store.schemaTimeout)
 	defer cancel()
 	if err := store.ensureSchema(ctx); err != nil {
@@ -362,6 +369,52 @@ func newMySQLTaskStoreFromDB(db *sql.DB, schemaTimeout time.Duration) *MySQLTask
 		db:            db,
 		schemaTimeout: schemaTimeout,
 	}
+}
+
+func (s *MySQLTaskStore) setSourcePasswordKey(key string) error {
+	if s == nil {
+		return nil
+	}
+	if strings.TrimSpace(key) == "" {
+		s.sourceCrypto = nil
+		return nil
+	}
+	decryptor, err := config.NewDecryptor(key)
+	if err != nil {
+		return err
+	}
+	s.sourceCrypto = decryptor
+	return nil
+}
+
+func (s *MySQLTaskStore) marshalSource(source tasks.SourceConfig) ([]byte, error) {
+	if s != nil && s.sourceCrypto != nil && source.Password != "" && !strings.HasPrefix(source.Password, config.EncryptionPrefix) {
+		encrypted, err := s.sourceCrypto.Encrypt(source.Password)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt source password: %w", err)
+		}
+		source.Password = encrypted
+	}
+	return json.Marshal(source)
+}
+
+func (s *MySQLTaskStore) unmarshalSource(sourceJSON string) (tasks.SourceConfig, error) {
+	var source tasks.SourceConfig
+	if err := json.Unmarshal([]byte(sourceJSON), &source); err != nil {
+		return source, err
+	}
+	if source.Password == "" || !strings.HasPrefix(source.Password, config.EncryptionPrefix) {
+		return source, nil
+	}
+	if s == nil || s.sourceCrypto == nil {
+		return source, fmt.Errorf("encrypted source password requires --encryption-key: %w", config.ErrEncryptionKeyRequired)
+	}
+	plain, err := s.sourceCrypto.Decrypt(source.Password)
+	if err != nil {
+		return source, fmt.Errorf("decrypt source password: %w", err)
+	}
+	source.Password = plain
+	return source, nil
 }
 
 // Close 关闭底层数据库连接。
@@ -478,7 +531,7 @@ func (s *MySQLTaskStore) UpsertTask(ctx context.Context, task tasks.Task) error 
 	ctx, span := startMetaSpan(ctx, "meta.mysql_store.upsert_task")
 	defer endMetaSpan(span)
 
-	sourceJSON, err := json.Marshal(task.Source)
+	sourceJSON, err := s.marshalSource(task.Source)
 	if err != nil {
 		return err
 	}
@@ -609,9 +662,11 @@ func (s *MySQLTaskStore) ListTasks(ctx context.Context) ([]tasks.Task, error) {
 		task.Epoch = epoch
 		task.RunID = runID.String
 		task.UpdatedAt = updatedAt
-		if err := json.Unmarshal([]byte(sourceJSON), &task.Source); err != nil {
+		source, err := s.unmarshalSource(sourceJSON)
+		if err != nil {
 			return nil, fmt.Errorf("decode source json for task %s: %w", task.ID, err)
 		}
+		task.Source = source
 		if err := json.Unmarshal([]byte(startJSON), &task.Start); err != nil {
 			return nil, fmt.Errorf("decode start json for task %s: %w", task.ID, err)
 		}

--- a/internal/meta/mysql_store_test.go
+++ b/internal/meta/mysql_store_test.go
@@ -1,18 +1,21 @@
 // Package meta provides module-level functionality for meta.
-// input: mocked MySQL contracts including OPEN/SEALED file state, retry and lease timing policies
-// output: persistence contract coverage for tasks, files, leases, runs, checkpoints, and numeric ListTasks order
+// input: mocked MySQL contracts including OPEN/SEALED file state, retry and lease timing policies, optional AES-256 source-password key
+// output: persistence contract coverage for tasks, files, leases, runs, checkpoints, numeric ListTasks order, and source_json password encryption
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
 
 import (
 	"context"
+	"database/sql/driver"
+	"encoding/json"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"binlog_server/internal/binlog"
+	"binlog_server/internal/config"
 	"binlog_server/internal/tasks"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -173,6 +176,220 @@ func TestMySQLTaskStore_ListTasks(t *testing.T) {
 func TestListTaskSQL_OrdersByNumericID(t *testing.T) {
 	if !strings.Contains(listTaskSQL, "ORDER BY CAST(id AS UNSIGNED), id") {
 		t.Fatalf("listTaskSQL must order by CAST(id AS UNSIGNED), id, got %q", listTaskSQL)
+	}
+}
+
+const testSourcePasswordKey = "01234567890123456789012345678901"
+
+type encryptedSourceJSONArg struct {
+	key      string
+	password string
+	host     string
+}
+
+func (a encryptedSourceJSONArg) Match(v driver.Value) bool {
+	raw, ok := v.(string)
+	if !ok {
+		b, ok := v.([]byte)
+		if !ok {
+			return false
+		}
+		raw = string(b)
+	}
+	var src tasks.SourceConfig
+	if err := json.Unmarshal([]byte(raw), &src); err != nil {
+		return false
+	}
+	if src.Host != a.host || src.User != "repl" || !strings.HasPrefix(src.Password, config.EncryptionPrefix) {
+		return false
+	}
+	d, err := config.NewDecryptor(a.key)
+	if err != nil {
+		return false
+	}
+	plain, err := d.Decrypt(src.Password)
+	return err == nil && plain == a.password
+}
+
+func TestMySQLTaskStore_EncryptsSourcePasswordWhenKeySet(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	if err := store.setSourcePasswordKey(testSourcePasswordKey); err != nil {
+		t.Fatalf("setSourcePasswordKey: %v", err)
+	}
+	task := tasks.Task{
+		ID:         "1",
+		Name:       "cluster-a",
+		ClusterKey: "cluster-a-key",
+		State:      tasks.StateCreated,
+		Source: tasks.SourceConfig{
+			Host:     "127.0.0.1",
+			Port:     3306,
+			User:     "repl",
+			Password: "secret",
+			Flavor:   "mysql",
+			ServerID: 200001,
+		},
+		Start: tasks.StartConfig{Mode: tasks.StartModeLatest},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(loadTaskRunStateSQL)).
+		WithArgs("1").
+		WillReturnRows(sqlmock.NewRows([]string{"run_id"}))
+	mock.ExpectExec(regexp.QuoteMeta(upsertTaskSQL)).
+		WithArgs("1", "cluster-a", "cluster-a-key", "CREATED", "", "", int64(0), "", encryptedSourceJSONArg{
+			key:      testSourcePasswordKey,
+			password: "secret",
+			host:     "127.0.0.1",
+		}, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	if err := store.UpsertTask(context.Background(), task); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if task.Source.Password != "secret" {
+		t.Fatalf("UpsertTask must not mutate in-memory password, got %q", task.Source.Password)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMySQLTaskStore_ListTasksDecryptsSourcePassword(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	if err := store.setSourcePasswordKey(testSourcePasswordKey); err != nil {
+		t.Fatalf("setSourcePasswordKey: %v", err)
+	}
+	d, err := config.NewDecryptor(testSourcePasswordKey)
+	if err != nil {
+		t.Fatalf("NewDecryptor: %v", err)
+	}
+	encrypted, err := d.Encrypt("secret")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	sourceJSON, err := json.Marshal(tasks.SourceConfig{
+		Host:     "127.0.0.1",
+		Port:     3306,
+		User:     "repl",
+		Password: encrypted,
+		Flavor:   "mysql",
+		ServerID: 200001,
+	})
+	if err != nil {
+		t.Fatalf("marshal source: %v", err)
+	}
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "cluster_key", "state", "last_error", "owner_worker_id", "epoch", "run_id", "source_json", "start_json", "storage_json", "updated_at",
+	}).AddRow(
+		"1", "cluster-a", "cluster-a-key", "STOPPED", "", "", int64(0), "",
+		string(sourceJSON), `{"mode":"LATEST"}`, `{"dir":"./data"}`, now,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(listTaskSQL)).WillReturnRows(rows)
+
+	list, err := store.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(list))
+	}
+	if list[0].Source.Password != "secret" {
+		t.Fatalf("expected decrypted plaintext password on Task.Source, got %q", list[0].Source.Password)
+	}
+	if list[0].Source.Host != "127.0.0.1" {
+		t.Fatalf("expected other source fields to stay plaintext, got %+v", list[0].Source)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMySQLTaskStore_ListTasksLoadsPlaintextSourcePasswordWithoutPrefix(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	if err := store.setSourcePasswordKey(testSourcePasswordKey); err != nil {
+		t.Fatalf("setSourcePasswordKey: %v", err)
+	}
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "cluster_key", "state", "last_error", "owner_worker_id", "epoch", "run_id", "source_json", "start_json", "storage_json", "updated_at",
+	}).AddRow(
+		"1", "cluster-a", "cluster-a-key", "STOPPED", "", "", int64(0), "",
+		`{"host":"127.0.0.1","port":3306,"user":"repl","password":"legacy-secret","flavor":"mysql","server_id":200001}`,
+		`{"mode":"LATEST"}`, `{"dir":"./data"}`, now,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(listTaskSQL)).WillReturnRows(rows)
+
+	list, err := store.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks returned error: %v", err)
+	}
+	if len(list) != 1 || list[0].Source.Password != "legacy-secret" {
+		t.Fatalf("expected existing plaintext source_json to load, got %+v err=%v", list, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMySQLTaskStore_ListTasksLoadsPlaintextWithoutKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "cluster_key", "state", "last_error", "owner_worker_id", "epoch", "run_id", "source_json", "start_json", "storage_json", "updated_at",
+	}).AddRow(
+		"1", "cluster-a", "cluster-a-key", "STOPPED", "", "", int64(0), "",
+		`{"host":"127.0.0.1","port":3306,"user":"repl","password":"legacy-secret","flavor":"mysql","server_id":200001}`,
+		`{"mode":"LATEST"}`, `{"dir":"./data"}`, now,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(listTaskSQL)).WillReturnRows(rows)
+
+	list, err := store.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks returned error: %v", err)
+	}
+	if len(list) != 1 || list[0].Source.Password != "legacy-secret" {
+		t.Fatalf("expected plaintext persist without key, got %+v err=%v", list, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestNewMySQLTaskStoreWithSchemaTimeout_RejectsInvalidEncryptionKey(t *testing.T) {
+	_, err := NewMySQLTaskStoreWithSchemaTimeout("user:pass@tcp(127.0.0.1:3306)/meta", time.Second, "short")
+	if err == nil {
+		t.Fatal("expected invalid encryption key to fail before schema checks")
+	}
+	if !strings.Contains(err.Error(), "32 bytes") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #57

Non-loopback `listen_addr` (including default `:8080`) now requires API auth and protect flags. Loopback demo still works. `config.example.yaml` binds `127.0.0.1:8080`. When `--encryption-key` is set, `source_json` passwords are stored as `enc:aes256:`.

**Behavior change:** copy-paste `:8080` with auth disabled no longer starts. Use loopback or enable auth.

**Review:** P1 example-config unstartable was fixed in `754427b`. Remaining P2: without a key, passwords stay plaintext.