### PR TITLE
fix: page tasks in SQL and get task by primary key (#59)

### DIFF
--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -8,7 +8,7 @@
 | `rate_limiter.go` | 基于 IP 的令牌桶限流器 |
 | `metrics_prometheus.go` | `/metrics` 采集与输出（基于 `prometheus/client_golang`） |
 | `tracing.go` | HTTP 入站 tracing middleware（OTel span） |
-| `handlers_tasks.go` | 任务相关 API 处理（CRUD、批量创建、启动停止、checkpoint、loopback-aware source lookup、summary/dashboard 聚合，以及任务 state/host/port 服务端分页） |
+| `handlers_tasks.go` | 任务相关 API 处理（CRUD、批量创建、启动停止、checkpoint、loopback-aware source lookup、summary/dashboard 聚合，以及任务 state/host/port 的 SQL LIMIT/OFFSET 分页） |
 | `handlers_cluster.go` | 集群观测与控制相关 API（workers、overview） |
 | `swagger_docs_only.go` | swagger 注释占位 |
 
@@ -19,8 +19,8 @@
 - `WithRateLimit(RateLimiterConfig) ServerOption` - 注入限流配置
 - `GET /api/summary` - 返回兼容既有字段的任务计数；`starting` 单独统计 STARTING，`running` 仅统计 runner ready 后的 RUNNING。
 - `GET /api/dashboard` - 返回同口径 summary、任务明细与 source 聚合；source 状态计数同时暴露 `starting` 与 `running`。
-- `GET /api/tasks` - 返回 `{items,total,limit,offset}` 任务页；页序为数字 id 升序；支持 host/port/state 过滤，默认 limit=100，limit 必须为 1..500，超过 500 返回 400 `invalid limit`。
-- `GET /api/dashboard` - 支持同一组过滤/分页参数；`summary`/`sources` 按全量过滤结果聚合，仅 `tasks` 明细切页，并返回 `total/limit/offset`。
+- `GET /api/tasks` - 返回 `{items,total,limit,offset}` 任务页；页序为数字 id 升序；支持 host/port/state 过滤；cluster/mysql 走 `ListTasksPage`（COUNT + `ORDER BY CAST(id AS UNSIGNED), id LIMIT/OFFSET`），standalone 仍切内存快照。默认 limit=100，limit 必须为 1..500，超过 500 返回 400 `invalid limit`。
+- `GET /api/dashboard` - 支持同一组过滤/分页参数；`tasks`/`total` 使用同一分页查询（total 为 COUNT）；`summary`/`sources` 仍按内存过滤快照聚合 delay 口径，并返回 `total/limit/offset`。
 - `POST /api/tasks/batch` - 接收 `items` 数组（1..100 个现有创建请求），整包 envelope 错误返回 400 且不创建；合法 envelope 按顺序逐项调用 `CreateTaskFromSpec`，返回 200 的 `{index,cluster_key,task|error}` 结果数组。
 
 ## Dependencies
@@ -37,7 +37,7 @@
 - 文件观测：`GET /api/tasks/{id}/files` 返回当前 `OPEN` segment 与历史 `SEALED` 文件。
 - 状态汇总：summary/dashboard 保留既有计数键，并新增 `starting`；STARTING 不混入 `running`。
 - Source 聚合：dashboard source 项保留 `running`，并新增独立 `starting` 状态计数。
-- 服务端分页：任务与 dashboard 在全量快照上过滤、计数和切片，页序按数字 task ID 升序（非数字 ID 排在数字之后、按字符串稳定排序）；非法 state/limit/offset/port 返回 400，limit 超过 500 返回 `invalid limit`。
+- 服务端分页：任务列表与 dashboard 任务页按数字 task ID 升序 SQL 分页（非数字 ID 排在数字之后）；host/port/state 在分页前下推到查询，total 来自 COUNT 而不是整表 `len`；非法 state/limit/offset/port 返回 400，limit 超过 500 返回 `invalid limit`。
 - 限流：基于 IP 的令牌桶限流，默认 100 req/s，burst 200
 - Tracing：OTel HTTP span（可选）
 

--- a/internal/api/handlers_tasks.go
+++ b/internal/api/handlers_tasks.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces, shared source endpoint identity
-// output: REST API JSON responses including single/batch task creation, numeric-id-ordered paginated task/dashboard data, loopback-equivalent source lookup, independent STARTING/RUNNING counters, at-tip delay 0/NORMAL, and structured 400 bodies
+// output: REST API JSON responses including single/batch task creation, SQL-paged task/dashboard data with COUNT totals, loopback-equivalent source lookup, independent STARTING/RUNNING counters, at-tip delay 0/NORMAL, and structured 400 bodies
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -252,25 +252,28 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	page, total, err := s.tasks.ListTasksPage(r.Context(), query.toFilter())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	items := filterTasksByQuery(s.tasks.ListTasks(), query)
-	sortTasksByID(items)
-	pageStart, pageEnd := taskPageBounds(len(items), query.Offset, query.Limit)
 	now := time.Now()
 	resp := dashboardResponse{
 		GeneratedAt:      now,
 		ThresholdSeconds: defaultDelayThresholdSeconds,
-		Total:            len(items),
+		Total:            total,
 		Limit:            query.Limit,
 		Offset:           query.Offset,
 		Summary: summaryResponse{
 			Total: len(items),
 		},
-		Tasks:   make([]dashboardTaskItem, 0, pageEnd-pageStart),
+		Tasks:   make([]dashboardTaskItem, 0, len(page)),
 		Sources: []sourceOverview{},
 	}
 
 	sourceMap := make(map[string]*sourceOverview)
-	for i, task := range items {
+	for _, task := range items {
 		switch task.State {
 		case tasks.StateRunning:
 			resp.Summary.Running++
@@ -293,13 +296,6 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			resp.Summary.Delayed++
 		case "ABNORMAL":
 			resp.Summary.Abnormal++
-		}
-
-		if i >= pageStart && i < pageEnd {
-			resp.Tasks = append(resp.Tasks, dashboardTaskItem{
-				Task:        sanitizeTask(task),
-				Replication: rep,
-			})
 		}
 
 		key := task.Source.Host + ":" + strconv.Itoa(int(task.Source.Port))
@@ -337,6 +333,14 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 		return resp.Sources[i].Host < resp.Sources[j].Host
 	})
+
+	for _, task := range page {
+		progress, ok, _ := s.tasks.GetReplicationProgress(task.ID)
+		resp.Tasks = append(resp.Tasks, dashboardTaskItem{
+			Task:        sanitizeTask(task),
+			Replication: buildReplicationResponse(task, progress, ok, now, defaultDelayThresholdSeconds),
+		})
+	}
 
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -413,12 +417,14 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		items := filterTasksByQuery(s.tasks.ListTasks(), query)
-		sortTasksByID(items)
-		page := paginateTasks(items, query.Offset, query.Limit)
+		page, total, err := s.tasks.ListTasksPage(r.Context(), query.toFilter())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		writeJSON(w, http.StatusOK, taskListResponse{
 			Items:  sanitizeTaskList(page),
-			Total:  len(items),
+			Total:  total,
 			Limit:  query.Limit,
 			Offset: query.Offset,
 		})
@@ -775,6 +781,16 @@ func parseTaskListQuery(r *http.Request) (taskListQuery, error) {
 	return query, nil
 }
 
+func (q taskListQuery) toFilter() tasks.TaskListFilter {
+	return tasks.TaskListFilter{
+		Host:   q.Host,
+		Port:   q.Port,
+		State:  q.State,
+		Limit:  q.Limit,
+		Offset: q.Offset,
+	}
+}
+
 func parseTaskState(raw string) (tasks.State, error) {
 	state := tasks.State(strings.TrimSpace(raw))
 	switch state {
@@ -794,71 +810,18 @@ func parseTaskState(raw string) (tasks.State, error) {
 }
 
 func filterTasksByQuery(items []tasks.Task, query taskListQuery) []tasks.Task {
-	out := make([]tasks.Task, 0, len(items))
-	for _, task := range items {
-		if query.Host != "" && task.Source.Host != query.Host {
-			continue
-		}
-		if query.Port != nil && task.Source.Port != *query.Port {
-			continue
-		}
-		if query.State != nil && task.State != *query.State {
-			continue
-		}
-		out = append(out, task)
-	}
-	return out
+	return tasks.FilterTasks(items, query.toFilter())
 }
 
 // sortTasksByID keeps API pages aligned with the metadata store's
 // ORDER BY CAST(id AS UNSIGNED), id convention: numeric ids ascending,
 // then non-numeric ids by string.
 func sortTasksByID(items []tasks.Task) {
-	sort.SliceStable(items, func(i, j int) bool {
-		return lessTaskID(items[i].ID, items[j].ID)
-	})
-}
-
-func lessTaskID(a, b string) bool {
-	ai, aOK := parseNumericTaskID(a)
-	bi, bOK := parseNumericTaskID(b)
-	switch {
-	case aOK && bOK:
-		if ai != bi {
-			return ai < bi
-		}
-		return a < b
-	case aOK:
-		return true
-	case bOK:
-		return false
-	default:
-		return a < b
-	}
-}
-
-func parseNumericTaskID(id string) (uint64, bool) {
-	n, err := strconv.ParseUint(id, 10, 64)
-	if err != nil {
-		return 0, false
-	}
-	return n, true
-}
-
-func taskPageBounds(total, offset, limit int) (int, int) {
-	if offset >= total {
-		return total, total
-	}
-	end := total
-	if limit <= total-offset {
-		end = offset + limit
-	}
-	return offset, end
+	tasks.SortTasksByID(items)
 }
 
 func paginateTasks(items []tasks.Task, offset, limit int) []tasks.Task {
-	start, end := taskPageBounds(len(items), offset, limit)
-	return items[start:end]
+	return tasks.PaginateTasks(items, offset, limit)
 }
 
 // filterTasksBySource 按 source 查询参数过滤任务集合。

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces
-// output: REST API responses including task batch creation, /healthz, and /api/health
+// output: REST API responses including SQL-paged task lists, task batch creation, /healthz, and /api/health
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -40,6 +40,7 @@ type taskService interface {
 	ListRuns(id string, limit int) ([]tasks.TaskRun, error)
 	ListWorkerHeartbeats(limit int) ([]tasks.WorkerHeartbeat, error)
 	ListTasks() []tasks.Task
+	ListTasksPage(ctx context.Context, filter tasks.TaskListFilter) ([]tasks.Task, int, error)
 	DeleteTask(id string) error
 	StartTask(id string) error
 	StopTask(id string) error

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,6 +1,6 @@
 // Package api provides module-level functionality for api.
 // input: HTTP requests, router params, scheduler/task service interfaces, task/error states, and shared source endpoint identity
-// output: REST/dashboard responses, task pagination/filter validation and numeric task-id page order coverage, batch task creation contracts, operator error visibility, independent STARTING/RUNNING status counters, task/cluster status codes, and source lookup regression coverage
+// output: REST/dashboard responses, SQL-paged list guards, task pagination/filter validation and numeric task-id page order coverage, batch task creation contracts, operator error visibility, independent STARTING/RUNNING status counters, task/cluster status codes, and source lookup regression coverage
 // pos: external control-plane API layer bridging clients and domain services
 // note: if this file changes, update this header and module README.md.
 package api
@@ -93,13 +93,37 @@ func (s *fakeAPIRunHistoryStore) UpsertTask(_ context.Context, task tasks.Task) 
 	return nil
 }
 
-// ListTasks 实现对应功能逻辑。
-func (s *fakeAPIRunHistoryStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
+func (s *fakeAPIRunHistoryStore) snapshot() []tasks.Task {
 	out := make([]tasks.Task, 0, len(s.tasks))
 	for _, task := range s.tasks {
 		out = append(out, task)
 	}
-	return out, nil
+	return out
+}
+
+// GetTask 实现对应功能逻辑。
+func (s *fakeAPIRunHistoryStore) GetTask(_ context.Context, taskID string) (tasks.Task, error) {
+	task, ok := s.tasks[taskID]
+	if !ok {
+		return tasks.Task{}, tasks.ErrTaskNotFound
+	}
+	return task, nil
+}
+
+// ListTasks 实现对应功能逻辑。
+func (s *fakeAPIRunHistoryStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
+	return s.snapshot(), nil
+}
+
+// ListTasksPage 实现对应功能逻辑。
+func (s *fakeAPIRunHistoryStore) ListTasksPage(_ context.Context, filter tasks.TaskListFilter) ([]tasks.Task, int, error) {
+	page, total := tasks.PageTasks(s.snapshot(), filter)
+	return page, total, nil
+}
+
+// ListStartingUnownedTasks 实现对应功能逻辑。
+func (s *fakeAPIRunHistoryStore) ListStartingUnownedTasks(_ context.Context) ([]tasks.Task, error) {
+	return tasks.StartingUnownedTasks(s.snapshot()), nil
 }
 
 // DeleteTask 实现对应功能逻辑。
@@ -836,13 +860,37 @@ func (s *failingUpdateStore) UpsertTask(_ context.Context, task tasks.Task) erro
 	return nil
 }
 
-// ListTasks 实现对应功能逻辑。
-func (s *failingUpdateStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
+func (s *failingUpdateStore) snapshot() []tasks.Task {
 	out := make([]tasks.Task, 0, len(s.tasks))
 	for _, task := range s.tasks {
 		out = append(out, task)
 	}
-	return out, nil
+	return out
+}
+
+// GetTask 实现对应功能逻辑。
+func (s *failingUpdateStore) GetTask(_ context.Context, taskID string) (tasks.Task, error) {
+	task, ok := s.tasks[taskID]
+	if !ok {
+		return tasks.Task{}, tasks.ErrTaskNotFound
+	}
+	return task, nil
+}
+
+// ListTasks 实现对应功能逻辑。
+func (s *failingUpdateStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
+	return s.snapshot(), nil
+}
+
+// ListTasksPage 实现对应功能逻辑。
+func (s *failingUpdateStore) ListTasksPage(_ context.Context, filter tasks.TaskListFilter) ([]tasks.Task, int, error) {
+	page, total := tasks.PageTasks(s.snapshot(), filter)
+	return page, total, nil
+}
+
+// ListStartingUnownedTasks 实现对应功能逻辑。
+func (s *failingUpdateStore) ListStartingUnownedTasks(_ context.Context) ([]tasks.Task, error) {
+	return tasks.StartingUnownedTasks(s.snapshot()), nil
 }
 
 // DeleteTask 实现对应功能逻辑。
@@ -2533,6 +2581,109 @@ func TestTaskAPI_ListTasksNumericIDPageOrder(t *testing.T) {
 	want := []string{"1", "2", "10", "100", "task-a", "task-b"}
 	if !equalStrings(got, want) {
 		t.Fatalf("dashboard page ids = %v, want %v", got, want)
+	}
+}
+
+type panicListTaskStore struct {
+	tasks map[string]tasks.Task
+}
+
+func newPanicListTaskStore() *panicListTaskStore {
+	return &panicListTaskStore{tasks: make(map[string]tasks.Task)}
+}
+
+func (s *panicListTaskStore) snapshot() []tasks.Task {
+	out := make([]tasks.Task, 0, len(s.tasks))
+	for _, task := range s.tasks {
+		out = append(out, task)
+	}
+	return out
+}
+
+func (s *panicListTaskStore) UpsertTask(_ context.Context, task tasks.Task) error {
+	s.tasks[task.ID] = task
+	return nil
+}
+
+func (s *panicListTaskStore) GetTask(_ context.Context, taskID string) (tasks.Task, error) {
+	task, ok := s.tasks[taskID]
+	if !ok {
+		return tasks.Task{}, tasks.ErrTaskNotFound
+	}
+	return task, nil
+}
+
+func (s *panicListTaskStore) ListTasks(context.Context) ([]tasks.Task, error) {
+	panic("ListTasks must not be used for paged list")
+}
+
+func (s *panicListTaskStore) ListTasksPage(_ context.Context, filter tasks.TaskListFilter) ([]tasks.Task, int, error) {
+	page, total := tasks.PageTasks(s.snapshot(), filter)
+	return page, total, nil
+}
+
+func (s *panicListTaskStore) ListStartingUnownedTasks(_ context.Context) ([]tasks.Task, error) {
+	return tasks.StartingUnownedTasks(s.snapshot()), nil
+}
+
+func (s *panicListTaskStore) DeleteTask(_ context.Context, taskID string) error {
+	delete(s.tasks, taskID)
+	return nil
+}
+
+// TestTaskAPI_ListTasksPageDoesNotLoadAllRows 验证列表/dashboard 翻页走 ListTasksPage，不依赖整表 ListTasks。
+func TestTaskAPI_ListTasksPageDoesNotLoadAllRows(t *testing.T) {
+	const totalTasks = 6
+	store := newPanicListTaskStore()
+	for i := 1; i <= totalTasks; i++ {
+		id := strconv.Itoa(i)
+		store.tasks[id] = tasks.Task{
+			ID:         id,
+			Name:       "task-" + id,
+			ClusterKey: "cluster-" + id,
+			State:      tasks.StateCreated,
+			Source:     tasks.SourceConfig{Host: "db-a", Port: 3306, User: "repl"},
+		}
+	}
+	handler := NewServer(tasks.NewScheduler(tasks.WithStore(store)))
+
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/api/tasks?limit=2&offset=2", nil))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("list returned %d body=%s", resp.Code, resp.Body.String())
+	}
+	var page struct {
+		Items  []tasks.Task `json:"items"`
+		Total  int          `json:"total"`
+		Limit  int          `json:"limit"`
+		Offset int          `json:"offset"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode list: %v body=%s", err, resp.Body.String())
+	}
+	if page.Total != totalTasks || page.Limit != 2 || page.Offset != 2 || len(page.Items) != 2 {
+		t.Fatalf("unexpected page: %+v", page)
+	}
+	if page.Items[0].ID != "3" || page.Items[1].ID != "4" {
+		t.Fatalf("unexpected page ids: %s %s", page.Items[0].ID, page.Items[1].ID)
+	}
+
+	dashboardResp := httptest.NewRecorder()
+	handler.ServeHTTP(dashboardResp, httptest.NewRequest(http.MethodGet, "/api/dashboard?limit=2&offset=2", nil))
+	if dashboardResp.Code != http.StatusOK {
+		t.Fatalf("dashboard returned %d body=%s", dashboardResp.Code, dashboardResp.Body.String())
+	}
+	var dashboard struct {
+		Total int `json:"total"`
+		Tasks []struct {
+			Task tasks.Task `json:"task"`
+		} `json:"tasks"`
+	}
+	if err := json.Unmarshal(dashboardResp.Body.Bytes(), &dashboard); err != nil {
+		t.Fatalf("decode dashboard: %v body=%s", err, dashboardResp.Body.String())
+	}
+	if dashboard.Total != totalTasks || len(dashboard.Tasks) != 2 || dashboard.Tasks[0].Task.ID != "3" || dashboard.Tasks[1].Task.ID != "4" {
+		t.Fatalf("unexpected dashboard page: %+v", dashboard)
 	}
 }
 

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
 // input: runtime config/template, persisted active tasks, scheduler/runner/meta store dependencies, process context
-// output: application lifecycle plus real-route production auth and worker-only regression coverage
+// output: application lifecycle plus real-route production auth, TaskStore page/get fakes, and worker-only regression coverage
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -60,10 +60,29 @@ func (s *fakeAppMetaStore) UpsertTask(_ context.Context, task tasks.Task) error 
 	return nil
 }
 
+func (s *fakeAppMetaStore) GetTask(_ context.Context, taskID string) (tasks.Task, error) {
+	s.regMu.Lock()
+	defer s.regMu.Unlock()
+	return tasks.LookupTask(s.listTasks, taskID)
+}
+
 func (s *fakeAppMetaStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
 	s.regMu.Lock()
 	defer s.regMu.Unlock()
 	return append([]tasks.Task(nil), s.listTasks...), nil
+}
+
+func (s *fakeAppMetaStore) ListTasksPage(_ context.Context, filter tasks.TaskListFilter) ([]tasks.Task, int, error) {
+	s.regMu.Lock()
+	defer s.regMu.Unlock()
+	page, total := tasks.PageTasks(append([]tasks.Task(nil), s.listTasks...), filter)
+	return page, total, nil
+}
+
+func (s *fakeAppMetaStore) ListStartingUnownedTasks(_ context.Context) ([]tasks.Task, error) {
+	s.regMu.Lock()
+	defer s.regMu.Unlock()
+	return tasks.StartingUnownedTasks(append([]tasks.Task(nil), s.listTasks...)), nil
 }
 
 func (s *fakeAppMetaStore) DeleteTask(_ context.Context, taskID string) error {
@@ -530,15 +549,45 @@ func (s *appFakeStore) UpsertTask(_ context.Context, task tasks.Task) error {
 	return nil
 }
 
-// ListTasks 实现对应功能逻辑。
-func (s *appFakeStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (s *appFakeStore) snapshot() []tasks.Task {
 	out := make([]tasks.Task, 0, len(s.tasks))
 	for _, task := range s.tasks {
 		out = append(out, task)
 	}
-	return out, nil
+	return out
+}
+
+// GetTask 实现对应功能逻辑。
+func (s *appFakeStore) GetTask(_ context.Context, taskID string) (tasks.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	task, ok := s.tasks[taskID]
+	if !ok {
+		return tasks.Task{}, tasks.ErrTaskNotFound
+	}
+	return task, nil
+}
+
+// ListTasks 实现对应功能逻辑。
+func (s *appFakeStore) ListTasks(_ context.Context) ([]tasks.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snapshot(), nil
+}
+
+// ListTasksPage 实现对应功能逻辑。
+func (s *appFakeStore) ListTasksPage(_ context.Context, filter tasks.TaskListFilter) ([]tasks.Task, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	page, total := tasks.PageTasks(s.snapshot(), filter)
+	return page, total, nil
+}
+
+// ListStartingUnownedTasks 实现对应功能逻辑。
+func (s *appFakeStore) ListStartingUnownedTasks(_ context.Context) ([]tasks.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return tasks.StartingUnownedTasks(s.snapshot()), nil
 }
 
 // DeleteTask 实现对应功能逻辑。

--- a/internal/meta/README.md
+++ b/internal/meta/README.md
@@ -1,7 +1,7 @@
 # internal/meta Module
 
 ## Files
-- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）；`ListTasks` 使用 `ORDER BY CAST(id AS UNSIGNED), id`，不改变 `id` 列类型。
+- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）；`GetTask` 按主键读取；`ListTasks` 仍为 Restore 全量快照（`ORDER BY CAST(id AS UNSIGNED), id`）；`ListTasksPage` 使用同一排序加 `LIMIT/OFFSET` 与 COUNT，host/port 过滤经 `JSON_EXTRACT(source_json)`；`ListStartingUnownedTasks` 只查 STARTING 且 owner 为空。
 - `lease_store.go`: lease 读写逻辑。
 - `retry.go`: 重试策略适配层与执行器封装（基于 backoff v4，屏蔽第三方类型）。
 - `tracing.go`: metadata store tracing 开关与 span helper（默认关闭）。
@@ -9,7 +9,7 @@
 - `sqlcgen/*`: sqlc 生成代码（禁止手改，使用 `make sqlc-generate` 更新）。
 
 ## Exports
-- Task/Checkpoint/Event/File（含 OPEN/SEALED）/Lease/Run/Worker metadata 存储接口。
+- Task/Checkpoint/Event/File（含 OPEN/SEALED）/Lease/Run/Worker metadata 存储接口（含 `GetTask`、`ListTasksPage`、`ListStartingUnownedTasks`）。
 - 启动期 schema 版本与结构校验（支持 schema 校验超时配置）。
 
 ## Dependencies

--- a/internal/meta/mysql_store.go
+++ b/internal/meta/mysql_store.go
@@ -1,6 +1,6 @@
 // Package meta provides module-level functionality for meta.
 // input: MySQL connections, SQL schema/contracts including file lifecycle state, retry/lease timing policies
-// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints, with ListTasks ordered by numeric id
+// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints, with GetTask by id and ListTasksPage SQL LIMIT/OFFSET
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
@@ -138,9 +138,25 @@ ON DUPLICATE KEY UPDATE
   updated_at = VALUES(updated_at);
 `
 
+const taskSelectColumns = `id, name, cluster_key, state, last_error, owner_worker_id, epoch, run_id, source_json, start_json, storage_json, updated_at`
+
 const listTaskSQL = `
 SELECT id, name, cluster_key, state, last_error, owner_worker_id, epoch, run_id, source_json, start_json, storage_json, updated_at
 FROM backup_tasks
+ORDER BY CAST(id AS UNSIGNED), id;
+`
+
+const getTaskSQL = `
+SELECT id, name, cluster_key, state, last_error, owner_worker_id, epoch, run_id, source_json, start_json, storage_json, updated_at
+FROM backup_tasks
+WHERE id = ?;
+`
+
+const listStartingUnownedTaskSQL = `
+SELECT id, name, cluster_key, state, last_error, owner_worker_id, epoch, run_id, source_json, start_json, storage_json, updated_at
+FROM backup_tasks
+WHERE state = ?
+  AND (owner_worker_id IS NULL OR owner_worker_id = '')
 ORDER BY CAST(id AS UNSIGNED), id;
 `
 
@@ -561,70 +577,153 @@ func (s *MySQLTaskStore) UpsertTask(ctx context.Context, task tasks.Task) error 
 	return nil
 }
 
-// ListTasks 读取全部任务快照并反序列化配置字段。
-func (s *MySQLTaskStore) ListTasks(ctx context.Context) ([]tasks.Task, error) {
-	ctx, span := startMetaSpan(ctx, "meta.mysql_store.list_tasks")
-	defer endMetaSpan(span)
+type rowScanner interface {
+	Scan(dest ...any) error
+}
 
-	rows, err := s.db.QueryContext(ctx, listTaskSQL)
+func taskListFilterClause(filter tasks.TaskListFilter) (string, []any) {
+	var parts []string
+	var args []any
+	if filter.State != nil {
+		parts = append(parts, "state = ?")
+		args = append(args, string(*filter.State))
+	}
+	if filter.Host != "" {
+		parts = append(parts, "JSON_UNQUOTE(JSON_EXTRACT(source_json, '$.host')) = ?")
+		args = append(args, filter.Host)
+	}
+	if filter.Port != nil {
+		parts = append(parts, "CAST(JSON_UNQUOTE(JSON_EXTRACT(source_json, '$.port')) AS UNSIGNED) = ?")
+		args = append(args, int(*filter.Port))
+	}
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(parts, " AND "), args
+}
+
+func listTasksPageSQL(filter tasks.TaskListFilter) (countSQL, selectSQL string, countArgs, selectArgs []any) {
+	where, args := taskListFilterClause(filter)
+	countSQL = "SELECT COUNT(*) FROM backup_tasks" + where
+	selectSQL = "SELECT " + taskSelectColumns + " FROM backup_tasks" + where + " ORDER BY CAST(id AS UNSIGNED), id LIMIT ? OFFSET ?"
+	countArgs = append([]any(nil), args...)
+	selectArgs = append(append([]any(nil), args...), filter.Limit, filter.Offset)
+	return countSQL, selectSQL, countArgs, selectArgs
+}
+
+func scanTask(src rowScanner) (tasks.Task, error) {
+	var (
+		task        tasks.Task
+		state       string
+		ownerWorker sql.NullString
+		epoch       int64
+		runID       sql.NullString
+		sourceJSON  string
+		startJSON   string
+		storageJSON string
+		lastError   sql.NullString
+		updatedAt   time.Time
+	)
+	if err := src.Scan(
+		&task.ID,
+		&task.Name,
+		&task.ClusterKey,
+		&state,
+		&lastError,
+		&ownerWorker,
+		&epoch,
+		&runID,
+		&sourceJSON,
+		&startJSON,
+		&storageJSON,
+		&updatedAt,
+	); err != nil {
+		return tasks.Task{}, err
+	}
+
+	task.State = tasks.State(state)
+	task.LastError = lastError.String
+	task.OwnerWorkerID = ownerWorker.String
+	task.Epoch = epoch
+	task.RunID = runID.String
+	task.UpdatedAt = updatedAt
+	if err := json.Unmarshal([]byte(sourceJSON), &task.Source); err != nil {
+		return tasks.Task{}, fmt.Errorf("decode source json for task %s: %w", task.ID, err)
+	}
+	if err := json.Unmarshal([]byte(startJSON), &task.Start); err != nil {
+		return tasks.Task{}, fmt.Errorf("decode start json for task %s: %w", task.ID, err)
+	}
+	if err := json.Unmarshal([]byte(storageJSON), &task.Storage); err != nil {
+		return tasks.Task{}, fmt.Errorf("decode storage json for task %s: %w", task.ID, err)
+	}
+	return task, nil
+}
+
+func (s *MySQLTaskStore) queryTasks(ctx context.Context, query string, args ...any) ([]tasks.Task, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var list []tasks.Task
+	list := make([]tasks.Task, 0)
 	for rows.Next() {
-		var (
-			task        tasks.Task
-			state       string
-			ownerWorker sql.NullString
-			epoch       int64
-			runID       sql.NullString
-			sourceJSON  string
-			startJSON   string
-			storageJSON string
-			lastError   sql.NullString
-			updatedAt   time.Time
-		)
-		if err := rows.Scan(
-			&task.ID,
-			&task.Name,
-			&task.ClusterKey,
-			&state,
-			&lastError,
-			&ownerWorker,
-			&epoch,
-			&runID,
-			&sourceJSON,
-			&startJSON,
-			&storageJSON,
-			&updatedAt,
-		); err != nil {
+		task, err := scanTask(rows)
+		if err != nil {
 			return nil, err
 		}
-
-		task.State = tasks.State(state)
-		task.LastError = lastError.String
-		task.OwnerWorkerID = ownerWorker.String
-		task.Epoch = epoch
-		task.RunID = runID.String
-		task.UpdatedAt = updatedAt
-		if err := json.Unmarshal([]byte(sourceJSON), &task.Source); err != nil {
-			return nil, fmt.Errorf("decode source json for task %s: %w", task.ID, err)
-		}
-		if err := json.Unmarshal([]byte(startJSON), &task.Start); err != nil {
-			return nil, fmt.Errorf("decode start json for task %s: %w", task.ID, err)
-		}
-		if err := json.Unmarshal([]byte(storageJSON), &task.Storage); err != nil {
-			return nil, fmt.Errorf("decode storage json for task %s: %w", task.ID, err)
-		}
-
 		list = append(list, task)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return list, nil
+}
+
+// ListTasks 读取全部任务快照并反序列化配置字段。Restore 仍使用该全量路径。
+func (s *MySQLTaskStore) ListTasks(ctx context.Context) ([]tasks.Task, error) {
+	ctx, span := startMetaSpan(ctx, "meta.mysql_store.list_tasks")
+	defer endMetaSpan(span)
+	return s.queryTasks(ctx, listTaskSQL)
+}
+
+// GetTask 按主键读取单个任务。
+func (s *MySQLTaskStore) GetTask(ctx context.Context, taskID string) (tasks.Task, error) {
+	ctx, span := startMetaSpan(ctx, "meta.mysql_store.get_task")
+	defer endMetaSpan(span)
+
+	task, err := scanTask(s.db.QueryRowContext(ctx, getTaskSQL, taskID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return tasks.Task{}, tasks.ErrTaskNotFound
+	}
+	if err != nil {
+		return tasks.Task{}, err
+	}
+	return task, nil
+}
+
+// ListTasksPage 在 SQL 层过滤、COUNT 并 LIMIT/OFFSET，不把整表读进内存再切页。
+func (s *MySQLTaskStore) ListTasksPage(ctx context.Context, filter tasks.TaskListFilter) ([]tasks.Task, int, error) {
+	ctx, span := startMetaSpan(ctx, "meta.mysql_store.list_tasks_page")
+	defer endMetaSpan(span)
+
+	countSQL, selectSQL, countArgs, selectArgs := listTasksPageSQL(filter)
+	var total int
+	if err := s.db.QueryRowContext(ctx, countSQL, countArgs...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	list, err := s.queryTasks(ctx, selectSQL, selectArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	return list, total, nil
+}
+
+// ListStartingUnownedTasks 仅查询 STARTING 且 owner_worker_id 为空的任务。
+func (s *MySQLTaskStore) ListStartingUnownedTasks(ctx context.Context) ([]tasks.Task, error) {
+	ctx, span := startMetaSpan(ctx, "meta.mysql_store.list_starting_unowned_tasks")
+	defer endMetaSpan(span)
+	return s.queryTasks(ctx, listStartingUnownedTaskSQL, string(tasks.StateStarting))
 }
 
 // DeleteTask 删除任务及其关联元数据。

--- a/internal/meta/mysql_store_test.go
+++ b/internal/meta/mysql_store_test.go
@@ -1,12 +1,13 @@
 // Package meta provides module-level functionality for meta.
 // input: mocked MySQL contracts including OPEN/SEALED file state, retry and lease timing policies
-// output: persistence contract coverage for tasks, files, leases, runs, checkpoints, and numeric ListTasks order
+// output: persistence contract coverage for tasks, files, leases, runs, checkpoints, GetTask by id, and SQL LIMIT/OFFSET pages
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
 
 import (
 	"context"
+	"database/sql/driver"
 	"regexp"
 	"strings"
 	"testing"
@@ -173,6 +174,199 @@ func TestMySQLTaskStore_ListTasks(t *testing.T) {
 func TestListTaskSQL_OrdersByNumericID(t *testing.T) {
 	if !strings.Contains(listTaskSQL, "ORDER BY CAST(id AS UNSIGNED), id") {
 		t.Fatalf("listTaskSQL must order by CAST(id AS UNSIGNED), id, got %q", listTaskSQL)
+	}
+}
+
+func toDriverValues(args []any) []driver.Value {
+	out := make([]driver.Value, len(args))
+	for i, arg := range args {
+		out[i] = arg
+	}
+	return out
+}
+
+func taskRowColumns() []string {
+	return []string{
+		"id", "name", "cluster_key", "state", "last_error", "owner_worker_id", "epoch", "run_id", "source_json", "start_json", "storage_json", "updated_at",
+	}
+}
+
+func addTaskRow(rows *sqlmock.Rows, id, name, clusterKey, state, sourceJSON string, now time.Time) *sqlmock.Rows {
+	return rows.AddRow(
+		id,
+		name,
+		clusterKey,
+		state,
+		"",
+		"",
+		int64(0),
+		"",
+		sourceJSON,
+		`{"mode":"LATEST"}`,
+		`{"dir":"./data"}`,
+		now,
+	)
+}
+
+// TestMySQLTaskStore_GetTaskUsesPrimaryKey 验证 GetTask 走 WHERE id=?。
+func TestMySQLTaskStore_GetTaskUsesPrimaryKey(t *testing.T) {
+	if !strings.Contains(getTaskSQL, "WHERE id = ?") {
+		t.Fatalf("getTaskSQL must filter by primary key, got %q", getTaskSQL)
+	}
+	if strings.Contains(getTaskSQL, "LIMIT") {
+		t.Fatalf("getTaskSQL must not paginate, got %q", getTaskSQL)
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	now := time.Now()
+	rows := addTaskRow(sqlmock.NewRows(taskRowColumns()), "7", "cluster-restored", "cluster-restored-key", "STOPPED",
+		`{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}`, now)
+	mock.ExpectQuery(regexp.QuoteMeta(getTaskSQL)).WithArgs("7").WillReturnRows(rows)
+
+	got, err := store.GetTask(context.Background(), "7")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.ID != "7" || got.Name != "cluster-restored" {
+		t.Fatalf("unexpected task: %+v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestMySQLTaskStore_GetTaskNotFound 验证主键未命中映射为 ErrTaskNotFound。
+func TestMySQLTaskStore_GetTaskNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	mock.ExpectQuery(regexp.QuoteMeta(getTaskSQL)).WithArgs("missing").WillReturnRows(sqlmock.NewRows(taskRowColumns()))
+
+	_, err = store.GetTask(context.Background(), "missing")
+	if err != tasks.ErrTaskNotFound {
+		t.Fatalf("expected ErrTaskNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestListTasksPageSQL_PushesFiltersAndLimit 验证分页 SQL 含 ORDER BY/LIMIT，JSON_EXTRACT 仅在 host/port 出现。
+func TestListTasksPageSQL_PushesFiltersAndLimit(t *testing.T) {
+	countSQL, selectSQL, _, selectArgs := listTasksPageSQL(tasks.TaskListFilter{Limit: 2, Offset: 2})
+	if strings.Contains(countSQL, "JSON_EXTRACT") || strings.Contains(selectSQL, "JSON_EXTRACT") {
+		t.Fatalf("JSON_EXTRACT must be omitted without host/port, count=%q select=%q", countSQL, selectSQL)
+	}
+	if !strings.Contains(selectSQL, "ORDER BY CAST(id AS UNSIGNED), id LIMIT ? OFFSET ?") {
+		t.Fatalf("paged select must order then limit, got %q", selectSQL)
+	}
+	if len(selectArgs) != 2 || selectArgs[0] != 2 || selectArgs[1] != 2 {
+		t.Fatalf("expected limit/offset args [2 2], got %#v", selectArgs)
+	}
+
+	state := tasks.StateFailed
+	port := uint16(3307)
+	_, filteredSQL, countArgs, pageArgs := listTasksPageSQL(tasks.TaskListFilter{
+		Host:   "db-b",
+		Port:   &port,
+		State:  &state,
+		Limit:  2,
+		Offset: 2,
+	})
+	if !strings.Contains(filteredSQL, "state = ?") {
+		t.Fatalf("state filter missing: %q", filteredSQL)
+	}
+	if !strings.Contains(filteredSQL, "JSON_UNQUOTE(JSON_EXTRACT(source_json, '$.host')) = ?") {
+		t.Fatalf("host JSON_EXTRACT missing: %q", filteredSQL)
+	}
+	if !strings.Contains(filteredSQL, "CAST(JSON_UNQUOTE(JSON_EXTRACT(source_json, '$.port')) AS UNSIGNED) = ?") {
+		t.Fatalf("port JSON_EXTRACT missing: %q", filteredSQL)
+	}
+	if len(countArgs) != 3 {
+		t.Fatalf("expected 3 count args, got %#v", countArgs)
+	}
+	if len(pageArgs) != 5 {
+		t.Fatalf("expected 5 page args (filters+limit+offset), got %#v", pageArgs)
+	}
+}
+
+// TestMySQLTaskStore_ListTasksPageUsesCountAndLimit 验证 COUNT + LIMIT/OFFSET，handler 不必看到整表。
+func TestMySQLTaskStore_ListTasksPageUsesCountAndLimit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	filter := tasks.TaskListFilter{Limit: 2, Offset: 2}
+	countSQL, selectSQL, _, selectArgs := listTasksPageSQL(filter)
+	mock.ExpectQuery(regexp.QuoteMeta(countSQL)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(6))
+
+	now := time.Now()
+	rows := addTaskRow(sqlmock.NewRows(taskRowColumns()), "3", "task-3", "k-3", "CREATED",
+		`{"host":"db-a","port":3306}`, now)
+	rows = addTaskRow(rows, "4", "task-4", "k-4", "CREATED", `{"host":"db-a","port":3306}`, now)
+	mock.ExpectQuery(regexp.QuoteMeta(selectSQL)).WithArgs(toDriverValues(selectArgs)...).WillReturnRows(rows)
+
+	page, total, err := store.ListTasksPage(context.Background(), filter)
+	if err != nil {
+		t.Fatalf("ListTasksPage returned error: %v", err)
+	}
+	if total != 6 || len(page) != 2 || page[0].ID != "3" || page[1].ID != "4" {
+		t.Fatalf("unexpected page total=%d items=%+v", total, page)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestMySQLTaskStore_ListStartingUnownedTasks 验证只查询 STARTING 且 owner 为空。
+func TestMySQLTaskStore_ListStartingUnownedTasks(t *testing.T) {
+	if !strings.Contains(listStartingUnownedTaskSQL, "state = ?") {
+		t.Fatalf("claim SQL must filter state, got %q", listStartingUnownedTaskSQL)
+	}
+	if !strings.Contains(listStartingUnownedTaskSQL, "owner_worker_id IS NULL OR owner_worker_id = ''") {
+		t.Fatalf("claim SQL must filter empty owner, got %q", listStartingUnownedTaskSQL)
+	}
+	if strings.Contains(listStartingUnownedTaskSQL, "LIMIT") {
+		t.Fatalf("claim SQL must not paginate, got %q", listStartingUnownedTaskSQL)
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	now := time.Now()
+	rows := addTaskRow(sqlmock.NewRows(taskRowColumns()), "1", "dispatch", "k-1", "STARTING",
+		`{"host":"127.0.0.1","port":3306}`, now)
+	mock.ExpectQuery(regexp.QuoteMeta(listStartingUnownedTaskSQL)).
+		WithArgs(string(tasks.StateStarting)).
+		WillReturnRows(rows)
+
+	list, err := store.ListStartingUnownedTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListStartingUnownedTasks returned error: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "1" {
+		t.Fatalf("unexpected claim list: %+v", list)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
 

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -1,9 +1,10 @@
 # internal/tasks Module
 
 ## Files
-- `scheduler.go`: 调度器核心类型、选项注入与通用辅助函数。
-- `scheduler_task_ops.go`: 任务 CRUD 与配置更新（含整包 CreateTaskFromSpec）。
-- `scheduler_lifecycle.go`: 启停、运行协程、重试退避，以及连续 10 次源不可达后的 FAILED（runner ready 后重新计数）。
+- `scheduler.go`: 调度器核心类型、选项注入、`TaskStore`（含 GetTask/ListTasksPage/ListStartingUnownedTasks）与通用辅助函数。
+- `scheduler_task_ops.go`: 任务 CRUD 与配置更新（含整包 CreateTaskFromSpec）；`GetTask` 按主键刷新；`ListTasksPage` 在有 store 时走 SQL 分页。
+- `scheduler_lifecycle.go`: 启停、运行协程、重试退避、`ClaimStartingTasks` 只认领 STARTING 空 owner，以及连续 10 次源不可达后的 FAILED（runner ready 后重新计数）。
+- `task_list.go`: 数字 id 排序、host/port/state 过滤与内存分页辅助，供 standalone 与测试 fake 复用。
 - `scheduler_transitions.go`: 私有生命周期转换规则（状态、事件、错误、ownership 与持久化）。
 - `errors.go`: 稳定操作员错误类型（永久的 1045 / log_bin off / 身份不可用，以及可重试的 `SOURCE_UNREACHABLE`）。
 - `scheduler_cluster_lease.go`: cluster lease 续租与降级/失租处理。
@@ -16,6 +17,8 @@
 
 ## Exports
 - 任务 CRUD、启动停止、状态推进。
+- `GetTask` 走 store 主键查询；`ListTasksPage` 返回 `{page, total}`；`ClaimStartingTasks` 不扫描整表。
+- `Restore` 仍通过 `ListTasks()` 加载启动全量快照。
 - `CreateTaskFromSpec`：整包校验后才 persist。
 - `FAILED` 可再次 `StartTask`（改完源库配置后）。
 - 仅 `SOURCE_UNREACHABLE` 连续失败最多重试 10 次；runner ready 会清零进程内连续失败计数，服务重启后重新计数，其他 retryable source code 不共享此封顶。

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task commands/events, loopback-aware metadata source policy, runner callbacks, store/lease/uploader dependencies
-// output: source validation decisions, task state transitions, scheduling decisions, and execution coordination
+// output: source validation decisions, task state transitions, scheduling decisions, TaskStore PK/page/claim contracts, and execution coordination
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -76,8 +76,14 @@ type runnerWithNotify interface {
 type TaskStore interface {
 	// UpsertTask 持久化任务配置与状态。
 	UpsertTask(ctx context.Context, task Task) error
+	// GetTask 按主键读取单个任务。
+	GetTask(ctx context.Context, taskID string) (Task, error)
 	// ListTasks 列出全部任务。
 	ListTasks(ctx context.Context) ([]Task, error)
+	// ListTasksPage 按过滤条件分页读取任务，total 为过滤后的 COUNT。
+	ListTasksPage(ctx context.Context, filter TaskListFilter) ([]Task, int, error)
+	// ListStartingUnownedTasks 仅读取 STARTING 且 owner 为空的任务。
+	ListStartingUnownedTasks(ctx context.Context) ([]Task, error)
 	// DeleteTask 删除指定任务。
 	DeleteTask(ctx context.Context, taskID string) error
 }

--- a/internal/tasks/scheduler_lifecycle.go
+++ b/internal/tasks/scheduler_lifecycle.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
-// input: start/stop commands, metadata source policy, runner callbacks, typed source errors, cancellation signals
-// output: guarded start/stop, bounded SOURCE_UNREACHABLE retry, and cancellation orchestration
+// input: start/stop commands, metadata source policy, runner callbacks, typed source errors, cancellation signals, ListStartingUnownedTasks
+// output: guarded start/stop, STARTING-unowned claim ticks, bounded SOURCE_UNREACHABLE retry, and cancellation orchestration
 // pos: scheduler execution loop delegating state mutations to scheduler_transitions.go
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -130,13 +130,13 @@ func (s *Scheduler) ClaimStartingTasks() (int, error) {
 	}
 
 	readCtx, cancelRead := s.withReadTimeout(context.Background())
-	list, err := store.ListTasks(readCtx)
+	list, err := store.ListStartingUnownedTasks(readCtx)
 	cancelRead()
 	if err != nil {
 		return 0, err
 	}
 
-	// 基于持久化快照做 best-effort 认领；
+	// 基于 STARTING + 空 owner 的定向查询做 best-effort 认领；
 	// 并发竞争由 StartTask 内的状态校验 + lease Acquire 结果保证安全。
 	claimed := 0
 	for _, item := range list {
@@ -231,8 +231,6 @@ func (s *Scheduler) StopTask(id string) error {
 	s.mu.Unlock()
 	return nil
 }
-
-// GetTask 读取任务详情；必要时会从 store 刷新。
 
 func (s *Scheduler) runTask(ctx context.Context, id string, task Task, done chan struct{}) {
 	defer func() {

--- a/internal/tasks/scheduler_observability.go
+++ b/internal/tasks/scheduler_observability.go
@@ -1,7 +1,7 @@
 // Package tasks provides module-level functionality for tasks.
-// input: replication/checkpoint/event/file/history read requests and store snapshots
+// input: replication/checkpoint/event/file/history read requests and TaskStore.GetTask for missing-task refresh
 // output: observability-facing task progress including at-tip lag, events, files, runs, and worker heartbeat views
-// pos: scheduler read/query layer for API and metrics consumption
+// pos: scheduler read/query layer for API and metrics consumption; missing-task checkpoint refresh uses GetTask
 // note: if this file changes, update this header and module README.md.
 package tasks
 
@@ -91,26 +91,17 @@ func (s *Scheduler) GetCheckpoint(ctx context.Context, taskID string) (binlog.Ch
 	store := s.store
 	s.mu.Unlock()
 
-	// Step 1: 内存未命中时，从 store 同步一次任务视图。
+	// Step 1: 内存未命中时，按主键补齐该任务，不加载整表。
 	if !ok && store != nil {
 		readCtx, cancel := s.withReadTimeout(ctx)
-		list, err := store.ListTasks(readCtx)
+		item, err := store.GetTask(readCtx, taskID)
 		cancel()
 		if err != nil {
 			return binlog.Checkpoint{}, false, err
 		}
-		found := false
 		s.mu.Lock()
-		for _, item := range list {
-			s.tasks[item.ID] = item
-			if item.ID == taskID {
-				found = true
-			}
-		}
+		s.tasks[item.ID] = item
 		s.mu.Unlock()
-		if !found {
-			return binlog.Checkpoint{}, false, ErrTaskNotFound
-		}
 	}
 	if !ok && store == nil {
 		return binlog.Checkpoint{}, false, ErrTaskNotFound

--- a/internal/tasks/scheduler_task_ops.go
+++ b/internal/tasks/scheduler_task_ops.go
@@ -1,12 +1,13 @@
 // Package tasks provides module-level functionality for tasks.
-// input: task mutation requests, metadata source policy, full create specs, and persisted task snapshots from TaskStore
-// output: source-isolated task CRUD/config updates persisted only after whole-spec validation
+// input: task mutation requests, metadata source policy, full create specs, and TaskStore GetTask/ListTasksPage
+// output: source-isolated task CRUD/config updates, primary-key GetTask refresh, and paged list reads
 // pos: scheduler task-management operations layer (non-runner lifecycle actions)
 // note: if this file changes, update this header and module README.md.
 package tasks
 
 import (
 	"context"
+	"errors"
 	"log"
 	"strconv"
 	"time"
@@ -326,7 +327,7 @@ func (s *Scheduler) ConfigureName(id, name string) error {
 
 func (s *Scheduler) GetTask(id string) (Task, error) {
 	// 常见误解：
-	// GetTask 返回的不一定是“纯内存快照”，当配置了 store 时会尝试拉取持久化最新值，
+	// GetTask 返回的不一定是“纯内存快照”，当配置了 store 时会按主键拉取持久化最新值，
 	// 目的是让 API 视图更接近真实元数据状态。
 	s.mu.Lock()
 	task, ok := s.tasks[id]
@@ -335,18 +336,15 @@ func (s *Scheduler) GetTask(id string) (Task, error) {
 
 	if store != nil {
 		ctx, cancel := s.withReadTimeout(context.Background())
-		list, err := store.ListTasks(ctx)
+		item, err := store.GetTask(ctx, id)
 		cancel()
 		if err == nil {
-			for _, item := range list {
-				if item.ID != id {
-					continue
-				}
-				s.mu.Lock()
-				s.tasks[id] = item
-				s.mu.Unlock()
-				return item, nil
-			}
+			s.mu.Lock()
+			s.tasks[id] = item
+			s.mu.Unlock()
+			return item, nil
+		}
+		if errors.Is(err, ErrTaskNotFound) {
 			return Task{}, ErrTaskNotFound
 		}
 		if ok {
@@ -409,6 +407,23 @@ func (s *Scheduler) ListTasks() []Task {
 		out = append(out, task)
 	}
 	return out
+}
+
+// ListTasksPage 返回过滤后的一页任务。有 store 时走 SQL 分页；standalone 仍切内存快照。
+func (s *Scheduler) ListTasksPage(ctx context.Context, filter TaskListFilter) ([]Task, int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.mu.Lock()
+	store := s.store
+	s.mu.Unlock()
+	if store != nil {
+		readCtx, cancel := s.withReadTimeout(ctx)
+		defer cancel()
+		return store.ListTasksPage(readCtx, filter)
+	}
+	page, total := PageTasks(s.ListTasks(), filter)
+	return page, total, nil
 }
 
 // ReportReplicationProgress 上报最新复制进度，供延迟计算和展示。

--- a/internal/tasks/scheduler_test.go
+++ b/internal/tasks/scheduler_test.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task commands/events, runner callbacks, store/lease/uploader dependencies
-// output: task state transitions, scheduling decisions, and execution coordination
+// output: task state transitions, primary-key GetTask/GetCheckpoint refresh, STARTING-unowned claim, and execution coordination
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -371,6 +371,35 @@ func TestScheduler_GetTaskRefreshesFromStore(t *testing.T) {
 	if got.State != StateRunning {
 		t.Fatalf("expected state %s from store, got %s", StateRunning, got.State)
 	}
+	if got := store.ListTasksCalls(); got != 1 {
+		t.Fatalf("expected CreateTask sync ListTasks once, got %d", got)
+	}
+	if got := store.GetTaskCalls(); got != 1 {
+		t.Fatalf("expected GetTask to hit store.GetTask once, got %d", got)
+	}
+}
+
+// TestScheduler_GetTaskUsesPrimaryKeyNotFullList 验证 GetTask 不走整表 ListTasks。
+func TestScheduler_GetTaskUsesPrimaryKeyNotFullList(t *testing.T) {
+	store := &schedulerTestStore{
+		tasks: map[string]Task{
+			"9": {ID: "9", Name: "remote", State: StateStopped},
+		},
+	}
+	s := NewScheduler(WithStore(store))
+	got, err := s.GetTask("9")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.Name != "remote" {
+		t.Fatalf("unexpected task: %+v", got)
+	}
+	if got := store.ListTasksCalls(); got != 0 {
+		t.Fatalf("GetTask must not call ListTasks, got %d", got)
+	}
+	if got := store.GetTaskCalls(); got != 1 {
+		t.Fatalf("expected GetTask calls=1, got %d", got)
+	}
 }
 
 type schedulerCheckpointReader struct {
@@ -421,6 +450,40 @@ func TestScheduler_GetCheckpointDoesNotRefreshTaskListForKnownTask(t *testing.T)
 	if got := store.ListTasksCalls(); got != 1 {
 		t.Fatalf("expected GetCheckpoint not to trigger extra ListTasks for known task, got %d", got)
 	}
+	if got := store.GetTaskCalls(); got != 0 {
+		t.Fatalf("expected GetCheckpoint not to call GetTask for known task, got %d", got)
+	}
+}
+
+// TestScheduler_GetCheckpointLoadsMissingTaskByPrimaryKey 验证缺失任务按主键补齐，不加载整表。
+func TestScheduler_GetCheckpointLoadsMissingTaskByPrimaryKey(t *testing.T) {
+	store := &schedulerTestStore{
+		tasks: map[string]Task{
+			"9": {ID: "9", Name: "remote", State: StateStopped},
+		},
+	}
+	reader := &schedulerCheckpointReader{
+		checkpoints: map[string]binlog.Checkpoint{
+			"9": {File: "mysql-bin.000009", Pos: 4},
+		},
+	}
+	s := NewScheduler(WithStore(store), WithCheckpointReader(reader))
+	cp, ok, err := s.GetCheckpoint(context.Background(), "9")
+	if err != nil {
+		t.Fatalf("GetCheckpoint returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected checkpoint exists")
+	}
+	if cp.File != "mysql-bin.000009" {
+		t.Fatalf("unexpected checkpoint: %+v", cp)
+	}
+	if got := store.ListTasksCalls(); got != 0 {
+		t.Fatalf("GetCheckpoint must not call ListTasks, got %d", got)
+	}
+	if got := store.GetTaskCalls(); got != 1 {
+		t.Fatalf("expected GetTask calls=1, got %d", got)
+	}
 }
 
 // TestScheduler_ClaimStartingTasksClaimsDispatchedTask 验证相关行为。
@@ -464,6 +527,12 @@ func TestScheduler_ClaimStartingTasksClaimsDispatchedTask(t *testing.T) {
 	if claimed != 1 {
 		t.Fatalf("expected claimed=1, got %d", claimed)
 	}
+	if got := store.ListStartingUnownedCalls(); got != 1 {
+		t.Fatalf("expected ListStartingUnownedTasks once, got %d", got)
+	}
+	if got := store.ListTasksCalls(); got != 1 {
+		t.Fatalf("expected ListTasks only from CreateTask sync, got %d", got)
+	}
 
 	select {
 	case <-workerRunner.started:
@@ -484,6 +553,57 @@ func TestScheduler_ClaimStartingTasksClaimsDispatchedTask(t *testing.T) {
 			t.Fatalf("expected state %s, got %s", StateRunning, got.State)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestScheduler_ClaimStartingTasksDoesNotListAllTasks 验证认领只查询 STARTING 空 owner，不走整表 ListTasks。
+func TestScheduler_ClaimStartingTasksDoesNotListAllTasks(t *testing.T) {
+	store := &schedulerTestStore{
+		tasks: map[string]Task{
+			"1": {
+				ID:     "1",
+				Name:   "dispatch",
+				State:  StateStarting,
+				Source: SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"},
+			},
+			"2": {
+				ID:            "2",
+				Name:          "owned",
+				State:         StateStarting,
+				OwnerWorkerID: "worker-b",
+				Source:        SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"},
+			},
+			"3": {
+				ID:     "3",
+				Name:   "running",
+				State:  StateRunning,
+				Source: SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"},
+			},
+		},
+	}
+	lease := &fakeLeaseManager{
+		acquireEpoch: 3,
+		acquireOK:    true,
+	}
+	worker := NewScheduler(
+		WithStore(store),
+		WithRunner(&fakeRunner{started: make(chan Task, 1)}),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("worker-a"),
+	)
+
+	claimed, err := worker.ClaimStartingTasks()
+	if err != nil {
+		t.Fatalf("ClaimStartingTasks returned error: %v", err)
+	}
+	if claimed != 1 {
+		t.Fatalf("expected claimed=1, got %d", claimed)
+	}
+	if got := store.ListTasksCalls(); got != 0 {
+		t.Fatalf("ClaimStartingTasks must not call ListTasks, got %d", got)
+	}
+	if got := store.ListStartingUnownedCalls(); got != 1 {
+		t.Fatalf("expected ListStartingUnownedTasks once, got %d", got)
 	}
 }
 
@@ -648,10 +768,12 @@ func TestScheduler_UpdateTaskStoreFailureHasNoMutation(t *testing.T) {
 }
 
 type schedulerTestStore struct {
-	mu            sync.Mutex
-	tasks         map[string]Task
-	listTasksCall int
-	upsertErr     error
+	mu                      sync.Mutex
+	tasks                   map[string]Task
+	listTasksCall           int
+	getTaskCall             int
+	listStartingUnownedCall int
+	upsertErr               error
 }
 
 // UpsertTask 实现对应功能逻辑。
@@ -665,16 +787,48 @@ func (s *schedulerTestStore) UpsertTask(_ context.Context, task Task) error {
 	return nil
 }
 
+func (s *schedulerTestStore) snapshotLocked() []Task {
+	out := make([]Task, 0, len(s.tasks))
+	for _, task := range s.tasks {
+		out = append(out, task)
+	}
+	return out
+}
+
+// GetTask 实现对应功能逻辑。
+func (s *schedulerTestStore) GetTask(_ context.Context, taskID string) (Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getTaskCall++
+	task, ok := s.tasks[taskID]
+	if !ok {
+		return Task{}, ErrTaskNotFound
+	}
+	return task, nil
+}
+
 // ListTasks 实现对应功能逻辑。
 func (s *schedulerTestStore) ListTasks(_ context.Context) ([]Task, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.listTasksCall++
-	out := make([]Task, 0, len(s.tasks))
-	for _, task := range s.tasks {
-		out = append(out, task)
-	}
-	return out, nil
+	return s.snapshotLocked(), nil
+}
+
+// ListTasksPage 实现对应功能逻辑。
+func (s *schedulerTestStore) ListTasksPage(_ context.Context, filter TaskListFilter) ([]Task, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	page, total := PageTasks(s.snapshotLocked(), filter)
+	return page, total, nil
+}
+
+// ListStartingUnownedTasks 实现对应功能逻辑。
+func (s *schedulerTestStore) ListStartingUnownedTasks(_ context.Context) ([]Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listStartingUnownedCall++
+	return StartingUnownedTasks(s.snapshotLocked()), nil
 }
 
 // DeleteTask 实现对应功能逻辑。
@@ -690,6 +844,20 @@ func (s *schedulerTestStore) ListTasksCalls() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.listTasksCall
+}
+
+// GetTaskCalls 实现对应功能逻辑。
+func (s *schedulerTestStore) GetTaskCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getTaskCall
+}
+
+// ListStartingUnownedCalls 实现对应功能逻辑。
+func (s *schedulerTestStore) ListStartingUnownedCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listStartingUnownedCall
 }
 
 // SetUpsertErr 实现对应功能逻辑。

--- a/internal/tasks/store_test.go
+++ b/internal/tasks/store_test.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task commands/events, runner callbacks, store/lease/uploader dependencies
-// output: task state transitions, scheduling decisions, and execution coordination
+// output: persistence-backed scheduler coverage including GetTask/ListTasksPage fakes
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -32,16 +32,46 @@ func (f *fakeStore) UpsertTask(_ context.Context, task Task) error {
 	return nil
 }
 
+func (f *fakeStore) snapshot() []Task {
+	out := make([]Task, 0, len(f.tasks))
+	for _, t := range f.tasks {
+		out = append(out, t)
+	}
+	return out
+}
+
+// GetTask 实现对应功能逻辑。
+func (f *fakeStore) GetTask(_ context.Context, taskID string) (Task, error) {
+	task, ok := f.tasks[taskID]
+	if !ok {
+		return Task{}, ErrTaskNotFound
+	}
+	return task, nil
+}
+
 // ListTasks 实现对应功能逻辑。
 func (f *fakeStore) ListTasks(_ context.Context) ([]Task, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	out := make([]Task, 0, len(f.tasks))
-	for _, t := range f.tasks {
-		out = append(out, t)
+	return f.snapshot(), nil
+}
+
+// ListTasksPage 实现对应功能逻辑。
+func (f *fakeStore) ListTasksPage(_ context.Context, filter TaskListFilter) ([]Task, int, error) {
+	if f.listErr != nil {
+		return nil, 0, f.listErr
 	}
-	return out, nil
+	page, total := PageTasks(f.snapshot(), filter)
+	return page, total, nil
+}
+
+// ListStartingUnownedTasks 实现对应功能逻辑。
+func (f *fakeStore) ListStartingUnownedTasks(_ context.Context) ([]Task, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return StartingUnownedTasks(f.snapshot()), nil
 }
 
 // DeleteTask 实现对应功能逻辑。

--- a/internal/tasks/task_list.go
+++ b/internal/tasks/task_list.go
@@ -1,0 +1,122 @@
+// Package tasks provides module-level functionality for tasks.
+// input: in-memory task snapshots and TaskListFilter host/port/state/limit/offset
+// output: numeric-id-ordered filtered pages, COUNT totals, and STARTING-unowned subsets
+// pos: shared list/filter/page helpers for TaskStore fakes and standalone Scheduler paging
+// note: if this file changes, update this header and module README.md.
+package tasks
+
+import (
+	"sort"
+	"strconv"
+)
+
+// TaskListFilter is the list/dashboard page contract pushed to SQL when a store is configured.
+type TaskListFilter struct {
+	Host   string
+	Port   *uint16
+	State  *State
+	Limit  int
+	Offset int
+}
+
+// FilterTasks applies cheap host/port/state predicates. Limit/Offset are ignored.
+func FilterTasks(items []Task, filter TaskListFilter) []Task {
+	out := make([]Task, 0, len(items))
+	for _, task := range items {
+		if filter.Host != "" && task.Source.Host != filter.Host {
+			continue
+		}
+		if filter.Port != nil && task.Source.Port != *filter.Port {
+			continue
+		}
+		if filter.State != nil && task.State != *filter.State {
+			continue
+		}
+		out = append(out, task)
+	}
+	return out
+}
+
+// SortTasksByID orders tasks as ORDER BY CAST(id AS UNSIGNED), id.
+func SortTasksByID(items []Task) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return LessTaskID(items[i].ID, items[j].ID)
+	})
+}
+
+// LessTaskID reports whether task id a should sort before b using numeric-then-string order.
+func LessTaskID(a, b string) bool {
+	ai, aOK := parseNumericTaskID(a)
+	bi, bOK := parseNumericTaskID(b)
+	switch {
+	case aOK && bOK:
+		if ai != bi {
+			return ai < bi
+		}
+		return a < b
+	case aOK:
+		return true
+	case bOK:
+		return false
+	default:
+		return a < b
+	}
+}
+
+func parseNumericTaskID(id string) (uint64, bool) {
+	n, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// TaskPageBounds returns the [start, end) slice range for a page.
+func TaskPageBounds(total, offset, limit int) (int, int) {
+	if offset >= total {
+		return total, total
+	}
+	end := total
+	if limit <= total-offset {
+		end = offset + limit
+	}
+	return offset, end
+}
+
+// PaginateTasks slices a pre-sorted task list.
+func PaginateTasks(items []Task, offset, limit int) []Task {
+	start, end := TaskPageBounds(len(items), offset, limit)
+	return items[start:end]
+}
+
+// PageTasks filters, sorts by numeric id, and pages. total is the filtered count, not the page length.
+func PageTasks(items []Task, filter TaskListFilter) ([]Task, int) {
+	filtered := FilterTasks(items, filter)
+	SortTasksByID(filtered)
+	return PaginateTasks(filtered, filter.Offset, filter.Limit), len(filtered)
+}
+
+// StartingUnownedTasks returns STARTING tasks whose owner_worker_id is empty.
+func StartingUnownedTasks(items []Task) []Task {
+	out := make([]Task, 0)
+	for _, item := range items {
+		if item.State != StateStarting {
+			continue
+		}
+		if item.OwnerWorkerID != "" {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+// LookupTask returns a task by id or ErrTaskNotFound.
+func LookupTask(items []Task, id string) (Task, error) {
+	for _, item := range items {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return Task{}, ErrTaskNotFound
+}

--- a/internal/tasks/task_list_test.go
+++ b/internal/tasks/task_list_test.go
@@ -1,0 +1,42 @@
+// Package tasks provides module-level functionality for tasks.
+// input: in-memory task snapshots used by PageTasks and StartingUnownedTasks
+// output: numeric-id page order and STARTING-unowned subset coverage
+// pos: unit tests for shared task list helpers
+// note: if this file changes, update this header and module README.md.
+package tasks
+
+import (
+	"testing"
+)
+
+func TestPageTasks_NumericIDOrderAndTotal(t *testing.T) {
+	items := []Task{
+		{ID: "100"},
+		{ID: "task-b"},
+		{ID: "2"},
+		{ID: "10"},
+		{ID: "task-a"},
+		{ID: "1"},
+	}
+	page, total := PageTasks(items, TaskListFilter{Limit: 2, Offset: 2})
+	if total != 6 {
+		t.Fatalf("total = %d, want 6", total)
+	}
+	got := []string{page[0].ID, page[1].ID}
+	want := []string{"10", "100"}
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("page ids = %v, want %v", got, want)
+	}
+}
+
+func TestStartingUnownedTasks_FiltersOwnedAndNonStarting(t *testing.T) {
+	items := []Task{
+		{ID: "1", State: StateStarting, OwnerWorkerID: ""},
+		{ID: "2", State: StateStarting, OwnerWorkerID: "worker-a"},
+		{ID: "3", State: StateRunning, OwnerWorkerID: ""},
+	}
+	got := StartingUnownedTasks(items)
+	if len(got) != 1 || got[0].ID != "1" {
+		t.Fatalf("StartingUnownedTasks = %+v, want task 1 only", got)
+	}
+}

--- a/internal/tasks/timeout_test.go
+++ b/internal/tasks/timeout_test.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: scheduler store/lease/uploader dependencies and timeout option configuration
-// output: timeout-boundary regression coverage for internal read/lease/upload calls
+// output: timeout-boundary regression coverage for GetTask/ListTasksPage/claim read, lease, and upload calls
 // pos: scheduler timeout governance tests for internal dependency interactions
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -23,12 +23,24 @@ func (s *timeoutListStore) UpsertTask(context.Context, Task) error { return nil 
 func (s *timeoutListStore) DeleteTask(context.Context, string) error {
 	return nil
 }
-func (s *timeoutListStore) ListTasks(ctx context.Context) ([]Task, error) {
+func (s *timeoutListStore) waitDeadline(ctx context.Context) error {
 	if _, ok := ctx.Deadline(); !ok {
-		return nil, errTimeoutTestMissingDeadline
+		return errTimeoutTestMissingDeadline
 	}
 	<-ctx.Done()
-	return nil, ctx.Err()
+	return ctx.Err()
+}
+func (s *timeoutListStore) GetTask(ctx context.Context, _ string) (Task, error) {
+	return Task{}, s.waitDeadline(ctx)
+}
+func (s *timeoutListStore) ListTasks(ctx context.Context) ([]Task, error) {
+	return nil, s.waitDeadline(ctx)
+}
+func (s *timeoutListStore) ListTasksPage(ctx context.Context, _ TaskListFilter) ([]Task, int, error) {
+	return nil, 0, s.waitDeadline(ctx)
+}
+func (s *timeoutListStore) ListStartingUnownedTasks(ctx context.Context) ([]Task, error) {
+	return nil, s.waitDeadline(ctx)
 }
 
 type timeoutLeaseManager struct{}


### PR DESCRIPTION
Fixes #59

`GET /api/tasks` and dashboard task pages use SQL `COUNT` + `LIMIT/OFFSET`. `GetTask` is `WHERE id=?`. Claim only selects unowned `STARTING`. #35 `{items,total,limit,offset}` shape is unchanged.

**Review:** approved. Dashboard summary/sources still aggregate the in-memory snapshot (delay is process-local).