### PR TITLE
fix: do not mark atTip on idle unless dump matches master status (#58)

### DIFF
--- a/internal/replication/README.md
+++ b/internal/replication/README.md
@@ -1,14 +1,14 @@
 # internal/replication Module
 
 ## Files
-- `mysql_runner.go`: 复制主执行流程（含 open segment 元数据及进度更新、LATEST/idle at-tip lag 上报、heartbeat 跳过落盘）。
+- `mysql_runner.go`: 复制主执行流程（含 open segment 元数据及进度更新、LATEST 立即 at-tip、idle 仅在 dump 达到 master file/pos 时标 at-tip、heartbeat 跳过落盘）。
 - `source_identity.go`: MySQL/MariaDB 源库身份，以及永久认证/配置错误与可重试网络错误分类。
-- `resolver.go`: 起点解析。
+- `resolver.go`: 起点解析，以及 dump 与 SHOW MASTER STATUS file/pos 的保守比较。
 - 其余 `*_test.go`: 复制、恢复、上传等行为测试。
-  其中 `mysql_runner_run_test.go` 重点覆盖 runner 级起点选择、LATEST at-tip vs FILE_POS catch-up 进度、checkpoint 推进/失败、错误传播与停止清理语义。
+  其中 `mysql_runner_run_test.go` 重点覆盖 runner 级起点选择、LATEST at-tip vs FILE_POS catch-up/idle-behind 进度、checkpoint 推进/失败、错误传播与停止清理语义。
 
 ## Exports
-- Runner 启停与进度上报。fresh LATEST 在 StartSync 成功后立即按 at-tip 上报；idle dump wait 共用同一 at-tip 规则；仍在追源 tip 的 FILE_POS/GTID 保持 event header lag。
+- Runner 启停与进度上报。fresh LATEST 在 StartSync 成功后立即按 at-tip 上报；idle dump wait 仅在 dump file/pos 已达到（或不落后于）源库 SHOW MASTER STATUS 时标 at-tip；仍落后的 FILE_POS/GTID 保持 event header lag。
 - 源网络超时、拒绝、主机不可达及复制流 EOF/UnexpectedEOF 统一暴露 `SOURCE_UNREACHABLE`，本地文件/metadata/lease 错误保持原分类。
 - MariaDB 身份：`mariadb:<server_id>:<gtid_domain_id>`；MySQL 仍用 `server_uuid`。
 - 文件落盘、checkpoint 对接、随落盘进度更新的 OPEN/SEALED 生命周期元数据、上传触发。

--- a/internal/replication/mysql_runner.go
+++ b/internal/replication/mysql_runner.go
@@ -1,6 +1,6 @@
 // Package replication provides module-level functionality for replication.
 // input: source replication config, flavor-aware identity, checkpoint/file metadata store dependencies
-// output: replication run control, observable OPEN/SEALED artifacts, at-tip/idle lag progress, and permanent source errors
+// output: replication run control, observable OPEN/SEALED artifacts, idle at-tip only when dump matches master file/pos, and permanent source errors
 // pos: data-plane runtime that consumes MySQL/MariaDB binlog stream and emits durable outputs
 // note: if this file changes, update this header and module README.md.
 package replication
@@ -442,7 +442,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 		// SynchronousEventHandler 模式下，事件由 syncer 内部 goroutine 推送到 handler。
 		// 这里阻塞等待错误或取消，保持任务生命周期。
 		for {
-			event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos, &atTip)
+			event, err := r.nextEvent(ctx, streamer, task.ID, task.Source, currentFile, currentPos, &atTip)
 			if err != nil {
 				if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 					return nil
@@ -457,7 +457,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 
 	// Step 5: 异步模式主循环（逐条拉取并处理事件）。
 	for {
-		event, err := r.nextEvent(ctx, streamer, task.ID, currentFile, currentPos, &atTip)
+		event, err := r.nextEvent(ctx, streamer, task.ID, task.Source, currentFile, currentPos, &atTip)
 		if err != nil {
 			if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 				return nil
@@ -475,7 +475,7 @@ func (r *MySQLRunner) run(ctx context.Context, task tasks.Task, onReady func()) 
 
 const idlePollInterval = 2 * time.Second
 
-func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, taskID, file string, pos uint32, atTip *bool) (*replication.BinlogEvent, error) {
+func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, taskID string, source tasks.SourceConfig, file string, pos uint32, atTip *bool) (*replication.BinlogEvent, error) {
 	eventCtx, cancel := context.WithTimeout(ctx, idlePollInterval)
 	event, err := streamer.GetEvent(eventCtx)
 	cancel()
@@ -487,19 +487,35 @@ func (r *MySQLRunner) nextEvent(ctx context.Context, streamer binlogStreamer, ta
 			return nil, err
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
-			// No event for idlePollInterval means the dump is at tip.
-			// Share the LATEST-start at-tip rule: delay must not use event-header age.
+			// Quiet dump wait is not at-tip by itself: FILE_POS/GTID catch-up can
+			// idle while still behind SHOW MASTER STATUS. Confirm file then pos.
+			tip := r.confirmIdleAtTip(ctx, source, file, pos)
 			if atTip != nil {
-				*atTip = true
+				*atTip = tip
 			}
 			if r.progressReporter != nil {
-				r.progressReporter.ReportReplicationProgress(taskID, time.Now().UTC(), file, pos, true)
+				eventAt := time.Time{}
+				if tip {
+					eventAt = time.Now().UTC()
+				}
+				r.progressReporter.ReportReplicationProgress(taskID, eventAt, file, pos, tip)
 			}
 			return nil, nil
 		}
 		return nil, classifySourceError(err)
 	}
 	return event, nil
+}
+
+func (r *MySQLRunner) confirmIdleAtTip(ctx context.Context, source tasks.SourceConfig, file string, pos uint32) bool {
+	if r.fetcher == nil {
+		return false
+	}
+	status, err := r.fetcher.FetchMasterStatus(ctx, source)
+	if err != nil {
+		return false
+	}
+	return dumpAtOrBeyondMaster(file, pos, status)
 }
 
 // finalizeSealedFile 负责 open 文件 seal、元数据落库以及 best-effort 上传。

--- a/internal/replication/mysql_runner_run_test.go
+++ b/internal/replication/mysql_runner_run_test.go
@@ -1,6 +1,6 @@
 // Package replication provides module-level functionality for replication.
 // input: fake source metadata, fake streamer/syncer, and injected writer/checkpoint doubles
-// output: runner-level tests for start selection, LATEST at-tip vs catch-up progress, checkpoint semantics, error propagation, and stop cleanup
+// output: runner-level tests for start selection, LATEST at-tip vs catch-up/idle-behind progress, checkpoint semantics, error propagation, and stop cleanup
 // pos: replication runtime test boundary around mysql runner orchestration
 // note: if this file changes, update this header and module README.md.
 package replication
@@ -344,8 +344,12 @@ func TestMySQLRunnerRun_FilePosCatchUpKeepsEventHeaderLag(t *testing.T) {
 	}
 }
 
-// TestMySQLRunnerRun_IdlePollReportsAtTip 验证 2s idle 与 LATEST start 共用 at-tip 规则。
+// TestMySQLRunnerRun_IdlePollReportsAtTip 验证 dump 已在 master file/pos 时，2s idle 标 at-tip。
 func TestMySQLRunnerRun_IdlePollReportsAtTip(t *testing.T) {
+	fetcher := &fakeSourceMetaFetcher{
+		status:     MasterStatus{File: "mysql-bin.000010", Pos: 4},
+		serverUUID: "srv-uuid-1",
+	}
 	streamer := &fakeStreamer{
 		results: []streamResult{
 			{err: context.DeadlineExceeded},
@@ -354,7 +358,7 @@ func TestMySQLRunnerRun_IdlePollReportsAtTip(t *testing.T) {
 	}
 	syncer := &fakeSyncer{streamer: streamer}
 	reporter := &fakeRunnerProgressReporter{}
-	runner := newTestRunner(t, &fakeSourceMetaFetcher{serverUUID: "srv-uuid-1"}, syncer, reporter)
+	runner := newTestRunner(t, fetcher, syncer, reporter)
 
 	err := runner.Run(context.Background(), newRunnerTask(tasks.StartConfig{
 		Mode: tasks.StartModeFilePos,
@@ -364,11 +368,98 @@ func TestMySQLRunnerRun_IdlePollReportsAtTip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
+	if fetcher.fetchStatusCall != 1 {
+		t.Fatalf("idle at-tip should confirm via FetchMasterStatus once, got %d", fetcher.fetchStatusCall)
+	}
 	if len(reporter.reports) != 1 || !reporter.reports[0].atTip {
-		t.Fatalf("idle poll should report at-tip, got %+v", reporter.reports)
+		t.Fatalf("idle poll at master file/pos should report at-tip, got %+v", reporter.reports)
 	}
 	if reporter.reports[0].file != "mysql-bin.000010" || reporter.reports[0].pos != 4 {
 		t.Fatalf("idle at-tip report %+v, want start file/pos", reporter.reports[0])
+	}
+}
+
+// TestMySQLRunnerRun_IdlePollBehindMasterDoesNotReportAtTip 验证追位点时 2s idle
+// 不能把 atTip 粘成 true；落后 master 时 delay 继续按 event time。
+func TestMySQLRunnerRun_IdlePollBehindMasterDoesNotReportAtTip(t *testing.T) {
+	oldEventAt := time.Date(2026, 8, 27, 4, 47, 20, 0, time.UTC)
+	fetcher := &fakeSourceMetaFetcher{
+		status:     MasterStatus{File: "mysql-bin.000020", Pos: 100},
+		serverUUID: "srv-uuid-1",
+	}
+	streamer := &fakeStreamer{
+		results: []streamResult{
+			{err: context.DeadlineExceeded},
+			{event: newRunnerEventAt(120, oldEventAt)},
+			{err: context.Canceled},
+		},
+	}
+	syncer := &fakeSyncer{streamer: streamer}
+	reporter := &fakeRunnerProgressReporter{}
+	runner := newTestRunner(t, fetcher, syncer, reporter)
+
+	err := runner.Run(context.Background(), newRunnerTask(tasks.StartConfig{
+		Mode: tasks.StartModeFilePos,
+		File: "mysql-bin.000010",
+		Pos:  4,
+	}))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if fetcher.fetchStatusCall != 1 {
+		t.Fatalf("idle should confirm tip via FetchMasterStatus once, got %d", fetcher.fetchStatusCall)
+	}
+	if len(reporter.reports) != 2 {
+		t.Fatalf("expected idle + catch-up progress reports, got %+v", reporter.reports)
+	}
+	idle := reporter.reports[0]
+	if idle.atTip {
+		t.Fatalf("idle while behind master reported at-tip: %+v", idle)
+	}
+	if !idle.at.IsZero() {
+		t.Fatalf("idle-behind report must not overwrite event time, got %+v", idle)
+	}
+	if idle.file != "mysql-bin.000010" || idle.pos != 4 {
+		t.Fatalf("idle-behind report %+v, want start file/pos", idle)
+	}
+	got := reporter.reports[1]
+	if got.atTip {
+		t.Fatalf("atTip stuck true after idle while behind: %+v", got)
+	}
+	if got.pos != 120 || !got.at.Equal(oldEventAt) {
+		t.Fatalf("catch-up report %+v, want pos=120 and old event header time", got)
+	}
+}
+
+// TestMySQLRunnerRun_IdlePollMasterStatusErrorDoesNotReportAtTip 验证 idle 无法确认 master 位点时保守保持 atTip=false。
+func TestMySQLRunnerRun_IdlePollMasterStatusErrorDoesNotReportAtTip(t *testing.T) {
+	fetcher := &fakeSourceMetaFetcher{
+		statusErr:  errors.New("show master status failed"),
+		serverUUID: "srv-uuid-1",
+	}
+	streamer := &fakeStreamer{
+		results: []streamResult{
+			{err: context.DeadlineExceeded},
+			{err: context.Canceled},
+		},
+	}
+	syncer := &fakeSyncer{streamer: streamer}
+	reporter := &fakeRunnerProgressReporter{}
+	runner := newTestRunner(t, fetcher, syncer, reporter)
+
+	err := runner.Run(context.Background(), newRunnerTask(tasks.StartConfig{
+		Mode: tasks.StartModeFilePos,
+		File: "mysql-bin.000010",
+		Pos:  4,
+	}))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if fetcher.fetchStatusCall != 1 {
+		t.Fatalf("idle should still call FetchMasterStatus, got %d", fetcher.fetchStatusCall)
+	}
+	if len(reporter.reports) != 1 || reporter.reports[0].atTip {
+		t.Fatalf("idle with master-status error should not report at-tip, got %+v", reporter.reports)
 	}
 }
 

--- a/internal/replication/resolver.go
+++ b/internal/replication/resolver.go
@@ -1,7 +1,7 @@
 // Package replication provides module-level functionality for replication.
-// input: source replication config, task state, checkpoint/file store dependencies
-// output: replication run control, local binlog artifacts, and upload/recovery signals
-// pos: data-plane runtime that consumes MySQL binlog stream and emits durable outputs
+// input: task start strategy, MasterStatusFetcher, dump file/pos
+// output: resolved FILE_POS/GTID start, conservative dump-vs-master file/pos comparison
+// pos: start-point resolver and idle at-tip comparison helper
 // note: if this file changes, update this header and module README.md.
 package replication
 
@@ -9,6 +9,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"binlog_server/internal/tasks"
 )
@@ -63,4 +65,52 @@ func ResolveStart(ctx context.Context, task tasks.Task, fetcher MasterStatusFetc
 	default:
 		return tasks.StartConfig{}, fmt.Errorf("unsupported start mode: %s", start.Mode)
 	}
+}
+
+// dumpAtOrBeyondMaster reports whether dump file/pos is at or past SHOW MASTER STATUS.
+// Comparison is file then pos. Typical names are mysql-bin.NNNNNN; unparseable or
+// mismatched prefixes are treated as not at tip.
+func dumpAtOrBeyondMaster(file string, pos uint32, master MasterStatus) bool {
+	if file == "" || master.File == "" || master.Pos == 0 {
+		return false
+	}
+	cmp, ok := compareBinlogFiles(file, master.File)
+	if !ok {
+		return false
+	}
+	if cmp != 0 {
+		return cmp > 0
+	}
+	return pos >= master.Pos
+}
+
+func compareBinlogFiles(a, b string) (int, bool) {
+	if a == b {
+		return 0, true
+	}
+	aPrefix, aSeq, aOK := splitBinlogName(a)
+	bPrefix, bSeq, bOK := splitBinlogName(b)
+	if !aOK || !bOK || aPrefix != bPrefix {
+		return 0, false
+	}
+	switch {
+	case aSeq > bSeq:
+		return 1, true
+	case aSeq < bSeq:
+		return -1, true
+	default:
+		return 0, true
+	}
+}
+
+func splitBinlogName(name string) (prefix string, seq uint64, ok bool) {
+	i := strings.LastIndex(name, ".")
+	if i <= 0 || i == len(name)-1 {
+		return "", 0, false
+	}
+	seq, err := strconv.ParseUint(name[i+1:], 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return name[:i], seq, true
 }

--- a/internal/replication/resolver_test.go
+++ b/internal/replication/resolver_test.go
@@ -1,7 +1,7 @@
 // Package replication provides module-level functionality for replication.
-// input: source replication config, task state, checkpoint/file store dependencies
-// output: replication run control, local binlog artifacts, and upload/recovery signals
-// pos: data-plane runtime that consumes MySQL binlog stream and emits durable outputs
+// input: task start strategy, fake MasterStatusFetcher, dump file/pos fixtures
+// output: resolver coverage for start modes and conservative dump-vs-master file/pos comparison
+// pos: start-point resolver and idle at-tip comparison test boundary
 // note: if this file changes, update this header and module README.md.
 package replication
 
@@ -217,5 +217,96 @@ func TestResolveStart_UnsupportedMode(t *testing.T) {
 	_, err := ResolveStart(context.Background(), task, &fakeStatusFetcher{})
 	if err == nil || err.Error() != "unsupported start mode: BAD_MODE" {
 		t.Fatalf("expected unsupported start mode error, got %v", err)
+	}
+}
+
+// TestDumpAtOrBeyondMaster 验证 dump 与 master file/pos 的保守比较（先 file 后 pos）。
+func TestDumpAtOrBeyondMaster(t *testing.T) {
+	tests := []struct {
+		name   string
+		file   string
+		pos    uint32
+		master MasterStatus
+		want   bool
+	}{
+		{
+			name:   "same file and pos",
+			file:   "mysql-bin.000010",
+			pos:    4,
+			master: MasterStatus{File: "mysql-bin.000010", Pos: 4},
+			want:   true,
+		},
+		{
+			name:   "same file dump ahead",
+			file:   "mysql-bin.000010",
+			pos:    100,
+			master: MasterStatus{File: "mysql-bin.000010", Pos: 4},
+			want:   true,
+		},
+		{
+			name:   "same file dump behind",
+			file:   "mysql-bin.000010",
+			pos:    4,
+			master: MasterStatus{File: "mysql-bin.000010", Pos: 100},
+			want:   false,
+		},
+		{
+			name:   "dump later file",
+			file:   "mysql-bin.000011",
+			pos:    4,
+			master: MasterStatus{File: "mysql-bin.000010", Pos: 999},
+			want:   true,
+		},
+		{
+			name:   "dump earlier file",
+			file:   "mysql-bin.000009",
+			pos:    999,
+			master: MasterStatus{File: "mysql-bin.000010", Pos: 4},
+			want:   false,
+		},
+		{
+			name:   "padded suffix same seq",
+			file:   "mysql-bin.000010",
+			pos:    4,
+			master: MasterStatus{File: "mysql-bin.10", Pos: 4},
+			want:   true,
+		},
+		{
+			name:   "different prefix",
+			file:   "mysql-bin.000010",
+			pos:    4,
+			master: MasterStatus{File: "binlog.000010", Pos: 4},
+			want:   false,
+		},
+		{
+			name:   "unparseable dump file",
+			file:   "custom-binlog",
+			pos:    4,
+			master: MasterStatus{File: "mysql-bin.000010", Pos: 4},
+			want:   false,
+		},
+		{
+			name:   "empty master",
+			file:   "mysql-bin.000010",
+			pos:    4,
+			master: MasterStatus{},
+			want:   false,
+		},
+		{
+			name:   "master pos zero",
+			file:   "mysql-bin.000010",
+			pos:    4,
+			master: MasterStatus{File: "mysql-bin.000010", Pos: 0},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dumpAtOrBeyondMaster(tt.file, tt.pos, tt.master)
+			if got != tt.want {
+				t.Fatalf("dumpAtOrBeyondMaster(%q, %d, %+v)=%v, want %v", tt.file, tt.pos, tt.master, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #58

Idle `GetEvent` timeout no longer sticks `atTip=true`. Tip is confirmed against `SHOW MASTER/BINLOG STATUS` (file then pos). FILE_POS/GTID catch-up through a quiet gap keeps real lag. #49 LATEST start at tip is unchanged.

**Review:** approved.