### PR TITLE
fix: claim expired-lease RUNNING tasks for cluster takeover (#55)

### DIFF
--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -5,7 +5,7 @@
 - `tracing.go`: tracing provider 初始化与生命周期管理。
 - `tracing_test.go`: OTLP HTTP 默认 traces 路径兼容性回归测试。
 - `http_server_test.go`: HTTP 超时和生产环境 auth fail-closed 校验测试。
-- `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`），包括 auth 到真实路由的回归。
+- `smoke_test.go`: 应用层烟测（HTTP 创建任务需带 `source.password`），包括 auth 到真实路由以及 worker claim 循环同时认领 STARTING/过期租约的回归。
 - `restart_recovery_test.go`: standalone 重启后安全的持久化 active task 自动恢复、metadata/source 冲突任务保持停止的回归测试。
 - `source_guard_test.go`: 从 `meta_dsn` 到任务 API 的 metadata/source 隔离装配回归测试。
 
@@ -19,6 +19,7 @@
 - 非空 `PRODUCTION` 用标准布尔值解析；control-plane 在 true 时强制 auth 已启用、同时保护 `/api/*` 和 `/metrics`，并复用 `config.ValidateAPIAuthConfig` 校验模式/已解析凭证；worker-only 不暴露该 API 且不套用此约束。
 - tracing：默认关闭；启用时装配 HTTP 入站 span 与元数据存储调用 span；无路径的 OTLP HTTP endpoint 沿用 `/v1/traces` 默认路径。
 - standalone/cluster worker 启动时自动恢复 metadata 中遗留的 active task，并从 checkpoint 续传。
+- cluster worker claim 循环同时认领无主 STARTING 与租约已过期的 RUNNING/LEASE_DEGRADED/RETRY_BACKOFF。
 
 ### Minimal Tracing Config Example
 ```yaml

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
 // input: runtime config, PRODUCTION environment flag, persisted task state, scheduler/runner/meta store dependencies, process context
-// output: role-aware application lifecycle control with production control-plane auth checks, metadata/source isolation, restart recovery, and shutdown
+// output: role-aware application lifecycle control with production control-plane auth checks, metadata/source isolation, restart recovery, expired-lease claim, and shutdown
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -298,7 +298,7 @@ func (a *App) Run(ctx context.Context) error {
 				effectiveBinaryVersion(),
 				5*time.Second,
 			)
-			// 定期认领 STARTING 任务，驱动分发后的任务进入真实执行。
+			// 定期认领 STARTING 与租约已过期任务，驱动分发后的任务进入真实执行。
 			go startWorkerClaimLoop(runCtx, scheduler, 2*time.Second)
 		}
 	}
@@ -727,8 +727,9 @@ type workerRegistrationStore interface {
 	ReleaseWorkerRegistration(ctx context.Context, workerID, sessionID string) error
 }
 
-type startingTaskClaimer interface {
+type workerTaskClaimer interface {
 	ClaimStartingTasks() (int, error)
+	ClaimExpiredTasks() (int, error)
 }
 
 // startWorkerHeartbeatLoop 周期上报 worker ONLINE/OFFLINE 心跳。
@@ -774,8 +775,8 @@ func startWorkerHeartbeatLoop(ctx context.Context, sink workerHeartbeatSink, wor
 	}
 }
 
-// startWorkerClaimLoop 周期触发 STARTING 任务认领，驱动 worker 拉起待执行任务。
-func startWorkerClaimLoop(ctx context.Context, claimer startingTaskClaimer, interval time.Duration) {
+// startWorkerClaimLoop 周期触发 STARTING 与过期租约任务认领，驱动 worker 拉起待执行任务。
+func startWorkerClaimLoop(ctx context.Context, claimer workerTaskClaimer, interval time.Duration) {
 	if claimer == nil {
 		return
 	}
@@ -795,10 +796,14 @@ func startWorkerClaimLoop(ctx context.Context, claimer startingTaskClaimer, inte
 			claimed, err := claimer.ClaimStartingTasks()
 			if err != nil {
 				log.Printf("worker claim starting tasks failed err=%v", err)
-				continue
-			}
-			if claimed > 0 {
+			} else if claimed > 0 {
 				log.Printf("worker claimed starting tasks count=%d", claimed)
+			}
+			expired, err := claimer.ClaimExpiredTasks()
+			if err != nil {
+				log.Printf("worker claim expired-lease tasks failed err=%v", err)
+			} else if expired > 0 {
+				log.Printf("worker claimed expired-lease tasks count=%d", expired)
 			}
 		}
 	}

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -1,6 +1,6 @@
 // Package app provides module-level functionality for app.
 // input: runtime config/template, persisted active tasks, scheduler/runner/meta store dependencies, process context
-// output: application lifecycle plus real-route production auth and worker-only regression coverage
+// output: application lifecycle plus real-route production auth, worker-only, and expired-lease claim-loop regression coverage
 // pos: application composition layer that wires modules into runnable service modes
 // note: if this file changes, update this header and module README.md.
 package app
@@ -811,6 +811,52 @@ func TestApp_ClusterWorkerIDUsedConsistentlyBySchedulerAndHeartbeat(t *testing.T
 	}
 	if hb.WorkerID != startedTask.OwnerWorkerID {
 		t.Fatalf("expected heartbeat worker_id equals scheduler owner_worker_id, hb=%q task=%q", hb.WorkerID, startedTask.OwnerWorkerID)
+	}
+}
+
+type fakeWorkerClaimer struct {
+	mu              sync.Mutex
+	startingCalls   int
+	expiredCalls    int
+	startingErr     error
+	expiredErr      error
+	startingClaimed int
+	expiredClaimed  int
+}
+
+func (f *fakeWorkerClaimer) ClaimStartingTasks() (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startingCalls++
+	return f.startingClaimed, f.startingErr
+}
+
+func (f *fakeWorkerClaimer) ClaimExpiredTasks() (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.expiredCalls++
+	return f.expiredClaimed, f.expiredErr
+}
+
+// TestStartWorkerClaimLoop_ClaimsStartingAndExpired 验证认领循环同时认领 STARTING 与过期租约任务。
+func TestStartWorkerClaimLoop_ClaimsStartingAndExpired(t *testing.T) {
+	claimer := &fakeWorkerClaimer{startingClaimed: 1, expiredClaimed: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go startWorkerClaimLoop(ctx, claimer, 10*time.Millisecond)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		claimer.mu.Lock()
+		startingCalls, expiredCalls := claimer.startingCalls, claimer.expiredCalls
+		claimer.mu.Unlock()
+		if startingCalls > 0 && expiredCalls > 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected both claim methods, starting=%d expired=%d", startingCalls, expiredCalls)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/internal/meta/README.md
+++ b/internal/meta/README.md
@@ -1,7 +1,7 @@
 # internal/meta Module
 
 ## Files
-- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）；`ListTasks` 使用 `ORDER BY CAST(id AS UNSIGNED), id`，不改变 `id` 列类型。
+- `mysql_store.go`: 元数据持久化实现与 schema 校验（含 binlog file OPEN/SEALED 状态）；`ListTasks` 使用 `ORDER BY CAST(id AS UNSIGNED), id`，不改变 `id` 列类型；`ListTasksWithExpiredLease` 以 INNER JOIN `task_leases` 列出租约已过期的 RUNNING/LEASE_DEGRADED/RETRY_BACKOFF。
 - `lease_store.go`: lease 读写逻辑。
 - `retry.go`: 重试策略适配层与执行器封装（基于 backoff v4，屏蔽第三方类型）。
 - `tracing.go`: metadata store tracing 开关与 span helper（默认关闭）。
@@ -10,6 +10,7 @@
 
 ## Exports
 - Task/Checkpoint/Event/File（含 OPEN/SEALED）/Lease/Run/Worker metadata 存储接口。
+- `ListTasksWithExpiredLease`：cluster worker 接管查询，只返回 `lease_expire_at <= NOW(6)` 的活跃任务。
 - 启动期 schema 版本与结构校验（支持 schema 校验超时配置）。
 
 ## Dependencies

--- a/internal/meta/mysql_store.go
+++ b/internal/meta/mysql_store.go
@@ -1,6 +1,6 @@
 // Package meta provides module-level functionality for meta.
 // input: MySQL connections, SQL schema/contracts including file lifecycle state, retry/lease timing policies
-// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints, with ListTasks ordered by numeric id
+// output: persistent metadata operations for tasks, files, leases, runs, and checkpoints, with ListTasks ordered by numeric id and ListTasksWithExpiredLease for cluster takeover
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
@@ -142,6 +142,15 @@ const listTaskSQL = `
 SELECT id, name, cluster_key, state, last_error, owner_worker_id, epoch, run_id, source_json, start_json, storage_json, updated_at
 FROM backup_tasks
 ORDER BY CAST(id AS UNSIGNED), id;
+`
+
+const listTasksWithExpiredLeaseSQL = `
+SELECT t.id, t.name, t.cluster_key, t.state, t.last_error, t.owner_worker_id, t.epoch, t.run_id, t.source_json, t.start_json, t.storage_json, t.updated_at
+FROM backup_tasks t
+INNER JOIN task_leases l ON l.task_id = t.id
+WHERE t.state IN ('RUNNING', 'LEASE_DEGRADED', 'RETRY_BACKOFF')
+  AND l.lease_expire_at <= NOW(6)
+ORDER BY CAST(t.id AS UNSIGNED), t.id;
 `
 
 const deleteTaskSQL = `
@@ -330,6 +339,9 @@ type MySQLTaskStore struct {
 	db            *sql.DB
 	schemaTimeout time.Duration
 }
+
+var _ tasks.TaskStore = (*MySQLTaskStore)(nil)
+var _ tasks.ExpiredLeaseTaskLister = (*MySQLTaskStore)(nil)
 
 // NewMySQLTaskStore 创建 MySQL 元数据存储并校验 schema 就绪。
 func NewMySQLTaskStore(dsn string) (*MySQLTaskStore, error) {
@@ -571,7 +583,23 @@ func (s *MySQLTaskStore) ListTasks(ctx context.Context) ([]tasks.Task, error) {
 		return nil, err
 	}
 	defer rows.Close()
+	return scanBackupTaskRows(rows)
+}
 
+// ListTasksWithExpiredLease lists active tasks whose joined lease row is already expired.
+func (s *MySQLTaskStore) ListTasksWithExpiredLease(ctx context.Context) ([]tasks.Task, error) {
+	ctx, span := startMetaSpan(ctx, "meta.mysql_store.list_tasks_with_expired_lease")
+	defer endMetaSpan(span)
+
+	rows, err := s.db.QueryContext(ctx, listTasksWithExpiredLeaseSQL)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanBackupTaskRows(rows)
+}
+
+func scanBackupTaskRows(rows *sql.Rows) ([]tasks.Task, error) {
 	var list []tasks.Task
 	for rows.Next() {
 		var (

--- a/internal/meta/mysql_store_test.go
+++ b/internal/meta/mysql_store_test.go
@@ -1,6 +1,6 @@
 // Package meta provides module-level functionality for meta.
 // input: mocked MySQL contracts including OPEN/SEALED file state, retry and lease timing policies
-// output: persistence contract coverage for tasks, files, leases, runs, checkpoints, and numeric ListTasks order
+// output: persistence contract coverage for tasks, files, leases, runs, checkpoints, numeric ListTasks order, and expired-lease listing
 // pos: metadata persistence layer between domain scheduler and MySQL storage engine
 // note: if this file changes, update this header and module README.md.
 package meta
@@ -173,6 +173,70 @@ func TestMySQLTaskStore_ListTasks(t *testing.T) {
 func TestListTaskSQL_OrdersByNumericID(t *testing.T) {
 	if !strings.Contains(listTaskSQL, "ORDER BY CAST(id AS UNSIGNED), id") {
 		t.Fatalf("listTaskSQL must order by CAST(id AS UNSIGNED), id, got %q", listTaskSQL)
+	}
+}
+
+// TestListTasksWithExpiredLeaseSQL_JoinsExpiredActiveStates 验证过期租约查询只覆盖可接管状态。
+func TestListTasksWithExpiredLeaseSQL_JoinsExpiredActiveStates(t *testing.T) {
+	if !strings.Contains(listTasksWithExpiredLeaseSQL, "INNER JOIN task_leases") {
+		t.Fatalf("listTasksWithExpiredLeaseSQL must join task_leases, got %q", listTasksWithExpiredLeaseSQL)
+	}
+	if !strings.Contains(listTasksWithExpiredLeaseSQL, "lease_expire_at <= NOW(6)") {
+		t.Fatalf("listTasksWithExpiredLeaseSQL must filter expired leases, got %q", listTasksWithExpiredLeaseSQL)
+	}
+	for _, state := range []string{"RUNNING", "LEASE_DEGRADED", "RETRY_BACKOFF"} {
+		if !strings.Contains(listTasksWithExpiredLeaseSQL, state) {
+			t.Fatalf("listTasksWithExpiredLeaseSQL must include state %s, got %q", state, listTasksWithExpiredLeaseSQL)
+		}
+	}
+	if !strings.Contains(listTasksWithExpiredLeaseSQL, "ORDER BY CAST(t.id AS UNSIGNED), t.id") {
+		t.Fatalf("listTasksWithExpiredLeaseSQL must order by numeric id, got %q", listTasksWithExpiredLeaseSQL)
+	}
+}
+
+// TestMySQLTaskStore_ListTasksWithExpiredLease 验证过期租约任务列表扫描。
+func TestMySQLTaskStore_ListTasksWithExpiredLease(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	store := newMySQLTaskStoreFromDB(db, 5*time.Second)
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "cluster_key", "state", "last_error", "owner_worker_id", "epoch", "run_id", "source_json", "start_json", "storage_json", "updated_at",
+	}).AddRow(
+		"7",
+		"cluster-expired",
+		"cluster-expired-key",
+		"RUNNING",
+		"",
+		"worker-dead",
+		int64(9),
+		"run-9",
+		`{"host":"127.0.0.1","port":3306,"user":"repl","flavor":"mysql","server_id":200001}`,
+		`{"mode":"LATEST"}`,
+		`{"dir":"./data"}`,
+		now,
+	)
+	mock.ExpectQuery(regexp.QuoteMeta(listTasksWithExpiredLeaseSQL)).WillReturnRows(rows)
+
+	list, err := store.ListTasksWithExpiredLease(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasksWithExpiredLease returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(list))
+	}
+	if list[0].ID != "7" || list[0].State != tasks.StateRunning {
+		t.Fatalf("unexpected task loaded: %+v", list[0])
+	}
+	if list[0].OwnerWorkerID != "worker-dead" || list[0].Epoch != 9 || list[0].RunID != "run-9" {
+		t.Fatalf("unexpected cluster run fields: owner=%q epoch=%d run_id=%q", list[0].OwnerWorkerID, list[0].Epoch, list[0].RunID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
 

--- a/internal/tasks/README.md
+++ b/internal/tasks/README.md
@@ -1,9 +1,9 @@
 # internal/tasks Module
 
 ## Files
-- `scheduler.go`: 调度器核心类型、选项注入与通用辅助函数。
+- `scheduler.go`: 调度器核心类型、选项注入与通用辅助函数；`ExpiredLeaseTaskLister` 供 cluster 过期租约查询。
 - `scheduler_task_ops.go`: 任务 CRUD 与配置更新（含整包 CreateTaskFromSpec）。
-- `scheduler_lifecycle.go`: 启停、运行协程、重试退避，以及连续 10 次源不可达后的 FAILED（runner ready 后重新计数）。
+- `scheduler_lifecycle.go`: 启停、运行协程、重试退避、`ClaimExpiredTasks` 过期租约接管（不走 StopTask），以及连续 10 次源不可达后的 FAILED（runner ready 后重新计数）。
 - `scheduler_transitions.go`: 私有生命周期转换规则（状态、事件、错误、ownership 与持久化）。
 - `errors.go`: 稳定操作员错误类型（永久的 1045 / log_bin off / 身份不可用，以及可重试的 `SOURCE_UNREACHABLE`）。
 - `scheduler_cluster_lease.go`: cluster lease 续租与降级/失租处理。
@@ -16,6 +16,8 @@
 
 ## Exports
 - 任务 CRUD、启动停止、状态推进。
+- `ClaimStartingTasks` 认领无主 STARTING；`ClaimExpiredTasks` 认领租约已过期的 RUNNING/LEASE_DEGRADED/RETRY_BACKOFF，Acquire 成功后直接拉起，不调用 StopTask。
+- `StartTask` 允许在 Acquire 成功后接管过期的 RUNNING/LEASE_DEGRADED；仍拒绝抢占未过期租约或本机仍在跑的任务。
 - `CreateTaskFromSpec`：整包校验后才 persist。
 - `FAILED` 可再次 `StartTask`（改完源库配置后）。
 - 仅 `SOURCE_UNREACHABLE` 连续失败最多重试 10 次；runner ready 会清零进程内连续失败计数，服务重启后重新计数，其他 retryable source code 不共享此封顶。

--- a/internal/tasks/lease_test.go
+++ b/internal/tasks/lease_test.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task commands/events, runner callbacks, store/lease/uploader dependencies
-// output: task state transitions, scheduling decisions, and execution coordination
+// output: task state transitions, scheduling decisions, cluster lease, and expired-lease takeover coverage
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -19,6 +19,7 @@ type fakeLeaseManager struct {
 	acquireEpoch int64
 	acquireOK    bool
 	acquireErr   error
+	acquireCalls int
 
 	renewCalls    int
 	renewFn       func(call int) (bool, error)
@@ -29,6 +30,9 @@ type fakeLeaseManager struct {
 
 // Acquire 实现对应功能逻辑。
 func (f *fakeLeaseManager) Acquire(_ context.Context, _ string, _ string, _ time.Duration) (int64, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acquireCalls++
 	return f.acquireEpoch, f.acquireOK, f.acquireErr
 }
 
@@ -752,5 +756,405 @@ func waitLeaseRenewCalls(t *testing.T, lease *fakeLeaseManager, want int, timeou
 			t.Fatalf("expected at least %d renew calls, got %d", want, got)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type expiredLeaseTestStore struct {
+	mu       sync.Mutex
+	tasks    map[string]Task
+	expired  []Task
+	upserted []Task
+}
+
+func (s *expiredLeaseTestStore) UpsertTask(_ context.Context, task Task) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.tasks == nil {
+		s.tasks = make(map[string]Task)
+	}
+	s.tasks[task.ID] = task
+	s.upserted = append(s.upserted, task)
+	return nil
+}
+
+func (s *expiredLeaseTestStore) ListTasks(_ context.Context) ([]Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Task, 0, len(s.tasks))
+	for _, task := range s.tasks {
+		out = append(out, task)
+	}
+	return out, nil
+}
+
+func (s *expiredLeaseTestStore) DeleteTask(_ context.Context, taskID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.tasks, taskID)
+	return nil
+}
+
+func (s *expiredLeaseTestStore) ListTasksWithExpiredLease(_ context.Context) ([]Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Task, len(s.expired))
+	copy(out, s.expired)
+	return out, nil
+}
+
+func (s *expiredLeaseTestStore) persistedStates() []State {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	states := make([]State, 0, len(s.upserted))
+	for _, task := range s.upserted {
+		states = append(states, task.State)
+	}
+	return states
+}
+
+func newExpiredOwnedTask(id, owner string, state State) Task {
+	return Task{
+		ID:            id,
+		Name:          "cluster-a",
+		ClusterKey:    "cluster-a-key",
+		State:         state,
+		OwnerWorkerID: owner,
+		Epoch:         7,
+		RunID:         "run-old",
+		Source:        SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"},
+		Start:         StartConfig{Mode: StartModeLatest},
+	}
+}
+
+func assertNoStopPersisted(t *testing.T, store *expiredLeaseTestStore) {
+	t.Helper()
+	for _, state := range store.persistedStates() {
+		if state == StateStopping || state == StateStopped {
+			t.Fatalf("takeover persisted %s", state)
+		}
+	}
+}
+
+func waitRunnerStarted(t *testing.T, runner *fakeRunner) {
+	t.Helper()
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected worker runner to start claimed task")
+	}
+}
+
+func TestScheduler_ClaimExpiredTasksStartsExpiredRunningTask(t *testing.T) {
+	store := &expiredLeaseTestStore{tasks: make(map[string]Task)}
+	lease := &fakeLeaseManager{acquireEpoch: 22, acquireOK: true}
+	runner := &fakeRunner{started: make(chan Task, 1)}
+	worker := NewScheduler(
+		WithStore(store),
+		WithRunner(runner),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("worker-b"),
+	)
+
+	task := newExpiredOwnedTask("1", "worker-dead", StateRunning)
+	store.tasks[task.ID] = task
+	store.expired = []Task{task}
+
+	claimed, err := worker.ClaimExpiredTasks()
+	if err != nil {
+		t.Fatalf("ClaimExpiredTasks returned error: %v", err)
+	}
+	if claimed != 1 {
+		t.Fatalf("expected claimed=1, got %d", claimed)
+	}
+	lease.mu.Lock()
+	acquireCalls := lease.acquireCalls
+	lease.mu.Unlock()
+	if acquireCalls == 0 {
+		t.Fatal("expected lease acquire on expired takeover")
+	}
+
+	waitRunnerStarted(t, runner)
+	waitTaskState(t, worker, task.ID, 2*time.Second, StateRunning)
+	assertNoStopPersisted(t, store)
+
+	got, err := worker.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.OwnerWorkerID != "worker-b" {
+		t.Fatalf("expected owner worker-b after takeover, got %q", got.OwnerWorkerID)
+	}
+	if got.Epoch != 22 {
+		t.Fatalf("expected epoch 22 after takeover, got %d", got.Epoch)
+	}
+
+	events, err := worker.ListEvents(task.ID, 20)
+	if err != nil {
+		t.Fatalf("ListEvents returned error: %v", err)
+	}
+	sawTakeover := false
+	for _, event := range events {
+		if event.Type == "TASK_STOPPING" || event.Type == "TASK_STOPPED" {
+			t.Fatalf("takeover emitted stop event %s", event.Type)
+		}
+		if event.Type == "TASK_LEASE_TAKEOVER" {
+			sawTakeover = true
+		}
+	}
+	if !sawTakeover {
+		t.Fatal("expected TASK_LEASE_TAKEOVER event")
+	}
+
+	if err := worker.StopTask(task.ID); err != nil {
+		t.Fatalf("StopTask returned error: %v", err)
+	}
+	waitTaskState(t, worker, task.ID, 2*time.Second, StateStopped)
+}
+
+func TestScheduler_ClaimExpiredTasksDoesNotPersistStoppedWhenAcquireFails(t *testing.T) {
+	store := &expiredLeaseTestStore{tasks: make(map[string]Task)}
+	lease := &fakeLeaseManager{acquireEpoch: 28, acquireOK: false}
+	runner := &fakeRunner{started: make(chan Task, 1)}
+	worker := NewScheduler(
+		WithStore(store),
+		WithRunner(runner),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("worker-b"),
+	)
+
+	task := newExpiredOwnedTask("1", "worker-live", StateRunning)
+	store.tasks[task.ID] = task
+	store.expired = []Task{task}
+
+	claimed, err := worker.ClaimExpiredTasks()
+	if err != nil {
+		t.Fatalf("ClaimExpiredTasks returned error: %v", err)
+	}
+	if claimed != 0 {
+		t.Fatalf("expected claimed=0 when acquire fails, got %d", claimed)
+	}
+	got, err := worker.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.State != StateRunning || got.OwnerWorkerID != "worker-live" {
+		t.Fatalf("expected original running owner retained, got state=%s owner=%q", got.State, got.OwnerWorkerID)
+	}
+	assertNoStopPersisted(t, store)
+	select {
+	case <-runner.started:
+		t.Fatal("did not expect runner to start when acquire failed")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestScheduler_ClaimExpiredTasksIgnoresValidLease(t *testing.T) {
+	store := &expiredLeaseTestStore{tasks: make(map[string]Task)}
+	lease := &fakeLeaseManager{acquireEpoch: 23, acquireOK: true}
+	runner := &fakeRunner{started: make(chan Task, 1)}
+	worker := NewScheduler(
+		WithStore(store),
+		WithRunner(runner),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("worker-b"),
+	)
+
+	task := newExpiredOwnedTask("1", "worker-live", StateRunning)
+	store.tasks[task.ID] = task
+	store.expired = nil
+
+	claimed, err := worker.ClaimExpiredTasks()
+	if err != nil {
+		t.Fatalf("ClaimExpiredTasks returned error: %v", err)
+	}
+	if claimed != 0 {
+		t.Fatalf("expected claimed=0 for valid lease, got %d", claimed)
+	}
+	select {
+	case <-runner.started:
+		t.Fatal("did not expect runner to start for unexpired lease")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestScheduler_StartTaskDoesNotStealLiveLease(t *testing.T) {
+	store := &expiredLeaseTestStore{tasks: make(map[string]Task)}
+	lease := &fakeLeaseManager{acquireEpoch: 24, acquireOK: false}
+	runner := &fakeRunner{started: make(chan Task, 1)}
+	s := NewScheduler(
+		WithStore(store),
+		WithRunner(runner),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("worker-b"),
+	)
+
+	task, err := s.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := s.ConfigureSource(task.ID, SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+
+	s.mu.Lock()
+	current := s.tasks[task.ID]
+	current.State = StateRunning
+	current.OwnerWorkerID = "worker-live"
+	current.Epoch = 7
+	current.RunID = "run-live"
+	s.tasks[task.ID] = current
+	s.mu.Unlock()
+	if err := store.UpsertTask(context.Background(), current); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	err = s.StartTask(task.ID)
+	if !errors.Is(err, ErrLeaseNotAcquired) {
+		t.Fatalf("expected ErrLeaseNotAcquired, got %v", err)
+	}
+	got, err := s.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if got.State != StateRunning {
+		t.Fatalf("expected state %s after failed takeover, got %s", StateRunning, got.State)
+	}
+	if got.OwnerWorkerID != "worker-live" {
+		t.Fatalf("expected original owner retained, got %q", got.OwnerWorkerID)
+	}
+	assertNoStopPersisted(t, store)
+	select {
+	case <-runner.started:
+		t.Fatal("did not expect runner to start when lease is still valid")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestScheduler_ClaimStartingTasksStillClaimsUnownedStarting(t *testing.T) {
+	store := &expiredLeaseTestStore{tasks: make(map[string]Task)}
+	lease := &fakeLeaseManager{acquireEpoch: 25, acquireOK: true}
+	control := NewScheduler(
+		WithStore(store),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("control-plane-a"),
+	)
+	workerRunner := &fakeRunner{started: make(chan Task, 1)}
+	worker := NewScheduler(
+		WithStore(store),
+		WithRunner(workerRunner),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("worker-a"),
+	)
+
+	task, err := control.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := control.ConfigureSource(task.ID, SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	if err := control.StartTask(task.ID); err != nil {
+		t.Fatalf("control StartTask returned error: %v", err)
+	}
+
+	running := newExpiredOwnedTask("99", "worker-dead", StateRunning)
+	store.mu.Lock()
+	store.tasks[running.ID] = running
+	store.expired = []Task{running}
+	store.mu.Unlock()
+
+	claimed, err := worker.ClaimStartingTasks()
+	if err != nil {
+		t.Fatalf("ClaimStartingTasks returned error: %v", err)
+	}
+	if claimed != 1 {
+		t.Fatalf("expected claimed=1 starting task, got %d", claimed)
+	}
+	waitRunnerStarted(t, workerRunner)
+	waitTaskState(t, worker, task.ID, 2*time.Second, StateRunning)
+
+	if err := worker.StopTask(task.ID); err != nil {
+		t.Fatalf("StopTask returned error: %v", err)
+	}
+	waitTaskState(t, worker, task.ID, 2*time.Second, StateStopped)
+}
+
+func TestScheduler_ClaimExpiredTasksSkipsLocalLiveRun(t *testing.T) {
+	store := &expiredLeaseTestStore{tasks: make(map[string]Task)}
+	lease := &fakeLeaseManager{acquireEpoch: 26, acquireOK: true}
+	runner := &fakeRunner{started: make(chan Task, 1)}
+	worker := NewScheduler(
+		WithStore(store),
+		WithRunner(runner),
+		WithClusterLeaseManager(lease),
+		WithClusterWorkerID("worker-a"),
+	)
+
+	task, err := worker.CreateTask("cluster-a", "cluster-a-key")
+	if err != nil {
+		t.Fatalf("CreateTask returned error: %v", err)
+	}
+	if err := worker.ConfigureSource(task.ID, SourceConfig{Host: "127.0.0.1", Port: 3306, User: "repl"}); err != nil {
+		t.Fatalf("ConfigureSource returned error: %v", err)
+	}
+	if err := worker.StartTask(task.ID); err != nil {
+		t.Fatalf("StartTask returned error: %v", err)
+	}
+	waitRunnerStarted(t, runner)
+	waitTaskState(t, worker, task.ID, 2*time.Second, StateRunning)
+
+	got, err := worker.GetTask(task.ID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	store.mu.Lock()
+	store.expired = []Task{got}
+	store.mu.Unlock()
+
+	claimed, err := worker.ClaimExpiredTasks()
+	if err != nil {
+		t.Fatalf("ClaimExpiredTasks returned error: %v", err)
+	}
+	if claimed != 0 {
+		t.Fatalf("expected claimed=0 when local run is live, got %d", claimed)
+	}
+
+	if err := worker.StopTask(task.ID); err != nil {
+		t.Fatalf("StopTask returned error: %v", err)
+	}
+	waitTaskState(t, worker, task.ID, 2*time.Second, StateStopped)
+}
+
+func TestScheduler_ClaimExpiredTasksStartsExpiredLeaseDegradedAndRetryBackoff(t *testing.T) {
+	for _, state := range []State{StateLeaseDegraded, StateRetryBackoff} {
+		t.Run(string(state), func(t *testing.T) {
+			store := &expiredLeaseTestStore{tasks: make(map[string]Task)}
+			lease := &fakeLeaseManager{acquireEpoch: 27, acquireOK: true}
+			runner := &fakeRunner{started: make(chan Task, 1)}
+			worker := NewScheduler(
+				WithStore(store),
+				WithRunner(runner),
+				WithClusterLeaseManager(lease),
+				WithClusterWorkerID("worker-b"),
+			)
+			task := newExpiredOwnedTask("1", "worker-dead", state)
+			store.tasks[task.ID] = task
+			store.expired = []Task{task}
+
+			claimed, err := worker.ClaimExpiredTasks()
+			if err != nil {
+				t.Fatalf("ClaimExpiredTasks returned error: %v", err)
+			}
+			if claimed != 1 {
+				t.Fatalf("expected claimed=1, got %d", claimed)
+			}
+			waitRunnerStarted(t, runner)
+			waitTaskState(t, worker, task.ID, 2*time.Second, StateRunning)
+			assertNoStopPersisted(t, store)
+			if err := worker.StopTask(task.ID); err != nil {
+				t.Fatalf("StopTask returned error: %v", err)
+			}
+			waitTaskState(t, worker, task.ID, 2*time.Second, StateStopped)
+		})
 	}
 }

--- a/internal/tasks/scheduler.go
+++ b/internal/tasks/scheduler.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: task commands/events, loopback-aware metadata source policy, runner callbacks, store/lease/uploader dependencies
-// output: source validation decisions, task state transitions, scheduling decisions, and execution coordination
+// output: source validation decisions, task state transitions, scheduling decisions, expired-lease listing contract, and execution coordination
 // pos: core domain orchestration layer governing backup task lifecycle and policies
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -80,6 +80,12 @@ type TaskStore interface {
 	ListTasks(ctx context.Context) ([]Task, error)
 	// DeleteTask 删除指定任务。
 	DeleteTask(ctx context.Context, taskID string) error
+}
+
+// ExpiredLeaseTaskLister lists active tasks whose cluster lease has expired.
+type ExpiredLeaseTaskLister interface {
+	// ListTasksWithExpiredLease lists RUNNING/LEASE_DEGRADED/RETRY_BACKOFF tasks with lease_expire_at <= NOW(6).
+	ListTasksWithExpiredLease(ctx context.Context) ([]Task, error)
 }
 
 type taskRunReader interface {

--- a/internal/tasks/scheduler_lifecycle.go
+++ b/internal/tasks/scheduler_lifecycle.go
@@ -1,6 +1,6 @@
 // Package tasks provides module-level functionality for tasks.
 // input: start/stop commands, metadata source policy, runner callbacks, typed source errors, cancellation signals
-// output: guarded start/stop, bounded SOURCE_UNREACHABLE retry, and cancellation orchestration
+// output: guarded start/stop, bounded SOURCE_UNREACHABLE retry, expired-lease takeover without StopTask, and cancellation orchestration
 // pos: scheduler execution loop delegating state mutations to scheduler_transitions.go
 // note: if this file changes, update this header and module README.md.
 package tasks
@@ -33,8 +33,17 @@ func (s *Scheduler) StartTask(id string) error {
 		task.RunID == "" &&
 		s.runner != nil &&
 		s.leaseManager != nil
+	canTakeoverExpired := s.runner != nil && s.leaseManager != nil &&
+		(task.State == StateRunning || task.State == StateLeaseDegraded)
+	if canTakeoverExpired {
+		if done, ok := s.runs[id]; ok && !isClosed(done) {
+			// 本机仍有活跃 run goroutine，拒绝把未退出的本地执行再拉起一份。
+			canTakeoverExpired = false
+		}
+	}
 	// 仅允许 claim “干净的 dispatch STARTING 任务”，避免误接管非预期中间态。
-	if task.State != StateCreated && task.State != StateStopped && task.State != StateRetryBackoff && task.State != StateFailed && !canClaimDispatched {
+	// 过期 RUNNING/LEASE_DEGRADED 可在 Acquire 成功后接管；Acquire 失败则不改状态。
+	if task.State != StateCreated && task.State != StateStopped && task.State != StateRetryBackoff && task.State != StateFailed && !canClaimDispatched && !canTakeoverExpired {
 		s.mu.Unlock()
 		return fmt.Errorf("cannot start from state %s", task.State)
 	}
@@ -69,6 +78,8 @@ func (s *Scheduler) StartTask(id string) error {
 
 	// Step 3: worker 执行分支，先 acquire lease，再进入 STARTING。
 	if s.leaseManager != nil {
+		previousOwner := task.OwnerWorkerID
+		previousState := task.State
 		leaseCtx, cancelLease := s.withLeaseTimeout(context.Background())
 		epoch, acquired, err := s.leaseManager.Acquire(leaseCtx, id, s.clusterWorkerID, s.leaseTTL)
 		cancelLease()
@@ -83,6 +94,10 @@ func (s *Scheduler) StartTask(id string) error {
 		task.OwnerWorkerID = s.clusterWorkerID
 		task.Epoch = epoch
 		task.RunID = fmt.Sprintf("%s-%d", id, time.Now().UnixNano())
+		if previousState == StateRunning || previousState == StateLeaseDegraded {
+			s.appendEventLocked(id, "TASK_LEASE_TAKEOVER", "claimed expired lease", previousOwner)
+			log.Printf("claimed expired lease task=%s previous_owner=%s previous_state=%s epoch=%d", id, previousOwner, previousState, epoch)
+		}
 	}
 
 	// 注意：这里仅表示“已发起启动流程”，不是“runner 已 ready”。
@@ -155,6 +170,51 @@ func (s *Scheduler) ClaimStartingTasks() (int, error) {
 	return claimed, nil
 }
 
+// ClaimExpiredTasks 让在线 worker 接管租约已过期的 RUNNING/LEASE_DEGRADED/RETRY_BACKOFF 任务。
+func (s *Scheduler) ClaimExpiredTasks() (int, error) {
+	s.mu.Lock()
+	store := s.store
+	runner := s.runner
+	leaseManager := s.leaseManager
+	s.mu.Unlock()
+
+	if store == nil || runner == nil || leaseManager == nil {
+		return 0, nil
+	}
+	lister, ok := store.(ExpiredLeaseTaskLister)
+	if !ok {
+		return 0, nil
+	}
+
+	readCtx, cancelRead := s.withReadTimeout(context.Background())
+	list, err := lister.ListTasksWithExpiredLease(readCtx)
+	cancelRead()
+	if err != nil {
+		return 0, err
+	}
+
+	claimed := 0
+	for _, item := range list {
+		if !isExpiredLeaseTakeoverState(item.State) {
+			continue
+		}
+		if !s.prepareExpiredTaskClaim(item) {
+			continue
+		}
+		if err := s.StartTask(item.ID); err != nil {
+			// 竞争窗口下可能被其他 worker 先拿到 lease，或本机仍持有有效执行；按 best-effort 跳过。
+			continue
+		}
+		log.Printf("claimed expired-lease task=%s previous_owner=%s previous_state=%s", item.ID, item.OwnerWorkerID, item.State)
+		claimed++
+	}
+	return claimed, nil
+}
+
+func isExpiredLeaseTakeoverState(state State) bool {
+	return state == StateRunning || state == StateLeaseDegraded || state == StateRetryBackoff
+}
+
 // prepareStartingTaskClaim 把 store 里的 STARTING 任务注入内存，并过滤本机不可接管场景。
 func (s *Scheduler) prepareStartingTaskClaim(item Task) bool {
 	s.mu.Lock()
@@ -170,6 +230,24 @@ func (s *Scheduler) prepareStartingTaskClaim(item Task) bool {
 			// 本地状态已进入执行/停止路径，不用 store 快照覆盖。
 			return false
 		}
+	}
+
+	s.tasks[item.ID] = item
+	return true
+}
+
+// prepareExpiredTaskClaim 把 store 里租约已过期的任务注入内存，并过滤本机仍在执行的场景。
+func (s *Scheduler) prepareExpiredTaskClaim(item Task) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if done, ok := s.runs[item.ID]; ok && !isClosed(done) {
+		// 本机已有活跃 run goroutine，拒绝重复接管。
+		return false
+	}
+	if current, ok := s.tasks[item.ID]; ok && current.State == StateStopping {
+		// 本地已进入停止路径，不用 store 快照覆盖。
+		return false
 	}
 
 	s.tasks[item.ID] = item


### PR DESCRIPTION
Fixes #55

Workers now claim `RUNNING|LEASE_DEGRADED|RETRY_BACKOFF` tasks whose lease has expired and start dump after a successful `Acquire`, without `StopTask`. Live leases are not stolen.

**Review:** approved (nits only). Merge after or stacked with #56 (`app.go` overlap).